### PR TITLE
feat(nyanpasu-core-manager): dynamic config lifecycle — apply_config saga, per-epoch artifacts, orphan recovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1983,6 +1983,7 @@ dependencies = [
  "dirs 6.0.0",
  "encoding_rs",
  "kill_tree",
+ "libc",
  "log",
  "memchr",
  "nix 0.31.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1888,6 +1888,7 @@ version = "0.1.0"
 dependencies = [
  "camino",
  "clash-api",
+ "nyanpasu-core-manager",
  "nyanpasu-utils",
  "parking_lot",
  "serde_yaml_ng",

--- a/crates/clash-api/src/api/configs.rs
+++ b/crates/clash-api/src/api/configs.rs
@@ -26,7 +26,9 @@ pub enum FindProcessMode {
 pub enum TunStack {
     #[serde(rename = "gVisor")]
     Gvisor,
+    #[serde(rename = "system")]
     System,
+    #[serde(rename = "mixed")]
     Mixed,
     #[serde(other)]
     Unknown,
@@ -219,6 +221,10 @@ pub struct RuntimeConfig {
     pub tuic_server: RuntimeTuicServer,
     pub ss_config: String,
     pub vmess_config: String,
+    #[serde(default)]
+    pub tcptun_config: Option<String>,
+    #[serde(default)]
+    pub udptun_config: Option<String>,
     pub authentication: Option<Vec<String>>,
     #[specta(type = Option<Vec<String>>)]
     pub skip_auth_prefixes: Option<Vec<IpNet>>,
@@ -281,8 +287,10 @@ pub struct UpdateConfigOptions {
 }
 
 /// Body accepted by `PATCH /configs`. Every outer field maps to a Go pointer.
-#[derive(Clone, Debug, Default, PartialEq, Eq, serde::Serialize, specta::Type)]
-#[serde(rename_all = "kebab-case")]
+#[derive(
+    Clone, Debug, Default, PartialEq, Eq, serde::Deserialize, serde::Serialize, specta::Type,
+)]
+#[serde(default, rename_all = "kebab-case")]
 pub struct ConfigPatch {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub port: Option<i64>,
@@ -335,8 +343,10 @@ pub struct ConfigPatch {
     pub interface_name: Option<String>,
 }
 
-#[derive(Clone, Debug, Default, PartialEq, Eq, serde::Serialize, specta::Type)]
-#[serde(rename_all = "kebab-case")]
+#[derive(
+    Clone, Debug, Default, PartialEq, Eq, serde::Deserialize, serde::Serialize, specta::Type,
+)]
+#[serde(default, rename_all = "kebab-case")]
 pub struct TunPatch {
     pub enable: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -432,8 +442,10 @@ pub struct TunPatch {
     pub sendmsgx: Option<bool>,
 }
 
-#[derive(Clone, Debug, Default, PartialEq, Eq, serde::Serialize, specta::Type)]
-#[serde(rename_all = "kebab-case")]
+#[derive(
+    Clone, Debug, Default, PartialEq, Eq, serde::Deserialize, serde::Serialize, specta::Type,
+)]
+#[serde(default, rename_all = "kebab-case")]
 pub struct TuicServerPatch {
     pub enable: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -521,5 +533,26 @@ mod tests {
             serde_json::to_value(patch).unwrap(),
             serde_json::json!({"tun": {"enable": false}})
         );
+    }
+
+    #[test]
+    fn runtime_config_without_optional_tunnel_configs_is_backward_compatible() {
+        let value = serde_json::json!({
+            "port": 0, "socks-port": 0, "redir-port": 0, "tproxy-port": 0,
+            "mixed-port": 0, "tun": {}, "tuic-server": {}, "ss-config": "",
+            "vmess-config": "", "authentication": null, "skip-auth-prefixes": null,
+            "lan-allowed-ips": null, "lan-disallowed-ips": null, "allow-lan": false,
+            "bind-address": "*", "inbound-tfo": false, "inbound-mptcp": false,
+            "mode": "rule", "unified-delay": false, "log-level": "info", "ipv6": false,
+            "interface-name": "", "routing-mark": 0, "geox-url": {},
+            "geo-auto-update": false, "geo-update-interval": 0, "geodata-mode": false,
+            "geodata-loader": "", "geosite-matcher": "", "tcp-concurrent": false,
+            "find-process-mode": "off", "sniffing": false, "global-ua": "",
+            "etag-support": false, "keep-alive-idle": 0, "keep-alive-interval": 0,
+            "disable-keep-alive": false
+        });
+        let config: RuntimeConfig = serde_json::from_value(value).unwrap();
+        assert_eq!(config.tcptun_config, None);
+        assert_eq!(config.udptun_config, None);
     }
 }

--- a/crates/nyanpasu-core-manager/Cargo.toml
+++ b/crates/nyanpasu-core-manager/Cargo.toml
@@ -10,6 +10,11 @@ doc = false
 name = "nyanpasu-fake-core"
 path = "tests/helpers/fake_core.rs"
 
+[[bin]]
+doc = false
+name = "nyanpasu-manager-host"
+path = "tests/helpers/manager_host.rs"
+
 [dependencies]
 camino = { version = "1.1", features = ["serde1"] }
 clash-api = { path = "../clash-api" }

--- a/crates/nyanpasu-core-manager/Cargo.toml
+++ b/crates/nyanpasu-core-manager/Cargo.toml
@@ -5,6 +5,10 @@ edition.workspace = true
 repository.workspace = true
 license.workspace = true
 
+[features]
+default = []
+test-hooks = []
+
 [[bin]]
 doc = false
 name = "nyanpasu-fake-core"
@@ -31,4 +35,5 @@ tokio-util.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
+nyanpasu-core-manager = { path = ".", features = ["test-hooks"] }
 tempfile = "3"

--- a/crates/nyanpasu-core-manager/README.md
+++ b/crates/nyanpasu-core-manager/README.md
@@ -270,8 +270,12 @@ controller.
 The runtime directory contains secret-bearing effective configuration. It is
 created with owner-only permissions (0700 directory and 0600 files on Unix;
 restricted ACLs on Windows), rejects symlinks/reparse points, and uses
-same-directory atomic replacement with file and directory durability. Runtime
-paths must remain inside that directory.
+same-directory atomic replacement. Unix fsyncs the file and parent directory;
+Windows fsyncs staged content but does not claim power-loss durability for
+`ReplaceFileW`, whose documented write-through flag is unsupported. Runtime
+paths must remain inside that directory. A process-lifetime `.manager.lock`
+prevents a second manager from sweeping or allocating epochs in an owned
+directory.
 
 Each pid record includes its epoch, executable identity, process start token,
 and runtime path. `CoreManager::new` sweeps before accepting work: it validates
@@ -279,6 +283,11 @@ every record, kills only a fully matching live process, confirms death, removes
 that epoch's yaml/pid/socket/backup/temp artifacts, and seeds the next epoch
 above the maximum artifact epoch observed. If identity cannot be proven, the
 manager fails construction instead of killing an uncertain process.
+
+Orphan termination is identity-bound to one open process handle on Windows and
+to a pidfd on supported Linux kernels. Older Linux kernels and other Unix
+targets revalidate the boot/start token and executable immediately before
+signaling; a minimal PID-reuse window remains on those fallback paths.
 
 ### One-shot config validation
 

--- a/crates/nyanpasu-core-manager/README.md
+++ b/crates/nyanpasu-core-manager/README.md
@@ -318,8 +318,8 @@ signaling; a minimal PID-reuse window remains on those fallback paths.
 Before killing a verified root, recovery captures its live descendant tree and
 records each descendant's executable and start token. It then confirms every
 captured identity is dead, skipping a PID that disappeared or changed identity.
-A descendant that exits or reparents before the two capture snapshots cannot be
-attributed safely and is not killed; persistent group/job identity would be
+A descendant that reparents before either capture snapshot observes it cannot
+be attributed safely and is not killed; persistent group/job identity would be
 needed to eliminate that residual gap.
 
 ### One-shot config validation

--- a/crates/nyanpasu-core-manager/README.md
+++ b/crates/nyanpasu-core-manager/README.md
@@ -233,6 +233,9 @@ match manager.apply_config(next_spec, expected).await? {
     ApplyOutcome::RolledBack { revision, failed_apply } => {
         /* old revision restored; retain failed_apply for diagnostics */
     }
+    ApplyOutcome::DurabilityUncertain { outcome, warning } => {
+        /* `outcome` was reconciled; persist/report the durability warning */
+    }
 }
 ```
 
@@ -277,12 +280,22 @@ paths must remain inside that directory. A process-lifetime `.manager.lock`
 prevents a second manager from sweeping or allocating epochs in an owned
 directory.
 
+If atomic replacement succeeds but parent-directory synchronization fails,
+reconciliation continues from the installed desired file and `apply_config`
+returns `ApplyOutcome::DurabilityUncertain` around the actual apply outcome.
+
 Each pid record includes its epoch, executable identity, process start token,
 and runtime path. `CoreManager::new` sweeps before accepting work: it validates
 every record, kills only a fully matching live process, confirms death, removes
 that epoch's yaml/pid/socket/backup/temp artifacts, and seeds the next epoch
 above the maximum artifact epoch observed. If identity cannot be proven, the
 manager fails construction instead of killing an uncertain process.
+
+If an in-process stop cannot prove death, the epoch is quarantined. Start,
+switch, restart, and config application return `Error::ManagerQuarantined`
+until `recover_quarantine()` validates the epoch record, confirms death, and
+cleans the retained artifacts. A missing or unverifiable record never clears
+the quarantine.
 
 Orphan termination is identity-bound to one open process handle on Windows and
 to a pidfd on supported Linux kernels. Older Linux kernels and other Unix

--- a/crates/nyanpasu-core-manager/README.md
+++ b/crates/nyanpasu-core-manager/README.md
@@ -10,19 +10,22 @@ over a `watch` channel.
 
 Key concepts:
 
-- **Epochs** — an `Instance` is immutable. Changing the config never mutates a
-  running core; the manager spawns a new instance with a new epoch and retires
-  the old one.
+- **Epochs and revisions** — an epoch is one process/controller lineage. A
+  `ConfigRevision` identifies desired config within that epoch by generation
+  and semantic hashes. Fully expressible changes can PATCH or reload the
+  current epoch; switch-class changes allocate a new epoch.
+- **Manager-owned snapshots** — both controller modes run from a private,
+  stable `config-{epoch}.yaml`, never directly from the caller's mutable file.
+  Supervisor respawns therefore reload the committed desired revision.
 - **Health-probed startup** — a start is only confirmed once
   `GET /version` on the core's external controller answers. `startup_timeout`
   is a *total* budget covering spawn, crash retries, and probing.
 - **Supervision** — crash → backoff → respawn → re-probe, bounded by
   `RestartPolicy`/`Backoff` from `nyanpasu-utils`. Dropping an `Instance`
   without `stop()` kills the whole process tree.
-- **Controller modes** — `Passthrough` probes the endpoint written in the
-  user's config; `Managed` rewrites the config to a manager-owned, per-epoch
-  local transport (named pipe on Windows, unix socket elsewhere), which is the
-  prerequisite for graceful switching.
+- **Controller modes** — `Passthrough` preserves the endpoint written in the
+  snapshot; `Managed` rewrites it to a per-epoch local transport (named pipe on
+  Windows, unix socket elsewhere), which is required for graceful switching.
 
 ## Requirements on the config
 
@@ -110,9 +113,10 @@ sequenceDiagram
 
 ### Graceful switch
 
-Selected only in `Managed` mode, for mihomo, without `dns.listen`. The old
-core keeps serving while the new one starts on zeroed listeners; traffic is
-moved by restoring the listeners via API after the old core releases them.
+Selected only in `Managed` mode when every inbound is provably zeroable and
+restorable. The old core keeps serving while the new one starts from a
+zero-inbound bootstrap. Both the bootstrap and full desired config pass the
+core's config check before overlap begins.
 
 ```mermaid
 sequenceDiagram
@@ -122,15 +126,17 @@ sequenceDiagram
     participant B as Core B (epoch N+1)
 
     App->>M: switch(spec B)
-    M->>M: derive B′ (listeners zeroed, epoch-N+1 endpoint)
-    M->>B: spawn + wait_ready
+    M->>M: derive + validate full B and zero-inbound bootstrap B′
+    M->>M: commit config-N+1.yaml = B′
+    M->>B: spawn from config-N+1.yaml + wait_ready
     Note over A: A keeps serving traffic
-    M->>A: stop() — ports released (point of no return)
-    M->>B: PATCH /configs — restore listeners (3 tries × 500 ms)
-    alt patch succeeded
+    M->>A: stop_and_confirm_dead() — ports released
+    M->>M: atomic replace config-N+1.yaml = full B
+    M->>B: PATCH /configs, GET projection, health probe
+    alt patch verified
         M-->>App: SwitchOutcome::Graceful
-    else patch failed
-        M->>B: stop(); hard restart B on the full config (same epoch)
+    else patch failed or uncertain
+        M->>B: stop_and_confirm_dead(); restart from committed full B (same epoch)
         M-->>App: SwitchOutcome::Hard { PatchFailed }
     end
 ```
@@ -148,7 +154,8 @@ cleanly: the old core is untouched and `Running` is re-published.
 | `ControllerMode::Passthrough` | `Hard { PassthroughMode }` |
 | Core kind is not mihomo | `Hard { UnsupportedKind }` |
 | Config sets `dns.listen` | `Hard { DnsListen }` |
-| Listener-restore PATCH keeps failing | hard restart, `Hard { PatchFailed }` |
+| Another inbound cannot be proven safe for overlap | `Hard { InboundConflict }` |
+| Listener-restore PATCH cannot be verified | same-epoch restart, `Hard { PatchFailed }` |
 | Otherwise | `Graceful` |
 
 ## Usage
@@ -174,7 +181,10 @@ let spec = InstanceSpec {
     options: InstanceOptions::default(),
 };
 
-let manager = CoreManager::new(ManagerOptions::default()); // Passthrough
+let manager = CoreManager::new(ManagerOptions {
+    runtime_dir: Some(Utf8PathBuf::from("/run/nyanpasu/core-runtime")),
+    ..ManagerOptions::default()
+}).await?; // Passthrough controller, manager-owned runtime snapshot
 manager.start(spec).await?; // resolves once the version probe passes
 manager.stop().await?;
 ```
@@ -194,7 +204,8 @@ let manager = CoreManager::new(ManagerOptions {
         controller_template: None,
     },
     cancel_token: CancellationToken::new(),
-});
+    ..ManagerOptions::default()
+}).await?;
 
 manager.start(spec_a).await?;
 match manager.switch(spec_b).await? {
@@ -203,10 +214,33 @@ match manager.switch(spec_b).await? {
 }
 ```
 
-In `Managed` mode the manager writes `derived_dir/epoch-{N}.yaml` (caller's
-config with the controller swapped for the per-epoch local endpoint), sweeps
-stale artifacts at startup, and deletes them on stop/switch. The advertised
-endpoint is available as `CoreStatus.controller`.
+The manager writes `config-{N}.yaml` and `core-{N}.pid` in its runtime
+directory. Managed mode may use `derived_dir` as the compatibility runtime-dir
+alias; Passthrough requires `runtime_dir` explicitly. The advertised endpoint
+is available as `CoreStatus.controller` in both modes.
+
+### Apply config with revision CAS
+
+```rust
+use nyanpasu_core_manager::{ApplyOutcome, InstanceSpec};
+
+let expected = manager.status().revision.as_ref().map(|revision| revision.id());
+match manager.apply_config(next_spec, expected).await? {
+    ApplyOutcome::Noop { revision }
+    | ApplyOutcome::Patched { revision }
+    | ApplyOutcome::Reloaded { revision }
+    | ApplyOutcome::Restarted { revision } => { /* desired revision active */ }
+    ApplyOutcome::RolledBack { revision, failed_apply } => {
+        /* old revision restored; retain failed_apply for diagnostics */
+    }
+}
+```
+
+`expected_revision` is checked before staging or publishing. PATCH writes the
+full desired file first, then requires `GET /configs` projection verification
+and a health probe. Reload uses `PUT /configs`; uncertain reconciliation stops
+and restarts from the committed snapshot. If that restart fails, the previous
+runtime file is atomically restored and restarted.
 
 ### Watch status
 
@@ -227,7 +261,24 @@ tokio::spawn(async move {
 ```
 
 `CoreStatus` also carries `changed_at` (unix ms of the last transition),
-`spec` (summary of the config in use), and `controller` (Managed mode only).
+`spec`, `controller`, and the active `ConfigRevision`. These fields are
+published together, so a new epoch is never paired with the previous epoch's
+controller.
+
+## Runtime directory security and recovery
+
+The runtime directory contains secret-bearing effective configuration. It is
+created with owner-only permissions (0700 directory and 0600 files on Unix;
+restricted ACLs on Windows), rejects symlinks/reparse points, and uses
+same-directory atomic replacement with file and directory durability. Runtime
+paths must remain inside that directory.
+
+Each pid record includes its epoch, executable identity, process start token,
+and runtime path. `CoreManager::new` sweeps before accepting work: it validates
+every record, kills only a fully matching live process, confirms death, removes
+that epoch's yaml/pid/socket/backup/temp artifacts, and seeds the next epoch
+above the maximum artifact epoch observed. If identity cannot be proven, the
+manager fails construction instead of killing an uncertain process.
 
 ### One-shot config validation
 

--- a/crates/nyanpasu-core-manager/README.md
+++ b/crates/nyanpasu-core-manager/README.md
@@ -158,6 +158,11 @@ cleanly: the old core is untouched and `Running` is re-published.
 | Listener-restore PATCH cannot be verified | same-epoch restart, `Hard { PatchFailed }` |
 | Otherwise | `Graceful` |
 
+If the runtime replacement was installed but parent-directory durability could
+not be confirmed, either successful switch result is wrapped in
+`SwitchOutcome::DurabilityUncertain`; callers should persist or report its
+warning while treating the nested outcome as the reconciled result.
+
 ## Usage
 
 ### Start and stop (Passthrough)
@@ -211,6 +216,9 @@ manager.start(spec_a).await?;
 match manager.switch(spec_b).await? {
     SwitchOutcome::Graceful => { /* zero-downtime switch */ }
     SwitchOutcome::Hard { reason } => { /* fell back to stop→start; see `reason` */ }
+    SwitchOutcome::DurabilityUncertain { outcome, warning } => {
+        /* `outcome` succeeded; persist/report `warning` */
+    }
 }
 ```
 
@@ -281,8 +289,11 @@ prevents a second manager from sweeping or allocating epochs in an owned
 directory.
 
 If atomic replacement succeeds but parent-directory synchronization fails,
-reconciliation continues from the installed desired file and `apply_config`
-returns `ApplyOutcome::DurabilityUncertain` around the actual apply outcome.
+reconciliation continues from the installed desired file. `apply_config`
+returns `ApplyOutcome::DurabilityUncertain` and graceful `switch()` returns
+`SwitchOutcome::DurabilityUncertain`, each around the actual reconciled
+outcome. Errors retain their original structured variant as the source of
+`Error::DurabilityUncertain`.
 
 Each pid record includes its epoch, executable identity, process start token,
 and runtime path. `CoreManager::new` sweeps before accepting work: it validates
@@ -294,13 +305,22 @@ manager fails construction instead of killing an uncertain process.
 If an in-process stop cannot prove death, the epoch is quarantined. Start,
 switch, restart, and config application return `Error::ManagerQuarantined`
 until `recover_quarantine()` validates the epoch record, confirms death, and
-cleans the retained artifacts. A missing or unverifiable record never clears
-the quarantine.
+cleans the retained artifacts. Recovery attempts every quarantined epoch and
+retains an in-memory death proof if artifact cleanup must be retried. A missing
+or unverifiable record never clears the quarantine. `stop()` and `shutdown()`
+intentionally bypass this gate so they can reduce the number of live processes;
+they do not clear quarantine.
 
 Orphan termination is identity-bound to one open process handle on Windows and
 to a pidfd on supported Linux kernels. Older Linux kernels and other Unix
 targets revalidate the boot/start token and executable immediately before
 signaling; a minimal PID-reuse window remains on those fallback paths.
+Before killing a verified root, recovery captures its live descendant tree and
+records each descendant's executable and start token. It then confirms every
+captured identity is dead, skipping a PID that disappeared or changed identity.
+A descendant that exits or reparents before the two capture snapshots cannot be
+attributed safely and is not killed; persistent group/job identity would be
+needed to eliminate that residual gap.
 
 ### One-shot config validation
 

--- a/crates/nyanpasu-core-manager/src/config.rs
+++ b/crates/nyanpasu-core-manager/src/config.rs
@@ -20,7 +20,6 @@ pub(crate) struct PreparedConfig {
     pub bytes: Vec<u8>,
     pub document: Mapping,
     pub controller: ResolvedController,
-    pub restore: RestorePlan,
     pub source_hash: String,
     pub effective_hash: String,
 }
@@ -37,43 +36,6 @@ pub(crate) enum RawController {
     #[cfg_attr(windows, allow(dead_code))]
     Unix(String),
     Http(String),
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum DeriveMode {
-    ControllerOnly,
-    ZeroListeners,
-}
-
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub(crate) struct RestorePlan {
-    pub port: Option<i64>,
-    pub socks_port: Option<i64>,
-    pub redir_port: Option<i64>,
-    pub tproxy_port: Option<i64>,
-    pub mixed_port: Option<i64>,
-    pub tun_enabled: bool,
-}
-
-impl RestorePlan {
-    pub(crate) fn to_patch(&self) -> clash_api::ConfigPatch {
-        clash_api::ConfigPatch {
-            port: self.port,
-            socks_port: self.socks_port,
-            redir_port: self.redir_port,
-            tproxy_port: self.tproxy_port,
-            mixed_port: self.mixed_port,
-            tun: self.tun_enabled.then(|| clash_api::TunPatch {
-                enable: true,
-                ..Default::default()
-            }),
-            ..Default::default()
-        }
-    }
-
-    pub(crate) fn is_empty(&self) -> bool {
-        *self == Self::default()
-    }
 }
 
 impl ConfigSnapshot {
@@ -111,29 +73,49 @@ impl ConfigSnapshot {
         inspect_mapping(&self.document)
     }
 
-    pub(crate) fn prepare(
+    pub(crate) fn prepare_full(
         &self,
         mode: &ControllerMode,
         runtime_dir: &Utf8Path,
         epoch: u64,
-        derive_mode: DeriveMode,
+    ) -> Result<PreparedConfig, Error> {
+        self.prepare(mode, runtime_dir, epoch, false)
+    }
+
+    pub(crate) fn prepare_bootstrap(
+        &self,
+        mode: &ControllerMode,
+        runtime_dir: &Utf8Path,
+        epoch: u64,
+    ) -> Result<PreparedConfig, Error> {
+        self.prepare(mode, runtime_dir, epoch, true)
+    }
+
+    fn prepare(
+        &self,
+        mode: &ControllerMode,
+        runtime_dir: &Utf8Path,
+        epoch: u64,
+        zero_inbounds: bool,
     ) -> Result<PreparedConfig, Error> {
         let mut document = self.document.clone();
-        let mut restore = RestorePlan::default();
 
-        if derive_mode == DeriveMode::ZeroListeners {
-            zero_listener(&mut document, "port", &mut restore.port);
-            zero_listener(&mut document, "socks-port", &mut restore.socks_port);
-            zero_listener(&mut document, "redir-port", &mut restore.redir_port);
-            zero_listener(&mut document, "tproxy-port", &mut restore.tproxy_port);
-            zero_listener(&mut document, "mixed-port", &mut restore.mixed_port);
+        if zero_inbounds {
+            for key in [
+                "port",
+                "socks-port",
+                "redir-port",
+                "tproxy-port",
+                "mixed-port",
+            ] {
+                zero_listener(&mut document, key);
+            }
             if let Some(tun) = document
                 .get_mut(Value::String("tun".to_owned()))
                 .and_then(Value::as_mapping_mut)
             {
                 let enable = Value::String("enable".to_owned());
                 if tun.get(&enable).and_then(Value::as_bool) == Some(true) {
-                    restore.tun_enabled = true;
                     tun.insert(enable, Value::from(false));
                 }
             }
@@ -173,7 +155,6 @@ impl ConfigSnapshot {
             bytes,
             document,
             controller,
-            restore,
         })
     }
 }
@@ -294,14 +275,14 @@ pub(crate) fn managed_endpoint_path(
     }
 }
 
-fn zero_listener(document: &mut Mapping, key: &str, slot: &mut Option<i64>) {
+fn zero_listener(document: &mut Mapping, key: &str) {
     let key = Value::String(key.to_owned());
-    if let Some(value) = document
+    if document
         .get(&key)
         .and_then(Value::as_i64)
         .filter(|value| *value != 0)
+        .is_some()
     {
-        *slot = Some(value);
         document.insert(key, Value::from(0));
     }
 }
@@ -342,7 +323,7 @@ mod tests {
     }
 
     #[test]
-    fn managed_prepare_zeroes_listeners_and_keeps_the_source_snapshot() {
+    fn managed_bootstrap_zeroes_listeners_and_keeps_the_source_snapshot() {
         let source = snapshot(
             "mixed-port: 7890\nexternal-controller: 127.0.0.1:9090\nsecret: sc\ntun:\n  enable: true\n",
         );
@@ -351,15 +332,24 @@ mod tests {
             controller_template: Some(r"\\.\pipe\ny-{epoch}".into()),
         };
         let prepared = source
-            .prepare(
-                &mode,
-                Utf8Path::new("runtime"),
-                7,
-                DeriveMode::ZeroListeners,
-            )
+            .prepare_bootstrap(&mode, Utf8Path::new("runtime"), 7)
             .unwrap();
-        assert_eq!(prepared.restore.mixed_port, Some(7890));
-        assert!(prepared.restore.tun_enabled);
+        assert_eq!(
+            prepared
+                .document
+                .get(Value::String("mixed-port".into()))
+                .and_then(Value::as_i64),
+            Some(0)
+        );
+        assert_eq!(
+            prepared
+                .document
+                .get(Value::String("tun".into()))
+                .and_then(Value::as_mapping)
+                .and_then(|tun| tun.get(Value::String("enable".into())))
+                .and_then(Value::as_bool),
+            Some(false)
+        );
         assert_eq!(prepared.controller.secret.as_deref(), Some("sc"));
         assert_eq!(
             source.info().controller,
@@ -376,17 +366,5 @@ mod tests {
             r"\\.\pipe\ny-42"
         );
         assert!(managed_endpoint_path(dir, None, 42).unwrap().contains("42"));
-    }
-
-    #[test]
-    fn restore_plan_maps_to_config_patch() {
-        let plan = RestorePlan {
-            mixed_port: Some(7890),
-            tun_enabled: true,
-            ..Default::default()
-        };
-        let patch = plan.to_patch();
-        assert_eq!(patch.mixed_port, Some(7890));
-        assert_eq!(patch.tun.as_ref().map(|tun| tun.enable), Some(true));
     }
 }

--- a/crates/nyanpasu-core-manager/src/config.rs
+++ b/crates/nyanpasu-core-manager/src/config.rs
@@ -18,6 +18,7 @@ pub(crate) struct ConfigSnapshot {
 #[derive(Debug, Clone)]
 pub(crate) struct PreparedConfig {
     pub bytes: Vec<u8>,
+    pub document: Mapping,
     pub controller: ResolvedController,
     pub restore: RestorePlan,
     pub source_hash: String,
@@ -28,7 +29,6 @@ pub(crate) struct PreparedConfig {
 pub(crate) struct ConfigInfo {
     pub controller: Option<RawController>,
     pub secret: Option<String>,
-    pub has_dns_listen: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -102,6 +102,11 @@ impl ConfigSnapshot {
         &self.source_path
     }
 
+    pub(crate) fn document(&self) -> &Mapping {
+        &self.document
+    }
+
+    #[cfg(test)]
     pub(crate) fn info(&self) -> ConfigInfo {
         inspect_mapping(&self.document)
     }
@@ -166,6 +171,7 @@ impl ConfigSnapshot {
             effective_hash: semantic_hash(&bytes),
             source_hash: self.source_hash.clone(),
             bytes,
+            document,
             controller,
             restore,
         })
@@ -233,16 +239,9 @@ fn inspect_mapping(doc: &Mapping) -> ConfigInfo {
 
     let controller =
         local.or_else(|| str_value(doc, "external-controller").map(RawController::Http));
-    let has_dns_listen = doc
-        .get(Value::String("dns".to_owned()))
-        .and_then(Value::as_mapping)
-        .and_then(|dns| dns.get(Value::String("listen".to_owned())))
-        .and_then(Value::as_str)
-        .is_some_and(|value| !value.is_empty());
     ConfigInfo {
         controller,
         secret: str_value(doc, "secret"),
-        has_dns_listen,
     }
 }
 

--- a/crates/nyanpasu-core-manager/src/config.rs
+++ b/crates/nyanpasu-core-manager/src/config.rs
@@ -1,9 +1,28 @@
-//! Runtime-config introspection (controller endpoint, secret, DNS listener).
+//! Immutable config snapshots and deterministic effective documents.
 
-use camino::Utf8Path;
+use camino::{Utf8Path, Utf8PathBuf};
 use serde_yaml_ng::{Mapping, Value};
 
-use crate::{error::Error, spec::ResolvedController};
+use crate::{
+    error::Error,
+    spec::{ControllerMode, ResolvedController},
+};
+
+#[derive(Debug, Clone)]
+pub(crate) struct ConfigSnapshot {
+    source_path: Utf8PathBuf,
+    document: Mapping,
+    source_hash: String,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct PreparedConfig {
+    pub bytes: Vec<u8>,
+    pub controller: ResolvedController,
+    pub restore: RestorePlan,
+    pub source_hash: String,
+    pub effective_hash: String,
+}
 
 #[derive(Debug)]
 pub(crate) struct ConfigInfo {
@@ -20,68 +39,9 @@ pub(crate) enum RawController {
     Http(String),
 }
 
-fn str_value(doc: &Mapping, key: &str) -> Option<String> {
-    doc.get(Value::String(key.to_owned()))
-        .and_then(Value::as_str)
-        .map(str::to_owned)
-        .filter(|s| !s.is_empty())
-}
-
-pub(crate) async fn inspect(config_path: &Utf8Path) -> Result<ConfigInfo, Error> {
-    let raw = tokio::fs::read_to_string(config_path).await?;
-    let doc: Mapping = serde_yaml_ng::from_str(&raw)?;
-    Ok(inspect_mapping(&doc))
-}
-
-fn inspect_mapping(doc: &Mapping) -> ConfigInfo {
-    #[cfg(windows)]
-    let local = str_value(doc, "external-controller-pipe").map(RawController::Pipe);
-    #[cfg(not(windows))]
-    let local = str_value(doc, "external-controller-unix").map(RawController::Unix);
-
-    let controller =
-        local.or_else(|| str_value(doc, "external-controller").map(RawController::Http));
-
-    let has_dns_listen = doc
-        .get(Value::String("dns".to_owned()))
-        .and_then(Value::as_mapping)
-        .and_then(|dns| dns.get(Value::String("listen".to_owned())))
-        .and_then(Value::as_str)
-        .is_some_and(|s| !s.is_empty());
-
-    ConfigInfo {
-        controller,
-        secret: str_value(doc, "secret"),
-        has_dns_listen,
-    }
-}
-
-pub(crate) fn resolve_controller(info: &ConfigInfo) -> Result<ResolvedController, Error> {
-    let raw = info.controller.as_ref().ok_or(Error::ControllerMissing)?;
-    let host = match raw {
-        RawController::Pipe(path) => clash_api::Host::named_pipe(path),
-        RawController::Unix(path) => clash_api::Host::unix_socket(path),
-        RawController::Http(addr) => clash_api::Host::http(probe_address(addr))?,
-    };
-    Ok(ResolvedController {
-        host,
-        secret: info.secret.clone(),
-    })
-}
-
-/// `0.0.0.0:9090`, `:9090`, and `[::]:9090` are bind addresses — probe loopback.
-fn probe_address(addr: &str) -> String {
-    match addr.rsplit_once(':') {
-        Some(("0.0.0.0" | "::" | "[::]" | "", port)) => format!("127.0.0.1:{port}"),
-        _ => addr.to_owned(),
-    }
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum DeriveMode {
-    /// Rewrite only the controller keys (Managed-mode normal start).
     ControllerOnly,
-    /// Also zero every listener so the new core can start beside the old one.
     ZeroListeners,
 }
 
@@ -116,241 +76,307 @@ impl RestorePlan {
     }
 }
 
-pub(crate) struct DerivedConfig {
-    pub path: camino::Utf8PathBuf,
-    pub controller: ResolvedController,
-    pub restore: RestorePlan,
+impl ConfigSnapshot {
+    /// Reads and parses the user config exactly once for one manager operation.
+    pub(crate) async fn load(source_path: &Utf8Path) -> Result<Self, Error> {
+        let raw = tokio::fs::read(source_path).await?;
+        Self::from_bytes(source_path.to_owned(), &raw)
+    }
+
+    fn from_bytes(source_path: Utf8PathBuf, raw: &[u8]) -> Result<Self, Error> {
+        let value: Value = serde_yaml_ng::from_slice(raw)?;
+        let Value::Mapping(document) = canonicalize(value)? else {
+            return Err(Error::InvalidConfig(
+                "top-level YAML document must be a mapping".into(),
+            ));
+        };
+        let canonical = serialize_mapping(&document)?;
+        Ok(Self {
+            source_path,
+            document,
+            source_hash: semantic_hash(&canonical),
+        })
+    }
+
+    pub(crate) fn source_path(&self) -> &Utf8Path {
+        &self.source_path
+    }
+
+    pub(crate) fn info(&self) -> ConfigInfo {
+        inspect_mapping(&self.document)
+    }
+
+    pub(crate) fn prepare(
+        &self,
+        mode: &ControllerMode,
+        runtime_dir: &Utf8Path,
+        epoch: u64,
+        derive_mode: DeriveMode,
+    ) -> Result<PreparedConfig, Error> {
+        let mut document = self.document.clone();
+        let mut restore = RestorePlan::default();
+
+        if derive_mode == DeriveMode::ZeroListeners {
+            zero_listener(&mut document, "port", &mut restore.port);
+            zero_listener(&mut document, "socks-port", &mut restore.socks_port);
+            zero_listener(&mut document, "redir-port", &mut restore.redir_port);
+            zero_listener(&mut document, "tproxy-port", &mut restore.tproxy_port);
+            zero_listener(&mut document, "mixed-port", &mut restore.mixed_port);
+            if let Some(tun) = document
+                .get_mut(Value::String("tun".to_owned()))
+                .and_then(Value::as_mapping_mut)
+            {
+                let enable = Value::String("enable".to_owned());
+                if tun.get(&enable).and_then(Value::as_bool) == Some(true) {
+                    restore.tun_enabled = true;
+                    tun.insert(enable, Value::from(false));
+                }
+            }
+        }
+
+        if let ControllerMode::Managed {
+            controller_template,
+            ..
+        } = mode
+        {
+            document.remove(Value::String("external-controller".to_owned()));
+            document.remove(Value::String("external-controller-pipe".to_owned()));
+            document.remove(Value::String("external-controller-unix".to_owned()));
+            let endpoint =
+                managed_endpoint_path(runtime_dir, controller_template.as_deref(), epoch)?;
+            #[cfg(windows)]
+            document.insert(
+                Value::String("external-controller-pipe".to_owned()),
+                Value::String(endpoint),
+            );
+            #[cfg(not(windows))]
+            document.insert(
+                Value::String("external-controller-unix".to_owned()),
+                Value::String(endpoint),
+            );
+        }
+
+        let Value::Mapping(document) = canonicalize(Value::Mapping(document))? else {
+            unreachable!("canonical mapping remains a mapping")
+        };
+        let info = inspect_mapping(&document);
+        let controller = resolve_controller(&info)?;
+        let bytes = serialize_mapping(&document)?;
+        Ok(PreparedConfig {
+            effective_hash: semantic_hash(&bytes),
+            source_hash: self.source_hash.clone(),
+            bytes,
+            controller,
+            restore,
+        })
+    }
+}
+
+fn canonicalize(value: Value) -> Result<Value, Error> {
+    match value {
+        Value::Mapping(mapping) => {
+            let mut entries = Vec::with_capacity(mapping.len());
+            for (key, value) in mapping {
+                let Value::String(key) = key else {
+                    return Err(Error::InvalidConfig(
+                        "all YAML mapping keys must be strings".into(),
+                    ));
+                };
+                entries.push((key, canonicalize(value)?));
+            }
+            entries.sort_by(|left, right| left.0.cmp(&right.0));
+            let mut canonical = Mapping::new();
+            for (key, value) in entries {
+                canonical.insert(Value::String(key), value);
+            }
+            Ok(Value::Mapping(canonical))
+        }
+        Value::Sequence(sequence) => sequence
+            .into_iter()
+            .map(canonicalize)
+            .collect::<Result<Vec<_>, _>>()
+            .map(Value::Sequence),
+        Value::Tagged(_) => Err(Error::InvalidConfig(
+            "tagged YAML values are not supported in runtime configs".into(),
+        )),
+        scalar => Ok(scalar),
+    }
+}
+
+fn serialize_mapping(document: &Mapping) -> Result<Vec<u8>, Error> {
+    Ok(serde_yaml_ng::to_string(document)?.into_bytes())
+}
+
+fn semantic_hash(bytes: &[u8]) -> String {
+    // Stable FNV-1a over canonical YAML; this is a change identity, not a
+    // cryptographic integrity primitive.
+    let mut hash = 0xcbf2_9ce4_8422_2325_u64;
+    for byte in bytes {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    format!("{hash:016x}")
+}
+
+fn str_value(doc: &Mapping, key: &str) -> Option<String> {
+    doc.get(Value::String(key.to_owned()))
+        .and_then(Value::as_str)
+        .map(str::to_owned)
+        .filter(|value| !value.is_empty())
+}
+
+fn inspect_mapping(doc: &Mapping) -> ConfigInfo {
+    #[cfg(windows)]
+    let local = str_value(doc, "external-controller-pipe").map(RawController::Pipe);
+    #[cfg(not(windows))]
+    let local = str_value(doc, "external-controller-unix").map(RawController::Unix);
+
+    let controller =
+        local.or_else(|| str_value(doc, "external-controller").map(RawController::Http));
+    let has_dns_listen = doc
+        .get(Value::String("dns".to_owned()))
+        .and_then(Value::as_mapping)
+        .and_then(|dns| dns.get(Value::String("listen".to_owned())))
+        .and_then(Value::as_str)
+        .is_some_and(|value| !value.is_empty());
+    ConfigInfo {
+        controller,
+        secret: str_value(doc, "secret"),
+        has_dns_listen,
+    }
+}
+
+pub(crate) fn resolve_controller(info: &ConfigInfo) -> Result<ResolvedController, Error> {
+    let raw = info.controller.as_ref().ok_or(Error::ControllerMissing)?;
+    let host = match raw {
+        RawController::Pipe(path) => clash_api::Host::named_pipe(path),
+        RawController::Unix(path) => clash_api::Host::unix_socket(path),
+        RawController::Http(address) => clash_api::Host::http(probe_address(address))?,
+    };
+    Ok(ResolvedController {
+        host,
+        secret: info.secret.clone(),
+    })
+}
+
+fn probe_address(address: &str) -> String {
+    match address.rsplit_once(':') {
+        Some(("0.0.0.0" | "::" | "[::]" | "", port)) => format!("127.0.0.1:{port}"),
+        _ => address.to_owned(),
+    }
+}
+
+pub(crate) fn validate_controller_template(template: Option<&str>) -> Result<(), Error> {
+    if template.is_some_and(|value| !value.contains("{epoch}")) {
+        return Err(Error::InvalidManagerOptions(
+            "managed controller_template must contain `{epoch}`".into(),
+        ));
+    }
+    Ok(())
 }
 
 pub(crate) fn managed_endpoint_path(
-    derived_dir: &Utf8Path,
+    runtime_dir: &Utf8Path,
     template: Option<&str>,
     epoch: u64,
-) -> String {
+) -> Result<String, Error> {
+    validate_controller_template(template)?;
     if let Some(template) = template {
-        return template.replace("{epoch}", &epoch.to_string());
+        return Ok(template.replace("{epoch}", &epoch.to_string()));
     }
     #[cfg(windows)]
     {
-        let _ = derived_dir;
-        format!(r"\\.\pipe\nyanpasu\core-{epoch}")
+        let _ = runtime_dir;
+        Ok(format!(r"\\.\pipe\nyanpasu\core-{epoch}"))
     }
     #[cfg(not(windows))]
     {
-        derived_dir.join(format!("core-{epoch}.sock")).to_string()
+        Ok(runtime_dir.join(format!("core-{epoch}.sock")).to_string())
     }
 }
 
-fn zero_listener(doc: &mut Mapping, key: &str, slot: &mut Option<i64>) {
+fn zero_listener(document: &mut Mapping, key: &str, slot: &mut Option<i64>) {
     let key = Value::String(key.to_owned());
-    if let Some(value) = doc.get(&key).and_then(Value::as_i64).filter(|v| *v != 0) {
+    if let Some(value) = document
+        .get(&key)
+        .and_then(Value::as_i64)
+        .filter(|value| *value != 0)
+    {
         *slot = Some(value);
-        doc.insert(key, Value::from(0));
+        document.insert(key, Value::from(0));
     }
-}
-
-/// Writes `derived_dir/epoch-{epoch}.yaml` — the caller's config with the
-/// controller swapped for the managed epoch endpoint (and, for
-/// [`DeriveMode::ZeroListeners`], every listener disabled and recorded).
-pub(crate) async fn derive(
-    config_path: &Utf8Path,
-    derived_dir: &Utf8Path,
-    template: Option<&str>,
-    epoch: u64,
-    mode: DeriveMode,
-) -> Result<DerivedConfig, Error> {
-    let raw = tokio::fs::read_to_string(config_path).await?;
-    let mut doc: Mapping = serde_yaml_ng::from_str(&raw)?;
-
-    let mut restore = RestorePlan::default();
-    if mode == DeriveMode::ZeroListeners {
-        zero_listener(&mut doc, "port", &mut restore.port);
-        zero_listener(&mut doc, "socks-port", &mut restore.socks_port);
-        zero_listener(&mut doc, "redir-port", &mut restore.redir_port);
-        zero_listener(&mut doc, "tproxy-port", &mut restore.tproxy_port);
-        zero_listener(&mut doc, "mixed-port", &mut restore.mixed_port);
-        if let Some(tun) = doc
-            .get_mut(Value::String("tun".to_owned()))
-            .and_then(Value::as_mapping_mut)
-        {
-            let enable = Value::String("enable".to_owned());
-            if tun.get(&enable).and_then(Value::as_bool) == Some(true) {
-                restore.tun_enabled = true;
-                tun.insert(enable, Value::from(false));
-            }
-        }
-    }
-
-    doc.remove(Value::String("external-controller".to_owned()));
-    doc.remove(Value::String("external-controller-pipe".to_owned()));
-    doc.remove(Value::String("external-controller-unix".to_owned()));
-    let endpoint = managed_endpoint_path(derived_dir, template, epoch);
-    #[cfg(windows)]
-    doc.insert(
-        Value::String("external-controller-pipe".to_owned()),
-        Value::String(endpoint.clone()),
-    );
-    #[cfg(not(windows))]
-    doc.insert(
-        Value::String("external-controller-unix".to_owned()),
-        Value::String(endpoint.clone()),
-    );
-    let secret = str_value(&doc, "secret");
-
-    tokio::fs::create_dir_all(derived_dir).await?;
-    let path = derived_dir.join(format!("epoch-{epoch}.yaml"));
-    tokio::fs::write(&path, serde_yaml_ng::to_string(&doc)?).await?;
-
-    #[cfg(windows)]
-    let host = clash_api::Host::named_pipe(&endpoint);
-    #[cfg(not(windows))]
-    let host = clash_api::Host::unix_socket(&endpoint);
-    Ok(DerivedConfig {
-        path,
-        controller: ResolvedController { host, secret },
-        restore,
-    })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    fn info_of(yaml: &str) -> ConfigInfo {
-        let doc: serde_yaml_ng::Mapping = serde_yaml_ng::from_str(yaml).unwrap();
-        inspect_mapping(&doc)
+    fn snapshot(yaml: &str) -> ConfigSnapshot {
+        ConfigSnapshot::from_bytes(Utf8PathBuf::from("config.yaml"), yaml.as_bytes()).unwrap()
     }
 
     #[test]
     fn extracts_http_controller_and_secret() {
-        let info = info_of("external-controller: 127.0.0.1:9090\nsecret: s3cret\n");
+        let info = snapshot("external-controller: 127.0.0.1:9090\nsecret: s3cret\n").info();
         assert_eq!(
             info.controller,
             Some(RawController::Http("127.0.0.1:9090".into()))
         );
         assert_eq!(info.secret.as_deref(), Some("s3cret"));
-        assert!(!info.has_dns_listen);
     }
 
     #[test]
-    fn local_transport_takes_priority_over_http() {
-        #[cfg(windows)]
-        {
-            let info = info_of(
-                "external-controller: 127.0.0.1:9090\nexternal-controller-pipe: \\\\.\\pipe\\x\n",
-            );
-            assert_eq!(
-                info.controller,
-                Some(RawController::Pipe(r"\\.\pipe\x".into()))
-            );
-        }
-        #[cfg(unix)]
-        {
-            let info = info_of(
-                "external-controller: 127.0.0.1:9090\nexternal-controller-unix: /run/x.sock\n",
-            );
-            assert_eq!(
-                info.controller,
-                Some(RawController::Unix("/run/x.sock".into()))
-            );
-        }
+    fn semantic_hash_ignores_mapping_order_and_whitespace() {
+        let first = snapshot("mode: rule\ndns:\n  enable: true\n  listen: ''\n");
+        let second = snapshot("dns: { listen: '', enable: true }\n\nmode: rule\n");
+        assert_eq!(first.source_hash, second.source_hash);
     }
 
     #[test]
-    fn detects_dns_listen() {
-        let info = info_of("dns:\n  listen: 0.0.0.0:53\n");
-        assert!(info.has_dns_listen);
-    }
-
-    #[test]
-    fn missing_controller_is_a_strict_error() {
-        let info = info_of("mixed-port: 7890\n");
-        assert!(matches!(
-            resolve_controller(&info),
-            Err(crate::Error::ControllerMissing)
-        ));
-    }
-
-    #[test]
-    fn wildcard_bind_addresses_probe_via_loopback() {
-        assert_eq!(probe_address("0.0.0.0:9090"), "127.0.0.1:9090");
-        assert_eq!(probe_address(":9090"), "127.0.0.1:9090");
-        assert_eq!(probe_address("[::]:9090"), "127.0.0.1:9090");
-        assert_eq!(probe_address("127.0.0.1:9090"), "127.0.0.1:9090");
-    }
-
-    #[tokio::test]
-    async fn derive_zeroes_listeners_and_records_the_restore_plan() {
-        let dir = tempfile::tempdir().unwrap();
-        let dir = camino::Utf8PathBuf::from_path_buf(dir.path().to_path_buf()).unwrap();
-        let src = dir.join("config.yaml");
-        std::fs::write(
-            &src,
-            "mixed-port: 7890\nsocks-port: 0\nexternal-controller: 127.0.0.1:9090\nsecret: sc\nmode: rule\ntun:\n  enable: true\n  stack: system\n",
+    fn non_string_mapping_keys_are_rejected_recursively() {
+        let error = ConfigSnapshot::from_bytes(
+            Utf8PathBuf::from("config.yaml"),
+            b"rules:\n  nested:\n    1: invalid\n",
         )
-        .unwrap();
-
-        let derived = derive(&src, &dir, None, 7, DeriveMode::ZeroListeners)
-            .await
-            .unwrap();
-        assert_eq!(derived.restore.mixed_port, Some(7890));
-        assert_eq!(
-            derived.restore.socks_port, None,
-            "0 means disabled — not restored"
-        );
-        assert!(derived.restore.tun_enabled);
-        assert_eq!(derived.controller.secret.as_deref(), Some("sc"));
-
-        let out: serde_yaml_ng::Mapping =
-            serde_yaml_ng::from_str(&std::fs::read_to_string(&derived.path).unwrap()).unwrap();
-        let get = |k: &str| out.get(Value::String(k.to_owned())).cloned();
-        assert_eq!(get("mixed-port"), Some(Value::from(0)));
-        assert_eq!(
-            get("mode"),
-            Some(Value::from("rule")),
-            "unrelated keys survive"
-        );
-        assert_eq!(get("external-controller"), None, "HTTP controller stripped");
-        let tun = get("tun").unwrap();
-        assert_eq!(
-            tun.as_mapping()
-                .unwrap()
-                .get(Value::String("enable".into())),
-            Some(&Value::from(false))
-        );
-        #[cfg(windows)]
-        assert!(get("external-controller-pipe").is_some());
-        #[cfg(not(windows))]
-        assert!(get("external-controller-unix").is_some());
+        .unwrap_err();
+        assert!(matches!(error, Error::InvalidConfig(_)));
     }
 
-    #[tokio::test]
-    async fn derive_controller_only_keeps_listeners() {
-        let dir = tempfile::tempdir().unwrap();
-        let dir = camino::Utf8PathBuf::from_path_buf(dir.path().to_path_buf()).unwrap();
-        let src = dir.join("config.yaml");
-        std::fs::write(&src, "mixed-port: 7890\n").unwrap();
-        let derived = derive(&src, &dir, None, 3, DeriveMode::ControllerOnly)
-            .await
+    #[test]
+    fn managed_prepare_zeroes_listeners_and_keeps_the_source_snapshot() {
+        let source = snapshot(
+            "mixed-port: 7890\nexternal-controller: 127.0.0.1:9090\nsecret: sc\ntun:\n  enable: true\n",
+        );
+        let mode = ControllerMode::Managed {
+            derived_dir: Utf8PathBuf::from("runtime"),
+            controller_template: Some(r"\\.\pipe\ny-{epoch}".into()),
+        };
+        let prepared = source
+            .prepare(
+                &mode,
+                Utf8Path::new("runtime"),
+                7,
+                DeriveMode::ZeroListeners,
+            )
             .unwrap();
-        assert!(derived.restore.is_empty());
-        let out: serde_yaml_ng::Mapping =
-            serde_yaml_ng::from_str(&std::fs::read_to_string(&derived.path).unwrap()).unwrap();
+        assert_eq!(prepared.restore.mixed_port, Some(7890));
+        assert!(prepared.restore.tun_enabled);
+        assert_eq!(prepared.controller.secret.as_deref(), Some("sc"));
         assert_eq!(
-            out.get(Value::String("mixed-port".into())),
-            Some(&Value::from(7890))
+            source.info().controller,
+            Some(RawController::Http("127.0.0.1:9090".into()))
         );
     }
 
     #[test]
-    fn endpoint_template_substitutes_epoch() {
-        let dir = camino::Utf8Path::new("/tmp/x");
+    fn endpoint_template_requires_and_substitutes_epoch() {
+        let dir = Utf8Path::new("/tmp/x");
+        assert!(managed_endpoint_path(dir, Some("fixed"), 1).is_err());
         assert_eq!(
-            managed_endpoint_path(dir, Some(r"\\.\pipe\ny-{epoch}"), 42),
+            managed_endpoint_path(dir, Some(r"\\.\pipe\ny-{epoch}"), 42).unwrap(),
             r"\\.\pipe\ny-42"
         );
-        let default_path = managed_endpoint_path(dir, None, 42);
-        assert!(default_path.contains("42"), "got {default_path}");
+        assert!(managed_endpoint_path(dir, None, 42).unwrap().contains("42"));
     }
 
     #[test]
@@ -362,7 +388,6 @@ mod tests {
         };
         let patch = plan.to_patch();
         assert_eq!(patch.mixed_port, Some(7890));
-        assert_eq!(patch.tun.as_ref().map(|t| t.enable), Some(true));
-        assert_eq!(patch.port, None);
+        assert_eq!(patch.tun.as_ref().map(|tun| tun.enable), Some(true));
     }
 }

--- a/crates/nyanpasu-core-manager/src/config.rs
+++ b/crates/nyanpasu-core-manager/src/config.rs
@@ -262,7 +262,11 @@ pub(crate) fn managed_endpoint_path(
 ) -> Result<String, Error> {
     validate_controller_template(template)?;
     if let Some(template) = template {
-        return Ok(template.replace("{epoch}", &epoch.to_string()));
+        let endpoint = template.replace("{epoch}", &epoch.to_string());
+        #[cfg(windows)]
+        return Ok(endpoint);
+        #[cfg(unix)]
+        return managed_unix_endpoint(runtime_dir, &endpoint);
     }
     #[cfg(windows)]
     {
@@ -273,6 +277,36 @@ pub(crate) fn managed_endpoint_path(
     {
         Ok(runtime_dir.join(format!("core-{epoch}.sock")).to_string())
     }
+}
+
+#[cfg(unix)]
+fn managed_unix_endpoint(runtime_dir: &Utf8Path, endpoint: &str) -> Result<String, Error> {
+    let endpoint = Utf8Path::new(endpoint);
+    let candidate = if endpoint.is_absolute() {
+        endpoint.to_owned()
+    } else {
+        runtime_dir.join(endpoint)
+    };
+    let parent = candidate.parent().ok_or_else(|| {
+        Error::InvalidManagerOptions("managed Unix controller has no parent directory".into())
+    })?;
+    let canonical_parent = std::fs::canonicalize(parent).map_err(|error| {
+        Error::InvalidManagerOptions(format!(
+            "managed Unix controller parent `{parent}` cannot be canonicalized: {error}"
+        ))
+    })?;
+    let canonical_parent = Utf8PathBuf::from_path_buf(canonical_parent).map_err(|_| {
+        Error::InvalidManagerOptions("managed Unix controller path is not UTF-8".into())
+    })?;
+    if !canonical_parent.starts_with(runtime_dir) {
+        return Err(Error::InvalidManagerOptions(format!(
+            "managed Unix controller `{candidate}` escapes runtime directory `{runtime_dir}`"
+        )));
+    }
+    let file_name = candidate.file_name().ok_or_else(|| {
+        Error::InvalidManagerOptions("managed Unix controller must name a socket file".into())
+    })?;
+    Ok(canonical_parent.join(file_name).to_string())
 }
 
 fn zero_listener(document: &mut Mapping, key: &str) {
@@ -361,10 +395,24 @@ mod tests {
     fn endpoint_template_requires_and_substitutes_epoch() {
         let dir = Utf8Path::new("/tmp/x");
         assert!(managed_endpoint_path(dir, Some("fixed"), 1).is_err());
+        #[cfg(windows)]
         assert_eq!(
             managed_endpoint_path(dir, Some(r"\\.\pipe\ny-{epoch}"), 42).unwrap(),
             r"\\.\pipe\ny-42"
         );
         assert!(managed_endpoint_path(dir, None, 42).unwrap().contains("42"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn managed_unix_template_must_stay_inside_runtime_directory() {
+        let root = tempfile::tempdir().unwrap();
+        let runtime = Utf8PathBuf::from_path_buf(root.path().join("runtime")).unwrap();
+        std::fs::create_dir(&runtime).unwrap();
+        assert!(managed_endpoint_path(&runtime, Some("core-{epoch}.sock"), 4).is_ok());
+        let outside = root.path().join("escaped-{epoch}.sock");
+        let outside = outside.to_str().unwrap();
+        let error = managed_endpoint_path(&runtime, Some(outside), 4).unwrap_err();
+        assert!(error.to_string().contains("escapes runtime directory"));
     }
 }

--- a/crates/nyanpasu-core-manager/src/config.rs
+++ b/crates/nyanpasu-core-manager/src/config.rs
@@ -415,4 +415,22 @@ mod tests {
         let error = managed_endpoint_path(&runtime, Some(outside), 4).unwrap_err();
         assert!(error.to_string().contains("escapes runtime directory"));
     }
+
+    #[cfg(unix)]
+    #[test]
+    fn managed_unix_template_rejects_escaping_parent_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let root = tempfile::tempdir().unwrap();
+        let runtime = root.path().join("runtime");
+        let outside = root.path().join("outside");
+        std::fs::create_dir(&runtime).unwrap();
+        std::fs::create_dir(&outside).unwrap();
+        symlink(&outside, runtime.join("link")).unwrap();
+        let runtime = Utf8PathBuf::from_path_buf(runtime.canonicalize().unwrap()).unwrap();
+        let template = runtime.join("link/core-{epoch}.sock");
+
+        let error = managed_endpoint_path(&runtime, Some(template.as_str()), 5).unwrap_err();
+        assert!(error.to_string().contains("escapes runtime directory"));
+    }
 }

--- a/crates/nyanpasu-core-manager/src/config_diff.rs
+++ b/crates/nyanpasu-core-manager/src/config_diff.rs
@@ -193,6 +193,9 @@ fn process_spec_changed(current: &InstanceSpec, desired: &InstanceSpec) -> bool 
 }
 
 fn classify_documents(current: &Mapping, desired: &Mapping) -> Result<ConfigChange, Error> {
+    if dns_listen(current) != dns_listen(desired) {
+        return Ok(ConfigChange::Switch);
+    }
     let changes = diff(current, desired);
     if changes.is_empty() {
         return Ok(ConfigChange::Noop);
@@ -210,7 +213,9 @@ fn classify_documents(current: &Mapping, desired: &Mapping) -> Result<ConfigChan
 
     let reloadable = changes.iter().all(|entry| {
         entry.path.first().is_some_and(|root| {
-            RELOAD_FIELDS.contains(&root.as_str()) && !is_dns_listen(&entry.path)
+            RELOAD_FIELDS.contains(&root.as_str())
+                && !is_dns_listen(&entry.path)
+                && !(root == "dns" && entry.path.len() == 1)
         })
     });
     Ok(if reloadable {
@@ -379,6 +384,13 @@ fn is_dns_listen(path: &[String]) -> bool {
         && path.get(1).is_some_and(|value| value == "listen")
 }
 
+fn dns_listen(document: &Mapping) -> Option<&Value> {
+    document
+        .get(Value::String("dns".into()))
+        .and_then(Value::as_mapping)
+        .and_then(|dns| dns.get(Value::String("listen".into())))
+}
+
 pub(crate) fn overlap_block(document: &Mapping) -> Option<OverlapBlock> {
     if let Some(listen) = document
         .get(Value::String("dns".into()))
@@ -525,6 +537,24 @@ mod tests {
     fn deletion_is_never_patch() {
         assert!(matches!(
             classify_documents(&mapping("allow-lan: true"), &Mapping::new()).unwrap(),
+            ConfigChange::Switch
+        ));
+    }
+
+    #[test]
+    fn dns_root_shape_changes_are_never_reloadable() {
+        let current = mapping("dns: {listen: '127.0.0.1:1053', ipv6: false}");
+        for desired in ["dns: null", "dns: disabled", "dns: [invalid]"] {
+            assert!(
+                matches!(
+                    classify_documents(&current, &mapping(desired)).unwrap(),
+                    ConfigChange::Switch
+                ),
+                "{desired} bypassed dns.listen protection"
+            );
+        }
+        assert!(matches!(
+            classify_documents(&mapping("dns: {ipv6: false}"), &mapping("dns: null")).unwrap(),
             ConfigChange::Switch
         ));
     }

--- a/crates/nyanpasu-core-manager/src/config_diff.rs
+++ b/crates/nyanpasu-core-manager/src/config_diff.rs
@@ -137,6 +137,19 @@ impl RuntimeProjection {
     }
 }
 
+pub(crate) fn restoration_patch(
+    bootstrap: &Mapping,
+    desired: &Mapping,
+) -> Result<Option<(Box<clash_api::ConfigPatch>, RuntimeProjection)>, Error> {
+    match classify_documents(bootstrap, desired)? {
+        ConfigChange::Noop => Ok(None),
+        ConfigChange::Patch { patch, projection } => Ok(Some((patch, projection))),
+        ConfigChange::Reload | ConfigChange::Switch => Err(Error::InvalidConfig(
+            "graceful bootstrap cannot be restored losslessly with ConfigPatch".into(),
+        )),
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum OverlapBlock {
     DnsListen,

--- a/crates/nyanpasu-core-manager/src/config_diff.rs
+++ b/crates/nyanpasu-core-manager/src/config_diff.rs
@@ -1,0 +1,747 @@
+//! Deny-by-default runtime-config change classification and GET projection.
+
+use std::collections::BTreeSet;
+
+use serde_yaml_ng::{Mapping, Value};
+
+use crate::{Error, InstanceSpec, kind::CoreKind};
+
+const PATCH_FIELDS: &[&str] = &[
+    "port",
+    "socks-port",
+    "redir-port",
+    "tproxy-port",
+    "mixed-port",
+    "tun",
+    "tuic-server",
+    "ss-config",
+    "vmess-config",
+    "tcptun-config",
+    "udptun-config",
+    "allow-lan",
+    "skip-auth-prefixes",
+    "lan-allowed-ips",
+    "lan-disallowed-ips",
+    "bind-address",
+    "mode",
+    "log-level",
+    "ipv6",
+    "sniffing",
+    "tcp-concurrent",
+    "find-process-mode",
+    "interface-name",
+];
+
+const TUN_PATCH_FIELDS: &[&str] = &[
+    "enable",
+    "device",
+    "stack",
+    "dns-hijack",
+    "auto-route",
+    "auto-detect-interface",
+    "mtu",
+    "gso",
+    "gso-max-size",
+    "inet6-address",
+    "iproute2-table-index",
+    "iproute2-rule-index",
+    "auto-redirect",
+    "auto-redirect-input-mark",
+    "auto-redirect-output-mark",
+    "auto-redirect-iproute2-fallback-rule-index",
+    "loopback-address",
+    "strict-route",
+    "route-address",
+    "route-address-set",
+    "route-exclude-address",
+    "route-exclude-address-set",
+    "include-interface",
+    "exclude-interface",
+    "include-uid",
+    "include-uid-range",
+    "exclude-uid",
+    "exclude-uid-range",
+    "include-android-user",
+    "include-package",
+    "exclude-package",
+    "include-mac-address",
+    "exclude-mac-address",
+    "endpoint-independent-nat",
+    "udp-timeout",
+    "icmp-timeout",
+    "file-descriptor",
+    "inet4-route-address",
+    "inet6-route-address",
+    "inet4-route-exclude-address",
+    "inet6-route-exclude-address",
+    "recvmsgx",
+    "sendmsgx",
+];
+
+const TUIC_PATCH_FIELDS: &[&str] = &[
+    "enable",
+    "listen",
+    "token",
+    "users",
+    "certificate",
+    "private-key",
+    "congestion-controller",
+    "max-idle-time",
+    "authentication-timeout",
+    "alpn",
+    "max-udp-relay-packet-size",
+    "cwnd",
+    "bbr-profile",
+];
+
+const RELOAD_FIELDS: &[&str] = &[
+    "proxies",
+    "proxy-groups",
+    "proxy-providers",
+    "rule-providers",
+    "providers",
+    "rules",
+    "hosts",
+    "dns",
+];
+
+const PROTECTED_SOURCE_FIELDS: &[&str] = &[
+    "external-controller",
+    "external-controller-pipe",
+    "external-controller-unix",
+    "secret",
+];
+
+#[derive(Debug)]
+pub(crate) enum ConfigChange {
+    Noop,
+    Patch {
+        patch: Box<clash_api::ConfigPatch>,
+        projection: RuntimeProjection,
+    },
+    Reload,
+    Switch,
+}
+
+#[derive(Debug)]
+pub(crate) struct RuntimeProjection {
+    expected: Vec<(Vec<String>, Value)>,
+}
+
+impl RuntimeProjection {
+    pub(crate) fn verify(&self, actual: &clash_api::RuntimeConfig) -> Result<bool, Error> {
+        let actual = serde_yaml_ng::to_value(actual)?;
+        Ok(self.expected.iter().all(|(path, expected)| {
+            value_at(&actual, path).is_some_and(|actual| actual == expected)
+        }))
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum OverlapBlock {
+    DnsListen,
+    InboundSurface,
+}
+
+pub(crate) fn classify(
+    current_source: &Mapping,
+    current_effective: &Mapping,
+    current_spec: &InstanceSpec,
+    desired_source: &Mapping,
+    desired_effective: &Mapping,
+    desired_spec: &InstanceSpec,
+) -> Result<ConfigChange, Error> {
+    if desired_spec.core.kind != CoreKind::Mihomo
+        || process_spec_changed(current_spec, desired_spec)
+    {
+        return Ok(ConfigChange::Switch);
+    }
+
+    let source_diff = diff(current_source, desired_source);
+    if source_diff.iter().any(|entry| {
+        entry
+            .path
+            .first()
+            .is_some_and(|root| PROTECTED_SOURCE_FIELDS.contains(&root.as_str()))
+            || is_dns_listen(&entry.path)
+    }) {
+        return Ok(ConfigChange::Switch);
+    }
+    classify_documents(current_effective, desired_effective)
+}
+
+fn process_spec_changed(current: &InstanceSpec, desired: &InstanceSpec) -> bool {
+    current.core.kind != desired.core.kind
+        || current.core.binary_path != desired.core.binary_path
+        || current.core.version != desired.core.version
+        || current.core.features != desired.core.features
+        || current.working_dir != desired.working_dir
+        || format!("{:?}", current.options) != format!("{:?}", desired.options)
+}
+
+fn classify_documents(current: &Mapping, desired: &Mapping) -> Result<ConfigChange, Error> {
+    let changes = diff(current, desired);
+    if changes.is_empty() {
+        return Ok(ConfigChange::Noop);
+    }
+
+    let patchable = changes.iter().all(|entry| {
+        entry.new.is_some()
+            && entry.path.first().is_some_and(|root| {
+                PATCH_FIELDS.contains(&root.as_str()) && patch_nested_path_is_supported(&entry.path)
+            })
+    });
+    if patchable {
+        return build_patch(desired, &changes);
+    }
+
+    let reloadable = changes.iter().all(|entry| {
+        entry.path.first().is_some_and(|root| {
+            RELOAD_FIELDS.contains(&root.as_str()) && !is_dns_listen(&entry.path)
+        })
+    });
+    Ok(if reloadable {
+        ConfigChange::Reload
+    } else {
+        ConfigChange::Switch
+    })
+}
+
+fn patch_nested_path_is_supported(path: &[String]) -> bool {
+    match path.first().map(String::as_str) {
+        Some("tun") => path
+            .get(1)
+            .is_some_and(|field| TUN_PATCH_FIELDS.contains(&field.as_str())),
+        Some("tuic-server") => path
+            .get(1)
+            .is_some_and(|field| TUIC_PATCH_FIELDS.contains(&field.as_str())),
+        Some(_) => path.len() == 1,
+        None => false,
+    }
+}
+
+fn build_patch(desired: &Mapping, changes: &[DiffEntry]) -> Result<ConfigChange, Error> {
+    let roots: BTreeSet<&str> = changes
+        .iter()
+        .filter_map(|entry| entry.path.first().map(String::as_str))
+        .collect();
+    let mut document = Mapping::new();
+    for root in roots {
+        let key = Value::String(root.to_owned());
+        let Some(value) = desired.get(&key) else {
+            return Ok(ConfigChange::Switch);
+        };
+        let value = match root {
+            "tun" => filter_mapping(value, TUN_PATCH_FIELDS)?,
+            "tuic-server" => filter_mapping(value, TUIC_PATCH_FIELDS)?,
+            _ => value.clone(),
+        };
+        document.insert(key, value);
+    }
+    for required_enable in ["tun", "tuic-server"] {
+        if document.contains_key(Value::String(required_enable.to_owned()))
+            && document
+                .get(Value::String(required_enable.to_owned()))
+                .and_then(Value::as_mapping)
+                .and_then(|mapping| mapping.get(Value::String("enable".to_owned())))
+                .and_then(Value::as_bool)
+                .is_none()
+        {
+            return Ok(ConfigChange::Switch);
+        }
+    }
+    let Ok(patch) = serde_yaml_ng::from_value::<clash_api::ConfigPatch>(Value::Mapping(document))
+    else {
+        return Ok(ConfigChange::Switch);
+    };
+    let serialized = serde_yaml_ng::to_value(&patch)?;
+    let mut expected = Vec::new();
+    collect_leaves(&serialized, &mut Vec::new(), &mut expected);
+    Ok(ConfigChange::Patch {
+        patch: Box::new(patch),
+        projection: RuntimeProjection { expected },
+    })
+}
+
+fn filter_mapping(value: &Value, allowed: &[&str]) -> Result<Value, Error> {
+    let mapping = value
+        .as_mapping()
+        .ok_or_else(|| Error::InvalidConfig("patchable nested config must be a mapping".into()))?;
+    let mut filtered = Mapping::new();
+    for (key, value) in mapping {
+        let Some(key_text) = key.as_str() else {
+            return Err(Error::InvalidConfig("config keys must be strings".into()));
+        };
+        if allowed.contains(&key_text) {
+            filtered.insert(key.clone(), value.clone());
+        }
+    }
+    Ok(Value::Mapping(filtered))
+}
+
+#[derive(Debug)]
+struct DiffEntry {
+    path: Vec<String>,
+    new: Option<Value>,
+}
+
+fn diff(current: &Mapping, desired: &Mapping) -> Vec<DiffEntry> {
+    let mut changes = Vec::new();
+    diff_value(
+        Some(&Value::Mapping(current.clone())),
+        Some(&Value::Mapping(desired.clone())),
+        &mut Vec::new(),
+        &mut changes,
+    );
+    changes
+}
+
+fn diff_value(
+    current: Option<&Value>,
+    desired: Option<&Value>,
+    path: &mut Vec<String>,
+    changes: &mut Vec<DiffEntry>,
+) {
+    if current == desired {
+        return;
+    }
+    let current_mapping = current.and_then(Value::as_mapping);
+    let desired_mapping = desired.and_then(Value::as_mapping);
+    if (current_mapping.is_some() || desired_mapping.is_some())
+        && (current.is_none()
+            || current_mapping.is_some() && (desired.is_none() || desired_mapping.is_some()))
+    {
+        let mut keys = BTreeSet::new();
+        if let Some(mapping) = current_mapping {
+            keys.extend(mapping.keys().filter_map(Value::as_str));
+        }
+        if let Some(mapping) = desired_mapping {
+            keys.extend(mapping.keys().filter_map(Value::as_str));
+        }
+        if !keys.is_empty() {
+            for key in keys {
+                let yaml_key = Value::String(key.to_owned());
+                path.push(key.to_owned());
+                diff_value(
+                    current_mapping.and_then(|mapping| mapping.get(&yaml_key)),
+                    desired_mapping.and_then(|mapping| mapping.get(&yaml_key)),
+                    path,
+                    changes,
+                );
+                path.pop();
+            }
+            return;
+        }
+    }
+    changes.push(DiffEntry {
+        path: path.clone(),
+        new: desired.cloned(),
+    });
+}
+
+fn collect_leaves(value: &Value, path: &mut Vec<String>, output: &mut Vec<(Vec<String>, Value)>) {
+    if let Some(mapping) = value.as_mapping()
+        && !mapping.is_empty()
+    {
+        for (key, value) in mapping {
+            if let Some(key) = key.as_str() {
+                path.push(key.to_owned());
+                collect_leaves(value, path, output);
+                path.pop();
+            }
+        }
+        return;
+    }
+    output.push((path.clone(), value.clone()));
+}
+
+fn value_at<'a>(value: &'a Value, path: &[String]) -> Option<&'a Value> {
+    path.iter().try_fold(value, |value, key| {
+        value.as_mapping()?.get(Value::String(key.to_owned()))
+    })
+}
+
+fn is_dns_listen(path: &[String]) -> bool {
+    path.first().is_some_and(|value| value == "dns")
+        && path.get(1).is_some_and(|value| value == "listen")
+}
+
+pub(crate) fn overlap_block(document: &Mapping) -> Option<OverlapBlock> {
+    if let Some(listen) = document
+        .get(Value::String("dns".into()))
+        .and_then(Value::as_mapping)
+        .and_then(|dns| dns.get(Value::String("listen".into())))
+    {
+        return match listen.as_str() {
+            Some("") => None,
+            Some(_) => Some(OverlapBlock::DnsListen),
+            None if listen.is_null() => None,
+            None => Some(OverlapBlock::InboundSurface),
+        };
+    }
+    for key in [
+        "port",
+        "socks-port",
+        "redir-port",
+        "tproxy-port",
+        "mixed-port",
+    ] {
+        if document
+            .get(Value::String(key.into()))
+            .is_some_and(|value| value.as_i64().is_none())
+        {
+            return Some(OverlapBlock::InboundSurface);
+        }
+    }
+    if let Some(tun) = document.get(Value::String("tun".into())) {
+        let Some(tun) = tun.as_mapping() else {
+            return Some(OverlapBlock::InboundSurface);
+        };
+        if tun
+            .get(Value::String("enable".into()))
+            .is_some_and(|enable| enable.as_bool().is_none())
+        {
+            return Some(OverlapBlock::InboundSurface);
+        }
+    }
+    if let Some(tuic) = document.get(Value::String("tuic-server".into())) {
+        let Some(tuic) = tuic.as_mapping() else {
+            return Some(OverlapBlock::InboundSurface);
+        };
+        match tuic.get(Value::String("enable".into())) {
+            Some(enable) if enable.as_bool() == Some(false) => {}
+            None if tuic.is_empty() => {}
+            Some(_) | None => return Some(OverlapBlock::InboundSurface),
+        }
+    }
+    for key in [
+        "ss-config",
+        "vmess-config",
+        "tcptun-config",
+        "udptun-config",
+    ] {
+        if document
+            .get(Value::String(key.into()))
+            .is_some_and(|value| value.as_str() != Some(""))
+        {
+            return Some(OverlapBlock::InboundSurface);
+        }
+    }
+    for key in ["listeners", "tunnels"] {
+        if document
+            .get(Value::String(key.into()))
+            .is_some_and(nonempty_collection)
+        {
+            return Some(OverlapBlock::InboundSurface);
+        }
+    }
+    for key in document.keys().filter_map(Value::as_str) {
+        let inbound_like = key.ends_with("-port")
+            || key.contains("listener")
+            || key.contains("inbound")
+            || key.contains("tunnel");
+        if inbound_like && !PATCH_FIELDS.contains(&key) && !matches!(key, "listeners" | "tunnels") {
+            return Some(OverlapBlock::InboundSurface);
+        }
+    }
+    None
+}
+
+fn nonempty_collection(value: &Value) -> bool {
+    match value {
+        Value::Null => false,
+        Value::String(value) => !value.is_empty(),
+        Value::Sequence(value) => !value.is_empty(),
+        Value::Mapping(value) => !value.is_empty(),
+        Value::Bool(_) | Value::Number(_) | Value::Tagged(_) => true,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{CoreSpec, InstanceOptions};
+
+    fn mapping(yaml: &str) -> Mapping {
+        serde_yaml_ng::from_str(yaml).unwrap()
+    }
+
+    fn spec(kind: CoreKind, binary: &str) -> InstanceSpec {
+        InstanceSpec {
+            core: CoreSpec {
+                kind,
+                binary_path: binary.into(),
+                version: None,
+                features: Vec::new(),
+            },
+            config_path: "source.yaml".into(),
+            working_dir: ".".into(),
+            pid_file: None,
+            options: InstanceOptions::default(),
+        }
+    }
+
+    #[test]
+    fn patch_reload_and_switch_are_deny_by_default() {
+        assert!(matches!(
+            classify_documents(&mapping("allow-lan: false"), &mapping("allow-lan: true")).unwrap(),
+            ConfigChange::Patch { .. }
+        ));
+        assert!(matches!(
+            classify_documents(
+                &mapping("rules: [MATCH,DIRECT]"),
+                &mapping("rules: [MATCH,REJECT]")
+            )
+            .unwrap(),
+            ConfigChange::Reload
+        ));
+        for desired in [
+            "external-controller: 127.0.0.1:9091",
+            "secret: changed",
+            "dns: { listen: '127.0.0.1:1053' }",
+            "unknown-field: true",
+        ] {
+            assert!(matches!(
+                classify_documents(&Mapping::new(), &mapping(desired)).unwrap(),
+                ConfigChange::Switch
+            ));
+        }
+    }
+
+    #[test]
+    fn deletion_is_never_patch() {
+        assert!(matches!(
+            classify_documents(&mapping("allow-lan: true"), &Mapping::new()).unwrap(),
+            ConfigChange::Switch
+        ));
+    }
+
+    #[test]
+    fn controller_process_and_unsupported_core_changes_switch() {
+        let current = spec(CoreKind::Mihomo, "mihomo");
+        let mut changed_binary = current.clone();
+        changed_binary.core.binary_path = "other-mihomo".into();
+        assert!(matches!(
+            classify(
+                &mapping("external-controller: 127.0.0.1:9090"),
+                &Mapping::new(),
+                &current,
+                &mapping("external-controller: 127.0.0.1:9091"),
+                &Mapping::new(),
+                &current,
+            )
+            .unwrap(),
+            ConfigChange::Switch
+        ));
+        assert!(matches!(
+            classify(
+                &Mapping::new(),
+                &Mapping::new(),
+                &current,
+                &Mapping::new(),
+                &Mapping::new(),
+                &changed_binary,
+            )
+            .unwrap(),
+            ConfigChange::Switch
+        ));
+        assert!(matches!(
+            classify(
+                &Mapping::new(),
+                &Mapping::new(),
+                &current,
+                &Mapping::new(),
+                &Mapping::new(),
+                &spec(CoreKind::ClashRs, "clash-rs"),
+            )
+            .unwrap(),
+            ConfigChange::Switch
+        ));
+    }
+
+    #[test]
+    fn nonzero_ports_are_zeroable_but_other_inbounds_block_overlap() {
+        assert_eq!(overlap_block(&mapping("mixed-port: 7890")), None);
+        for yaml in [
+            "listeners: [{name: inbound}]",
+            "tunnels: [tcp/1.1.1.1:1]",
+            "dns: {listen: '127.0.0.1:1053'}",
+            "tcptun-config: inbound",
+            "new-listener: true",
+            "dns: {listen: 1053}",
+            "tun: {enable: yes}",
+        ] {
+            assert!(overlap_block(&mapping(yaml)).is_some(), "{yaml}");
+        }
+    }
+
+    #[test]
+    fn every_config_patch_field_has_a_runtime_projection() {
+        let desired = mapping(
+            r#"
+port: 1
+socks-port: 2
+redir-port: 3
+tproxy-port: 4
+mixed-port: 5
+tun:
+  enable: true
+  device: tun0
+  stack: system
+  dns-hijack: ['any:53']
+  auto-route: true
+  auto-detect-interface: true
+  mtu: 1400
+  gso: true
+  gso-max-size: 32000
+  inet6-address: ['fd00::1/126']
+  iproute2-table-index: 100
+  iproute2-rule-index: 10000
+  auto-redirect: true
+  auto-redirect-input-mark: 1
+  auto-redirect-output-mark: 2
+  auto-redirect-iproute2-fallback-rule-index: 3
+  loopback-address: ['127.0.0.1']
+  strict-route: true
+  route-address: ['10.0.0.0/8']
+  route-address-set: [private]
+  route-exclude-address: ['192.0.2.0/24']
+  route-exclude-address-set: [excluded]
+  include-interface: [Ethernet]
+  exclude-interface: [Loopback]
+  include-uid: [1000]
+  include-uid-range: ['1000:1001']
+  exclude-uid: [1002]
+  exclude-uid-range: ['1002:1003']
+  include-android-user: [0]
+  include-package: [app]
+  exclude-package: [blocked]
+  include-mac-address: ['00:11:22:33:44:55']
+  exclude-mac-address: ['00:11:22:33:44:66']
+  endpoint-independent-nat: true
+  udp-timeout: 30
+  icmp-timeout: 30
+  file-descriptor: 4
+  inet4-route-address: ['10.0.0.0/8']
+  inet6-route-address: ['fd00::/8']
+  inet4-route-exclude-address: ['192.0.2.0/24']
+  inet6-route-exclude-address: ['2001:db8::/32']
+  recvmsgx: true
+  sendmsgx: true
+tuic-server:
+  enable: true
+  listen: '127.0.0.1:443'
+  token: [token]
+  users: {user: pass}
+  certificate: cert
+  private-key: key
+  congestion-controller: bbr
+  max-idle-time: 10
+  authentication-timeout: 5
+  alpn: [h3]
+  max-udp-relay-packet-size: 1200
+  cwnd: 10
+  bbr-profile: default
+ss-config: ss
+vmess-config: vmess
+tcptun-config: tcp
+udptun-config: udp
+allow-lan: true
+skip-auth-prefixes: ['127.0.0.1/32']
+lan-allowed-ips: ['10.0.0.0/8']
+lan-disallowed-ips: ['192.0.2.0/24']
+bind-address: '*'
+mode: rule
+log-level: debug
+ipv6: true
+sniffing: true
+tcp-concurrent: true
+find-process-mode: strict
+interface-name: Ethernet
+"#,
+        );
+        let ConfigChange::Patch { patch, projection } =
+            classify_documents(&Mapping::new(), &desired).unwrap()
+        else {
+            panic!("complete expressible document must patch")
+        };
+        let Value::Mapping(patch_document) = serde_yaml_ng::to_value(&patch).unwrap() else {
+            unreachable!()
+        };
+        let roots: BTreeSet<&str> = patch_document.keys().filter_map(Value::as_str).collect();
+        assert_eq!(roots, PATCH_FIELDS.iter().copied().collect());
+
+        let mut runtime = mapping(
+            r#"
+port: 0
+socks-port: 0
+redir-port: 0
+tproxy-port: 0
+mixed-port: 0
+tun: {}
+tuic-server: {}
+ss-config: ''
+vmess-config: ''
+tcptun-config: null
+udptun-config: null
+authentication: null
+skip-auth-prefixes: null
+lan-allowed-ips: null
+lan-disallowed-ips: null
+allow-lan: false
+bind-address: '*'
+inbound-tfo: false
+inbound-mptcp: false
+mode: rule
+unified-delay: false
+log-level: info
+ipv6: false
+interface-name: ''
+routing-mark: 0
+geox-url: {}
+geo-auto-update: false
+geo-update-interval: 0
+geodata-mode: false
+geodata-loader: ''
+geosite-matcher: ''
+tcp-concurrent: false
+find-process-mode: off
+sniffing: false
+global-ua: ''
+etag-support: false
+keep-alive-idle: 0
+keep-alive-interval: 0
+disable-keep-alive: false
+"#,
+        );
+        merge(&mut runtime, &patch_document);
+        let runtime: clash_api::RuntimeConfig =
+            serde_yaml_ng::from_value(Value::Mapping(runtime)).unwrap();
+        assert!(projection.verify(&runtime).unwrap());
+        assert_eq!(
+            projection.expected.len(),
+            leaf_count(&Value::Mapping(patch_document))
+        );
+    }
+
+    fn merge(target: &mut Mapping, patch: &Mapping) {
+        for (key, value) in patch {
+            if let (Some(target), Some(patch)) = (
+                target.get_mut(key).and_then(Value::as_mapping_mut),
+                value.as_mapping(),
+            ) {
+                merge(target, patch);
+            } else {
+                target.insert(key.clone(), value.clone());
+            }
+        }
+    }
+
+    fn leaf_count(value: &Value) -> usize {
+        value
+            .as_mapping()
+            .filter(|mapping| !mapping.is_empty())
+            .map(|mapping| mapping.values().map(leaf_count).sum())
+            .unwrap_or(1)
+    }
+}

--- a/crates/nyanpasu-core-manager/src/error.rs
+++ b/crates/nyanpasu-core-manager/src/error.rs
@@ -25,6 +25,8 @@ pub enum Error {
     InvalidManagerOptions(String),
     #[error("unsafe runtime artifact: {0}")]
     UnsafeRuntimeArtifact(Utf8PathBuf),
+    #[error("runtime directory is already owned by another manager: {0}")]
+    RuntimeDirectoryOwned(Utf8PathBuf),
     #[error("core process death could not be confirmed: {0}")]
     StopUnconfirmed(String),
     #[error("config revision conflict: expected {expected}, actual {actual:?}")]

--- a/crates/nyanpasu-core-manager/src/error.rs
+++ b/crates/nyanpasu-core-manager/src/error.rs
@@ -1,6 +1,6 @@
 use camino::Utf8PathBuf;
 
-use crate::kind::CoreKind;
+use crate::{kind::CoreKind, state::RevisionId};
 
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
@@ -27,6 +27,15 @@ pub enum Error {
     UnsafeRuntimeArtifact(Utf8PathBuf),
     #[error("core process death could not be confirmed: {0}")]
     StopUnconfirmed(String),
+    #[error("config revision conflict: expected {expected}, actual {actual:?}")]
+    RevisionConflict {
+        expected: RevisionId,
+        actual: Option<RevisionId>,
+    },
+    #[error("config apply failed: {0}")]
+    ApplyFailed(String),
+    #[error("config apply failed ({apply}); rollback also failed ({rollback})")]
+    ApplyRollbackFailed { apply: String, rollback: String },
     #[error("core did not become healthy before the startup timeout; stderr tail:\n{stderr_tail}")]
     StartupTimeout { stderr_tail: String },
     #[error("core failed to start; stderr tail:\n{stderr_tail}")]

--- a/crates/nyanpasu-core-manager/src/error.rs
+++ b/crates/nyanpasu-core-manager/src/error.rs
@@ -40,6 +40,12 @@ pub enum Error {
     ApplyFailed(String),
     #[error("config apply failed ({apply}); rollback also failed ({rollback})")]
     ApplyRollbackFailed { apply: String, rollback: String },
+    #[error("{source}; runtime durability warning: {warning}")]
+    DurabilityUncertain {
+        #[source]
+        source: Box<Error>,
+        warning: String,
+    },
     #[error("core did not become healthy before the startup timeout; stderr tail:\n{stderr_tail}")]
     StartupTimeout { stderr_tail: String },
     #[error("core failed to start; stderr tail:\n{stderr_tail}")]

--- a/crates/nyanpasu-core-manager/src/error.rs
+++ b/crates/nyanpasu-core-manager/src/error.rs
@@ -29,6 +29,8 @@ pub enum Error {
     RuntimeDirectoryOwned(Utf8PathBuf),
     #[error("core process death could not be confirmed: {0}")]
     StopUnconfirmed(String),
+    #[error("manager is quarantined by uncertain epoch {epoch}: {reason}")]
+    ManagerQuarantined { epoch: u64, reason: String },
     #[error("config revision conflict: expected {expected}, actual {actual:?}")]
     RevisionConflict {
         expected: RevisionId,

--- a/crates/nyanpasu-core-manager/src/error.rs
+++ b/crates/nyanpasu-core-manager/src/error.rs
@@ -19,6 +19,14 @@ pub enum Error {
     UnsupportedCore(CoreKind),
     #[error("config check failed: {0}")]
     ConfigCheckFailed(String),
+    #[error("invalid runtime config: {0}")]
+    InvalidConfig(String),
+    #[error("invalid manager options: {0}")]
+    InvalidManagerOptions(String),
+    #[error("unsafe runtime artifact: {0}")]
+    UnsafeRuntimeArtifact(Utf8PathBuf),
+    #[error("core process death could not be confirmed: {0}")]
+    StopUnconfirmed(String),
     #[error("core did not become healthy before the startup timeout; stderr tail:\n{stderr_tail}")]
     StartupTimeout { stderr_tail: String },
     #[error("core failed to start; stderr tail:\n{stderr_tail}")]

--- a/crates/nyanpasu-core-manager/src/health.rs
+++ b/crates/nyanpasu-core-manager/src/health.rs
@@ -4,11 +4,24 @@ use std::time::Duration;
 
 use crate::{error::Error, spec::ResolvedController};
 
-/// Builds a probe/control client: 1s per-request timeout so one hung request
-/// can never eat the whole startup deadline; retrying is the caller's loop.
-pub(crate) fn build_client(controller: &ResolvedController) -> Result<clash_api::Client, Error> {
+/// Builds a probe client with the fixed one-second health timeout.
+pub(crate) fn build_health_client(
+    controller: &ResolvedController,
+) -> Result<clash_api::Client, Error> {
     let mut builder = clash_api::Client::builder(controller.host.clone())
         .configure_reqwest(|b| b.timeout(Duration::from_secs(1)));
+    if let Some(secret) = &controller.secret {
+        builder = builder.secret(secret.as_str());
+    }
+    Ok(builder.build()?)
+}
+
+pub(crate) fn build_control_client(
+    controller: &ResolvedController,
+    timeout: Duration,
+) -> Result<clash_api::Client, Error> {
+    let mut builder = clash_api::Client::builder(controller.host.clone())
+        .configure_reqwest(|builder| builder.timeout(timeout));
     if let Some(secret) = &controller.secret {
         builder = builder.secret(secret.as_str());
     }
@@ -22,7 +35,7 @@ pub(crate) struct HealthCheck {
 impl HealthCheck {
     pub(crate) fn new(controller: &ResolvedController) -> Result<Self, Error> {
         Ok(Self {
-            client: build_client(controller)?,
+            client: build_health_client(controller)?,
         })
     }
 

--- a/crates/nyanpasu-core-manager/src/instance.rs
+++ b/crates/nyanpasu-core-manager/src/instance.rs
@@ -246,7 +246,13 @@ impl Instance {
         let runtime_dir = self.spec.config_path.parent().ok_or_else(|| {
             Error::StopUnconfirmed("runtime config has no parent directory".into())
         })?;
-        let reaped = reap_epoch_pid_file(pid_file.as_std_path(), runtime_dir.as_std_path()).await?;
+        let reaped = reap_epoch_pid_file(pid_file.as_std_path(), runtime_dir.as_std_path())
+            .await
+            .map_err(|error| {
+                Error::StopUnconfirmed(format!(
+                    "{stop_error}; epoch identity reaper failed: {error}"
+                ))
+            })?;
         if matches!(
             reaped,
             OrphanReapOutcome::AlreadyExited | OrphanReapOutcome::Killed

--- a/crates/nyanpasu-core-manager/src/instance.rs
+++ b/crates/nyanpasu-core-manager/src/instance.rs
@@ -206,7 +206,11 @@ impl Instance {
     /// record is the only authority used for the fallback kill.
     pub async fn stop_and_confirm_dead(self, timeout: std::time::Duration) -> Result<(), Error> {
         if self.state_rx.borrow().is_terminal() {
-            self.reap_epoch_record_if_present().await?;
+            self.reap_epoch_record_if_present().await.map_err(|error| {
+                Error::StopUnconfirmed(format!(
+                    "terminal instance identity verification failed: {error}"
+                ))
+            })?;
             return Ok(());
         }
         self.shared.user_stop.store(true, Ordering::SeqCst);

--- a/crates/nyanpasu-core-manager/src/instance.rs
+++ b/crates/nyanpasu-core-manager/src/instance.rs
@@ -9,7 +9,8 @@ use std::{
 };
 
 use nyanpasu_utils::process::{
-    Command, ProcessError, ProcessEvent, Supervisor, SupervisorEvent, TerminatedPayload,
+    Command, EpochPidFile, OrphanReapOutcome, ProcessError, ProcessEvent, ReadinessProbe,
+    Supervisor, SupervisorEvent, TerminatedPayload, reap_epoch_pid_file,
 };
 use tokio::{
     sync::{mpsc, watch},
@@ -92,10 +93,11 @@ impl Instance {
         let (event_tx, event_rx) = mpsc::unbounded_channel();
         let supervisor = Supervisor::builder({
             let spec = spec.clone();
-            move || build_command(&spec)
+            move || build_command(&spec, epoch)
         })
         .restart_policy(spec.options.restart_policy)
         .backoff(spec.options.backoff)
+        .readiness(ReadinessProbe::Acknowledged)
         .cancel_token(cancel.clone())
         .on_event(move |event| {
             let _ = event_tx.send(event);
@@ -192,24 +194,84 @@ impl Instance {
         }
     }
 
-    /// Stops the core (graceful, then tree kill) and waits until the terminal
-    /// state is published.
+    /// Compatibility wrapper for callers that do not provide a manager stop
+    /// deadline.
     pub async fn stop(self) -> Result<(), Error> {
+        self.stop_and_confirm_dead(std::time::Duration::from_secs(10))
+            .await
+    }
+
+    /// Stops supervision and proves the epoch process is dead before returning.
+    /// If normal supervisor termination is uncertain, the structured epoch pid
+    /// record is the only authority used for the fallback kill.
+    pub async fn stop_and_confirm_dead(self, timeout: std::time::Duration) -> Result<(), Error> {
         if self.state_rx.borrow().is_terminal() {
+            self.reap_epoch_record_if_present().await?;
             return Ok(());
         }
         self.shared.user_stop.store(true, Ordering::SeqCst);
         self.shared.publish(InstanceState::Stopping);
         let supervisor = self.shared.supervisor.lock().await.take();
-        if let Some(supervisor) = supervisor {
-            match supervisor.stop().await {
-                Ok(()) | Err(ProcessError::AlreadyExited) => {}
-                Err(error) => return Err(Error::Process(error)),
+        let stop_result = match supervisor {
+            Some(supervisor) => match tokio::time::timeout(timeout, supervisor.stop()).await {
+                Ok(Ok(())) | Ok(Err(ProcessError::AlreadyExited)) => Ok(()),
+                Ok(Err(error)) => Err(format!("supervisor stop failed: {error}")),
+                Err(_) => Err(format!("supervisor stop exceeded {timeout:?}")),
+            },
+            None => Ok(()),
+        };
+
+        let mut monitor_confirmed = false;
+        if let Some(mut monitor) = self.shared.monitor.lock().await.take() {
+            match tokio::time::timeout(timeout, &mut monitor).await {
+                Ok(_) => monitor_confirmed = true,
+                Err(_) => {
+                    monitor.abort();
+                    let _ = monitor.await;
+                }
             }
         }
-        if let Some(monitor) = self.shared.monitor.lock().await.take() {
-            let _ = monitor.await;
+        let terminal = self.state_rx.borrow().is_terminal();
+        if stop_result.is_ok() && (monitor_confirmed || terminal) {
+            self.reap_epoch_record_if_present().await?;
+            return Ok(());
         }
+        let stop_error = stop_result
+            .err()
+            .unwrap_or_else(|| "instance monitor did not confirm termination".to_owned());
+
+        let Some(pid_file) = epoch_pid_path(&self.spec, self.epoch) else {
+            return Err(Error::StopUnconfirmed(stop_error));
+        };
+        let runtime_dir = self.spec.config_path.parent().ok_or_else(|| {
+            Error::StopUnconfirmed("runtime config has no parent directory".into())
+        })?;
+        let reaped = reap_epoch_pid_file(pid_file.as_std_path(), runtime_dir.as_std_path()).await?;
+        if matches!(
+            reaped,
+            OrphanReapOutcome::AlreadyExited | OrphanReapOutcome::Killed
+        ) || (matches!(reaped, OrphanReapOutcome::NotFound) && terminal)
+        {
+            if !terminal {
+                self.shared
+                    .publish(InstanceState::Stopped(StopReason::User));
+            }
+            return Ok(());
+        }
+        Err(Error::StopUnconfirmed(stop_error))
+    }
+
+    async fn reap_epoch_record_if_present(&self) -> Result<(), Error> {
+        let Some(pid_file) = epoch_pid_path(&self.spec, self.epoch) else {
+            return Ok(());
+        };
+        if !tokio::fs::try_exists(pid_file).await? {
+            return Ok(());
+        }
+        let runtime_dir = self.spec.config_path.parent().ok_or_else(|| {
+            Error::StopUnconfirmed("runtime config has no parent directory".into())
+        })?;
+        let _ = reap_epoch_pid_file(pid_file.as_std_path(), runtime_dir.as_std_path()).await?;
         Ok(())
     }
 }
@@ -223,7 +285,7 @@ impl Drop for Instance {
     }
 }
 
-fn build_command(spec: &InstanceSpec) -> Command {
+fn build_command(spec: &InstanceSpec, epoch: u64) -> Command {
     let args = spec
         .core
         .kind
@@ -241,9 +303,27 @@ fn build_command(spec: &InstanceSpec) -> Command {
         )
         .current_dir(spec.working_dir.as_str());
     if let Some(pid_file) = &spec.pid_file {
-        command = command.pid_file(pid_file.as_str());
+        command = if epoch_pid_path(spec, epoch).is_some() {
+            command.epoch_pid_file(EpochPidFile::new(
+                pid_file.as_std_path(),
+                epoch,
+                spec.config_path.as_std_path(),
+            ))
+        } else {
+            command.pid_file(pid_file.as_std_path())
+        };
     }
     command
+}
+
+fn epoch_pid_path(spec: &InstanceSpec, epoch: u64) -> Option<&camino::Utf8Path> {
+    let pid_file = spec.pid_file.as_deref()?;
+    let expected_pid = format!("core-{epoch}.pid");
+    let expected_config = format!("config-{epoch}.yaml");
+    (pid_file.file_name() == Some(expected_pid.as_str())
+        && spec.config_path.file_name() == Some(expected_config.as_str())
+        && pid_file.parent() == spec.config_path.parent())
+    .then_some(pid_file)
 }
 
 struct Probe {
@@ -316,8 +396,16 @@ async fn monitor_loop(
                 let deadline = probe.as_ref().expect("guarded").deadline;
                 if health.probe_once().await {
                     let pid = probe.take().expect("guarded").pid;
-                    ever_ready = true;
-                    shared.publish(InstanceState::Running { pid });
+                    let supervisor = shared.supervisor.lock().await;
+                    let acknowledged = match supervisor.as_ref() {
+                        Some(supervisor) => supervisor.acknowledge_ready(pid).await,
+                        None => false,
+                    };
+                    drop(supervisor);
+                    if acknowledged {
+                        ever_ready = true;
+                        shared.publish(InstanceState::Running { pid });
+                    }
                 } else if ever_ready && Instant::now() >= deadline {
                     // A post-crash respawn never became healthy again.
                     probe = None;

--- a/crates/nyanpasu-core-manager/src/instance.rs
+++ b/crates/nyanpasu-core-manager/src/instance.rs
@@ -237,7 +237,11 @@ impl Instance {
         }
         let terminal = self.state_rx.borrow().is_terminal();
         if stop_result.is_ok() && (monitor_confirmed || terminal) {
-            self.reap_epoch_record_if_present().await?;
+            self.reap_epoch_record_if_present().await.map_err(|error| {
+                Error::StopUnconfirmed(format!(
+                    "stopped instance identity verification failed: {error}"
+                ))
+            })?;
             return Ok(());
         }
         let stop_error = stop_result

--- a/crates/nyanpasu-core-manager/src/lib.rs
+++ b/crates/nyanpasu-core-manager/src/lib.rs
@@ -9,6 +9,7 @@ mod health;
 pub mod instance;
 pub mod kind;
 pub mod manager;
+pub mod runtime_store;
 pub mod spec;
 pub mod state;
 
@@ -17,7 +18,8 @@ pub use error::Error;
 pub use instance::Instance;
 pub use kind::CoreKind;
 pub use manager::{CoreManager, DegradeReason, SwitchOutcome};
+pub use runtime_store::{RuntimeConfigBackup, RuntimeConfigStore, StagedRuntimeConfig};
 pub use spec::{
     ControllerMode, CoreSpec, InstanceOptions, InstanceSpec, ManagerOptions, ResolvedController,
 };
-pub use state::{CoreState, CoreStatus, InstanceState, SpecSummary, StopReason};
+pub use state::{ConfigRevision, CoreState, CoreStatus, InstanceState, SpecSummary, StopReason};

--- a/crates/nyanpasu-core-manager/src/lib.rs
+++ b/crates/nyanpasu-core-manager/src/lib.rs
@@ -19,7 +19,10 @@ pub use error::Error;
 pub use instance::Instance;
 pub use kind::CoreKind;
 pub use manager::{ApplyOutcome, CoreManager, DegradeReason, SwitchOutcome};
-pub use runtime_store::{RuntimeConfigBackup, RuntimeConfigStore, StagedRuntimeConfig};
+pub use runtime_store::{
+    RuntimeCommitDurability, RuntimeConfigBackup, RuntimeConfigCommit, RuntimeConfigStore,
+    StagedRuntimeConfig,
+};
 pub use spec::{
     ControllerMode, CoreSpec, InstanceOptions, InstanceSpec, ManagerOptions, ResolvedController,
 };

--- a/crates/nyanpasu-core-manager/src/lib.rs
+++ b/crates/nyanpasu-core-manager/src/lib.rs
@@ -4,6 +4,7 @@
 //! Design: docs/superpowers/specs/2026-07-18-nyanpasu-core-manager-design.md
 
 mod config;
+mod config_diff;
 mod error;
 mod health;
 pub mod instance;
@@ -17,9 +18,11 @@ pub use clash_api::Host;
 pub use error::Error;
 pub use instance::Instance;
 pub use kind::CoreKind;
-pub use manager::{CoreManager, DegradeReason, SwitchOutcome};
+pub use manager::{ApplyOutcome, CoreManager, DegradeReason, SwitchOutcome};
 pub use runtime_store::{RuntimeConfigBackup, RuntimeConfigStore, StagedRuntimeConfig};
 pub use spec::{
     ControllerMode, CoreSpec, InstanceOptions, InstanceSpec, ManagerOptions, ResolvedController,
 };
-pub use state::{ConfigRevision, CoreState, CoreStatus, InstanceState, SpecSummary, StopReason};
+pub use state::{
+    ConfigRevision, CoreState, CoreStatus, InstanceState, RevisionId, SpecSummary, StopReason,
+};

--- a/crates/nyanpasu-core-manager/src/manager.rs
+++ b/crates/nyanpasu-core-manager/src/manager.rs
@@ -6,7 +6,7 @@ use std::sync::{
     atomic::{AtomicU64, Ordering},
 };
 
-use nyanpasu_utils::process::reap_epoch_pid_file;
+use nyanpasu_utils::process::{OrphanReapOutcome, reap_epoch_pid_file};
 use serde_yaml_ng::Mapping;
 use tokio::sync::watch;
 
@@ -58,6 +58,10 @@ pub enum ApplyOutcome {
         revision: ConfigRevision,
         failed_apply: String,
     },
+    DurabilityUncertain {
+        outcome: Box<ApplyOutcome>,
+        warning: String,
+    },
 }
 
 fn graceful_degrade_reason(
@@ -99,6 +103,13 @@ struct Inner {
 struct Ctrl {
     current: Option<Active>,
     last_spec: Option<InstanceSpec>,
+    quarantine: Vec<QuarantinedEpoch>,
+}
+
+#[derive(Debug, Clone)]
+struct QuarantinedEpoch {
+    epoch: u64,
+    reason: String,
 }
 
 struct Active {
@@ -198,14 +209,13 @@ impl CoreManager {
         };
         let store = RuntimeConfigStore::new(runtime_dir).await?;
         let runtime_lock = store.acquire_ownership().await?;
-        let max_epoch = sweep_orphans(&store).await?;
 
         if let ControllerMode::Managed {
             controller_template,
             ..
         } = &options.controller_mode
         {
-            config::validate_controller_template(controller_template.as_deref())?;
+            config::managed_endpoint_path(store.dir(), controller_template.as_deref(), 0)?;
         }
         for (name, timeout) in [
             ("control_timeout", options.control_timeout),
@@ -218,6 +228,7 @@ impl CoreManager {
                 )));
             }
         }
+        let max_epoch = sweep_orphans(&store).await?;
         let (status_tx, _) = watch::channel(CoreStatus::initial());
         Ok(Self {
             inner: Arc::new(Inner {
@@ -245,6 +256,7 @@ impl CoreManager {
         expected_revision: Option<RevisionId>,
     ) -> Result<ApplyOutcome, Error> {
         let mut ctrl = self.inner.ctrl.lock().await;
+        reject_quarantine(&ctrl)?;
         let current = ctrl.current.as_ref().ok_or(Error::NotStarted)?;
         if current.instance.state().borrow().is_terminal() {
             return Err(Error::NotStarted);
@@ -297,15 +309,19 @@ impl CoreManager {
             effective_document,
             staged,
         } = prepared;
-        if let Err(error) = self
+        let commit = match self
             .inner
             .store
             .commit_replace(staged, revision.epoch)
             .await
         {
-            let _ = self.inner.store.remove_backup(backup).await;
-            return Err(error);
-        }
+            Ok(commit) => commit,
+            Err(error) => {
+                let _ = self.inner.store.remove_backup(backup).await;
+                return Err(error);
+            }
+        };
+        let durability_warning = commit.durability_warning().map(str::to_owned);
         let desired = PreparedLaunch {
             source_spec,
             effective_spec,
@@ -351,11 +367,13 @@ impl CoreManager {
             if let Err(error) = self.inner.store.remove_backup(backup).await {
                 tracing::warn!("failed to remove successful apply backup: {error}");
             }
-            return Ok(outcome);
+            return Ok(with_durability_warning(outcome, durability_warning));
         }
 
-        self.restart_with_compensation(&mut ctrl, desired, backup)
-            .await
+        let result = self
+            .restart_with_compensation(&mut ctrl, desired, backup)
+            .await;
+        with_durability_result(result, durability_warning)
     }
 
     async fn prepare_apply(
@@ -516,13 +534,22 @@ impl CoreManager {
             .await
         {
             if matches!(error, Error::StopUnconfirmed(_)) {
-                self.publish_terminal_error(&error);
-                return Err(error);
+                return Err(self.latch_quarantine(ctrl, old_revision.epoch, error));
             }
             let message = format!("failed to stop current epoch for reconcile: {error}");
             self.publish_terminal_error(&Error::ApplyFailed(message.clone()));
             return Err(Error::ApplyFailed(message));
         }
+
+        self.inner.publish(
+            CoreState::Restarting {
+                epoch: desired.revision.epoch,
+                attempt: 0,
+            },
+            Some(spec_summary(&desired.source_spec)),
+            Some(desired.controller.host.clone()),
+            Some(desired.revision.clone()),
+        );
 
         match self
             .spawn_replacement(
@@ -535,8 +562,7 @@ impl CoreManager {
             Ok(instance) => {
                 let revision = desired.revision.clone();
                 let pid = instance.pid().unwrap_or_default();
-                let forwarder =
-                    spawn_forwarder(self.inner.clone(), instance.state(), revision.epoch);
+                let forwarder = spawn_forwarder(&self.inner, instance.state(), revision.epoch);
                 ctrl.last_spec = Some(desired.source_spec.clone());
                 ctrl.current = Some(Active {
                     instance,
@@ -560,30 +586,39 @@ impl CoreManager {
                 Ok(ApplyOutcome::Restarted { revision })
             }
             Err(error @ Error::StopUnconfirmed(_)) => {
-                self.publish_terminal_error(&error);
-                Err(error)
+                Err(self.latch_quarantine(ctrl, desired.revision.epoch, error))
             }
             Err(apply_error) => {
                 let apply_text = apply_error.to_string();
-                if let Err(restore_error) = self.inner.store.restore(&backup).await {
-                    let error = Error::ApplyRollbackFailed {
-                        apply: apply_text,
-                        rollback: format!("runtime restore failed: {restore_error}"),
-                    };
-                    self.publish_terminal_error(&error);
-                    return Err(error);
-                }
-                match self
+                let restore = match self.inner.store.restore(&backup).await {
+                    Ok(restore) => restore,
+                    Err(restore_error) => {
+                        let error = Error::ApplyRollbackFailed {
+                            apply: apply_text,
+                            rollback: format!("runtime restore failed: {restore_error}"),
+                        };
+                        self.publish_terminal_error(&error);
+                        return Err(error);
+                    }
+                };
+                let restore_warning = restore.durability_warning().map(str::to_owned);
+                self.inner.publish(
+                    CoreState::Restarting {
+                        epoch: old_revision.epoch,
+                        attempt: 0,
+                    },
+                    Some(spec_summary(&old_source_spec)),
+                    Some(old_controller.host.clone()),
+                    Some(old_revision.clone()),
+                );
+                let rollback = match self
                     .spawn_replacement(old_effective_spec, old_revision.epoch, old_controller)
                     .await
                 {
                     Ok(instance) => {
                         let pid = instance.pid().unwrap_or_default();
-                        let forwarder = spawn_forwarder(
-                            self.inner.clone(),
-                            instance.state(),
-                            old_revision.epoch,
-                        );
+                        let forwarder =
+                            spawn_forwarder(&self.inner, instance.state(), old_revision.epoch);
                         ctrl.last_spec = Some(old_source_spec.clone());
                         ctrl.current = Some(Active {
                             instance,
@@ -613,8 +648,7 @@ impl CoreManager {
                         let error = Error::StopUnconfirmed(format!(
                             "desired apply failed ({apply_text}); rollback replacement {rollback_error}"
                         ));
-                        self.publish_terminal_error(&error);
-                        Err(error)
+                        Err(self.latch_quarantine(ctrl, old_revision.epoch, error))
                     }
                     Err(rollback_error) => {
                         let error = Error::ApplyRollbackFailed {
@@ -624,7 +658,8 @@ impl CoreManager {
                         self.publish_terminal_error(&error);
                         Err(error)
                     }
-                }
+                };
+                with_durability_result(rollback, restore_warning)
             }
         }
     }
@@ -653,13 +688,22 @@ impl CoreManager {
         {
             let _ = self.inner.store.cleanup_epoch(epoch).await;
             if matches!(error, Error::StopUnconfirmed(_)) {
-                self.publish_terminal_error(&error);
-                return Err(error);
+                return Err(self.latch_quarantine(ctrl, old_epoch, error));
             }
             let message = format!("failed to stop current epoch for switch: {error}");
             self.publish_terminal_error(&Error::ApplyFailed(message.clone()));
             return Err(Error::ApplyFailed(message));
         }
+
+        self.inner.publish(
+            CoreState::Switching {
+                from: Some(old_epoch),
+                to: desired.revision.epoch,
+            },
+            Some(spec_summary(&desired.source_spec)),
+            Some(desired.controller.host.clone()),
+            Some(desired.revision.clone()),
+        );
 
         match self
             .spawn_replacement(
@@ -672,8 +716,7 @@ impl CoreManager {
             Ok(instance) => {
                 let revision = desired.revision.clone();
                 let pid = instance.pid().unwrap_or_default();
-                let forwarder =
-                    spawn_forwarder(self.inner.clone(), instance.state(), revision.epoch);
+                let forwarder = spawn_forwarder(&self.inner, instance.state(), revision.epoch);
                 ctrl.last_spec = Some(desired.source_spec.clone());
                 ctrl.current = Some(Active {
                     instance,
@@ -697,25 +740,30 @@ impl CoreManager {
                 Ok(ApplyOutcome::Restarted { revision })
             }
             Err(error @ Error::StopUnconfirmed(_)) => {
-                self.publish_terminal_error(&error);
-                Err(error)
+                Err(self.latch_quarantine(ctrl, desired.revision.epoch, error))
             }
             Err(apply_error) => {
                 let apply_text = apply_error.to_string();
                 if let Err(error) = self.inner.store.cleanup_epoch(epoch).await {
                     tracing::warn!("failed to clean rejected desired epoch: {error}");
                 }
+                self.inner.publish(
+                    CoreState::Restarting {
+                        epoch: old_revision.epoch,
+                        attempt: 0,
+                    },
+                    Some(spec_summary(&old_source_spec)),
+                    Some(old_controller.host.clone()),
+                    Some(old_revision.clone()),
+                );
                 match self
                     .spawn_replacement(old_effective_spec, old_revision.epoch, old_controller)
                     .await
                 {
                     Ok(instance) => {
                         let pid = instance.pid().unwrap_or_default();
-                        let forwarder = spawn_forwarder(
-                            self.inner.clone(),
-                            instance.state(),
-                            old_revision.epoch,
-                        );
+                        let forwarder =
+                            spawn_forwarder(&self.inner, instance.state(), old_revision.epoch);
                         ctrl.last_spec = Some(old_source_spec.clone());
                         ctrl.current = Some(Active {
                             instance,
@@ -742,8 +790,7 @@ impl CoreManager {
                         let error = Error::StopUnconfirmed(format!(
                             "desired switch failed ({apply_text}); rollback replacement {rollback_error}"
                         ));
-                        self.publish_terminal_error(&error);
-                        Err(error)
+                        Err(self.latch_quarantine(ctrl, old_revision.epoch, error))
                     }
                     Err(rollback_error) => {
                         let error = Error::ApplyRollbackFailed {
@@ -900,6 +947,7 @@ impl CoreManager {
 
     pub async fn start(&self, spec: InstanceSpec) -> Result<(), Error> {
         let mut ctrl = self.inner.ctrl.lock().await;
+        reject_quarantine(&ctrl)?;
         let running = ctrl
             .current
             .as_ref()
@@ -910,10 +958,16 @@ impl CoreManager {
         if let Some(stale) = ctrl.current.take() {
             abort_and_await(stale.forwarder).await;
             let epoch = stale.instance.epoch();
-            stale
+            if let Err(error) = stale
                 .instance
                 .stop_and_confirm_dead(self.inner.options.stop_timeout)
-                .await?;
+                .await
+            {
+                if matches!(error, Error::StopUnconfirmed(_)) {
+                    return Err(self.latch_quarantine(&mut ctrl, epoch, error));
+                }
+                return Err(error);
+            }
             self.inner.store.cleanup_epoch(epoch).await?;
         }
         self.start_locked(&mut ctrl, spec).await
@@ -963,15 +1017,23 @@ impl CoreManager {
             }
         };
 
-        if let Err(error) = instance.wait_ready().await {
-            let stopped = instance
+        if let Err(readiness_error) = instance.wait_ready().await {
+            match instance
                 .stop_and_confirm_dead(self.inner.options.stop_timeout)
-                .await;
-            if stopped.is_ok() {
-                let _ = self.inner.store.cleanup_epoch(epoch).await;
+                .await
+            {
+                Ok(()) => {
+                    let _ = self.inner.store.cleanup_epoch(epoch).await;
+                    self.publish_terminal_error(&readiness_error);
+                    return Err(readiness_error);
+                }
+                Err(stop_error) => {
+                    let error = Error::StopUnconfirmed(format!(
+                        "{readiness_error}; failed to stop rejected initial instance: {stop_error}"
+                    ));
+                    return Err(self.latch_quarantine(ctrl, epoch, error));
+                }
             }
-            self.publish_terminal_error(&error);
-            return Err(error);
         }
 
         let pid = instance.pid().unwrap_or_default();
@@ -981,7 +1043,7 @@ impl CoreManager {
             Some(instance.controller().host.clone()),
             Some(prepared.revision.clone()),
         );
-        let forwarder = spawn_forwarder(self.inner.clone(), instance.state(), epoch);
+        let forwarder = spawn_forwarder(&self.inner, instance.state(), epoch);
         ctrl.last_spec = Some(prepared.source_spec.clone());
         ctrl.current = Some(Active {
             instance,
@@ -1005,14 +1067,64 @@ impl CoreManager {
         );
     }
 
+    fn latch_quarantine(&self, ctrl: &mut Ctrl, epoch: u64, error: Error) -> Error {
+        record_quarantine(ctrl, epoch, error.to_string());
+        let quarantine = quarantine_error(ctrl).expect("quarantine was just inserted");
+        self.publish_terminal_error(&quarantine);
+        error
+    }
+
+    /// Attempts identity-verified recovery of every uncertain epoch. Manager
+    /// operations remain rejected until every quarantined process is proven
+    /// dead and its artifacts are cleaned.
+    pub async fn recover_quarantine(&self) -> Result<(), Error> {
+        let mut ctrl = self.inner.ctrl.lock().await;
+        if ctrl.quarantine.is_empty() {
+            return Ok(());
+        }
+        let quarantined = ctrl.quarantine.clone();
+        for entry in quarantined {
+            let pid_path = self.inner.store.pid_path(entry.epoch);
+            match reap_epoch_pid_file(pid_path.as_std_path(), self.inner.store.dir().as_std_path())
+                .await
+            {
+                Ok(OrphanReapOutcome::AlreadyExited | OrphanReapOutcome::Killed) => {
+                    self.inner.store.cleanup_epoch(entry.epoch).await?;
+                    ctrl.quarantine
+                        .retain(|quarantine| quarantine.epoch != entry.epoch);
+                }
+                Ok(OrphanReapOutcome::NotFound) => {
+                    return Err(Error::ManagerQuarantined {
+                        epoch: entry.epoch,
+                        reason: format!(
+                            "{}; authoritative epoch pid record is unavailable",
+                            entry.reason
+                        ),
+                    });
+                }
+                Err(error) => {
+                    return Err(Error::ManagerQuarantined {
+                        epoch: entry.epoch,
+                        reason: format!("{}; recovery failed: {error}", entry.reason),
+                    });
+                }
+            }
+        }
+        self.inner
+            .publish(CoreState::Stopped { reason: None }, None, None, None);
+        Ok(())
+    }
+
     pub async fn restart(&self) -> Result<SwitchOutcome, Error> {
         let mut ctrl = self.inner.ctrl.lock().await;
+        reject_quarantine(&ctrl)?;
         let spec = ctrl.last_spec.clone().ok_or(Error::NotStarted)?;
         self.switch_locked(&mut ctrl, spec).await
     }
 
     pub async fn switch(&self, spec: InstanceSpec) -> Result<SwitchOutcome, Error> {
         let mut ctrl = self.inner.ctrl.lock().await;
+        reject_quarantine(&ctrl)?;
         self.switch_locked(&mut ctrl, spec).await
     }
 
@@ -1029,10 +1141,16 @@ impl CoreManager {
             if let Some(stale) = ctrl.current.take() {
                 abort_and_await(stale.forwarder).await;
                 let epoch = stale.instance.epoch();
-                stale
+                if let Err(error) = stale
                     .instance
                     .stop_and_confirm_dead(self.inner.options.stop_timeout)
-                    .await?;
+                    .await
+                {
+                    if matches!(error, Error::StopUnconfirmed(_)) {
+                        return Err(self.latch_quarantine(ctrl, epoch, error));
+                    }
+                    return Err(error);
+                }
                 self.inner.store.cleanup_epoch(epoch).await?;
             }
             self.start_locked(ctrl, spec).await?;
@@ -1094,6 +1212,9 @@ impl CoreManager {
             .await
         {
             let _ = self.inner.store.cleanup_epoch(epoch).await;
+            if matches!(error, Error::StopUnconfirmed(_)) {
+                return Err(self.latch_quarantine(ctrl, old_epoch, error));
+            }
             self.publish_terminal_error(&error);
             return Err(error);
         }
@@ -1121,7 +1242,7 @@ impl CoreManager {
             Some(instance.controller().host.clone()),
             Some(prepared.revision.clone()),
         );
-        let forwarder = spawn_forwarder(self.inner.clone(), instance.state(), epoch);
+        let forwarder = spawn_forwarder(&self.inner, instance.state(), epoch);
         ctrl.last_spec = Some(prepared.source_spec.clone());
         ctrl.current = Some(Active {
             instance,
@@ -1195,8 +1316,7 @@ impl CoreManager {
                     let error = Error::StopUnconfirmed(format!(
                         "{error}; failed to stop rejected graceful bootstrap: {stop_error}"
                     ));
-                    self.publish_terminal_error(&error);
-                    return Err(error);
+                    return Err(self.latch_quarantine(ctrl, epoch, error));
                 }
             }
         }
@@ -1210,37 +1330,56 @@ impl CoreManager {
             .await
         {
             drop(full_staged);
+            let old_uncertain = matches!(error, Error::StopUnconfirmed(_));
+            let old_reason = error.to_string();
             let new_stop = instance
                 .stop_and_confirm_dead(self.inner.options.stop_timeout)
                 .await;
-            if new_stop.is_ok() {
-                let _ = self.inner.store.cleanup_epoch(epoch).await;
+            match new_stop {
+                Ok(()) => {
+                    let _ = self.inner.store.cleanup_epoch(epoch).await;
+                    if old_uncertain {
+                        return Err(self.latch_quarantine(ctrl, old_epoch, error));
+                    }
+                    self.publish_terminal_error(&error);
+                    return Err(error);
+                }
+                Err(new_error) => {
+                    if old_uncertain {
+                        record_quarantine(ctrl, old_epoch, old_reason);
+                    }
+                    let error = Error::StopUnconfirmed(format!(
+                        "old epoch stop failed: {error}; new bootstrap stop also failed: {new_error}"
+                    ));
+                    return Err(self.latch_quarantine(ctrl, epoch, error));
+                }
             }
-            let error = match new_stop {
-                Ok(()) => error,
-                Err(new_error) => Error::StopUnconfirmed(format!(
-                    "old epoch stop failed: {error}; new bootstrap stop also failed: {new_error}"
-                )),
-            };
-            self.publish_terminal_error(&error);
-            return Err(error);
         }
 
-        if let Err(error) = self.inner.store.commit_replace(full_staged, epoch).await {
-            let new_stop = instance
-                .stop_and_confirm_dead(self.inner.options.stop_timeout)
-                .await;
-            if new_stop.is_ok() {
-                let _ = self.inner.store.cleanup_epoch(epoch).await;
+        let commit = match self.inner.store.commit_replace(full_staged, epoch).await {
+            Ok(commit) => commit,
+            Err(error) => {
+                let new_stop = instance
+                    .stop_and_confirm_dead(self.inner.options.stop_timeout)
+                    .await;
+                if new_stop.is_ok() {
+                    let _ = self.inner.store.cleanup_epoch(epoch).await;
+                }
+                let error = match new_stop {
+                    Ok(()) => error,
+                    Err(new_error) => Error::StopUnconfirmed(format!(
+                        "full runtime commit failed: {error}; bootstrap stop also failed: {new_error}"
+                    )),
+                };
+                if matches!(error, Error::StopUnconfirmed(_)) {
+                    return Err(self.latch_quarantine(ctrl, epoch, error));
+                }
+                self.publish_terminal_error(&error);
+                return Err(error);
             }
-            let error = match new_stop {
-                Ok(()) => error,
-                Err(new_error) => Error::StopUnconfirmed(format!(
-                    "full runtime commit failed: {error}; bootstrap stop also failed: {new_error}"
-                )),
-            };
-            self.publish_terminal_error(&error);
-            return Err(error);
+        };
+        if let Some(warning) = commit.durability_warning() {
+            tracing::warn!("graceful runtime replacement durability is uncertain: {warning}");
         }
 
         let reconciled = tokio::time::timeout(self.inner.options.reconcile_timeout, async {
@@ -1266,6 +1405,9 @@ impl CoreManager {
             .stop_and_confirm_dead(self.inner.options.stop_timeout)
             .await
         {
+            if matches!(error, Error::StopUnconfirmed(_)) {
+                return Err(self.latch_quarantine(ctrl, epoch, error));
+            }
             self.publish_terminal_error(&error);
             return Err(error);
         }
@@ -1275,8 +1417,7 @@ impl CoreManager {
         {
             Ok(replacement) => replacement,
             Err(error @ Error::StopUnconfirmed(_)) => {
-                self.publish_terminal_error(&error);
-                return Err(error);
+                return Err(self.latch_quarantine(ctrl, epoch, error));
             }
             Err(error) => {
                 let _ = self.inner.store.cleanup_epoch(epoch).await;
@@ -1313,9 +1454,15 @@ impl CoreManager {
                 Some(instance.controller().host.clone()),
                 Some(revision),
             );
-            instance
+            if let Err(error) = instance
                 .stop_and_confirm_dead(self.inner.options.stop_timeout)
-                .await?;
+                .await
+            {
+                if matches!(error, Error::StopUnconfirmed(_)) {
+                    return Err(self.latch_quarantine(&mut ctrl, epoch, error));
+                }
+                return Err(error);
+            }
             if let Err(error) = self.inner.store.cleanup_epoch(epoch).await {
                 self.publish_terminal_error(&error);
                 return Err(error);
@@ -1333,6 +1480,9 @@ impl CoreManager {
             .stop_and_confirm_dead(self.inner.options.stop_timeout)
             .await
         {
+            if matches!(error, Error::StopUnconfirmed(_)) {
+                return Err(self.latch_quarantine(&mut ctrl, epoch, error));
+            }
             self.publish_terminal_error(&error);
             return Err(error);
         }
@@ -1377,6 +1527,9 @@ impl CoreManager {
                 .stop_and_confirm_dead(self.inner.options.stop_timeout)
                 .await
             {
+                if matches!(error, Error::StopUnconfirmed(_)) {
+                    return Err(self.latch_quarantine(&mut ctrl, epoch, error));
+                }
                 self.publish_terminal_error(&error);
                 return Err(error);
             }
@@ -1394,6 +1547,44 @@ impl CoreManager {
             );
         }
         Ok(())
+    }
+}
+
+fn quarantine_error(ctrl: &Ctrl) -> Option<Error> {
+    let first = ctrl.quarantine.first()?;
+    let reason = if ctrl.quarantine.len() == 1 {
+        first.reason.clone()
+    } else {
+        let epochs = ctrl
+            .quarantine
+            .iter()
+            .map(|entry| entry.epoch.to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!("{}; additional uncertain epochs: {epochs}", first.reason)
+    };
+    Some(Error::ManagerQuarantined {
+        epoch: first.epoch,
+        reason,
+    })
+}
+
+fn record_quarantine(ctrl: &mut Ctrl, epoch: u64, reason: String) {
+    if let Some(existing) = ctrl
+        .quarantine
+        .iter_mut()
+        .find(|quarantine| quarantine.epoch == epoch)
+    {
+        existing.reason = reason;
+    } else {
+        ctrl.quarantine.push(QuarantinedEpoch { epoch, reason });
+    }
+}
+
+fn reject_quarantine(ctrl: &Ctrl) -> Result<(), Error> {
+    match quarantine_error(ctrl) {
+        Some(error) => Err(error),
+        None => Ok(()),
     }
 }
 
@@ -1431,20 +1622,50 @@ fn instance_core_state(epoch: u64, state: &InstanceState) -> CoreState {
 }
 
 fn spawn_forwarder(
-    inner: Arc<Inner>,
+    inner: &Arc<Inner>,
     mut state_rx: watch::Receiver<InstanceState>,
     epoch: u64,
 ) -> tokio::task::JoinHandle<()> {
+    let inner = Arc::downgrade(inner);
     tokio::spawn(async move {
         while state_rx.changed().await.is_ok() {
             let state = state_rx.borrow_and_update().clone();
             let terminal = state.is_terminal();
+            let Some(inner) = inner.upgrade() else {
+                break;
+            };
             inner.publish_epoch_state(epoch, instance_core_state(epoch, &state));
             if terminal {
                 break;
             }
         }
     })
+}
+
+fn with_durability_warning(outcome: ApplyOutcome, warning: Option<String>) -> ApplyOutcome {
+    match warning {
+        Some(warning) => ApplyOutcome::DurabilityUncertain {
+            outcome: Box::new(outcome),
+            warning,
+        },
+        None => outcome,
+    }
+}
+
+fn with_durability_result(
+    result: Result<ApplyOutcome, Error>,
+    warning: Option<String>,
+) -> Result<ApplyOutcome, Error> {
+    match (result, warning) {
+        (Ok(outcome), warning) => Ok(with_durability_warning(outcome, warning)),
+        (Err(Error::StopUnconfirmed(message)), Some(warning)) => Err(Error::StopUnconfirmed(
+            format!("{message}; runtime durability warning: {warning}"),
+        )),
+        (Err(error), Some(warning)) => Err(Error::ApplyFailed(format!(
+            "{error}; runtime durability warning: {warning}"
+        ))),
+        (Err(error), None) => Err(error),
+    }
 }
 
 #[cfg(test)]

--- a/crates/nyanpasu-core-manager/src/manager.rs
+++ b/crates/nyanpasu-core-manager/src/manager.rs
@@ -10,17 +10,20 @@ use std::{
 };
 
 use nyanpasu_utils::process::reap_epoch_pid_file;
+use serde_yaml_ng::Mapping;
 use tokio::sync::watch;
 
 use crate::{
     config::{self, ConfigSnapshot, DeriveMode},
+    config_diff::{self, ConfigChange, OverlapBlock},
     error::Error,
     instance::Instance,
     kind::CoreKind,
-    runtime_store::RuntimeConfigStore,
+    runtime_store::{RuntimeConfigStore, StagedRuntimeConfig},
     spec::{ControllerMode, InstanceSpec, ManagerOptions, ResolvedController},
     state::{
-        ConfigRevision, CoreState, CoreStatus, InstanceState, SpecSummary, StopReason, now_ms,
+        ConfigRevision, CoreState, CoreStatus, InstanceState, RevisionId, SpecSummary, StopReason,
+        now_ms,
     },
 };
 
@@ -30,6 +33,7 @@ pub enum DegradeReason {
     PassthroughMode,
     UnsupportedKind,
     DnsListen,
+    InboundConflict,
     PatchFailed,
 }
 
@@ -39,15 +43,42 @@ pub enum SwitchOutcome {
     Hard { reason: DegradeReason },
 }
 
-fn decide(managed: bool, kind: CoreKind, has_dns_listen: bool) -> Option<DegradeReason> {
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ApplyOutcome {
+    Noop {
+        revision: ConfigRevision,
+    },
+    Patched {
+        revision: ConfigRevision,
+    },
+    Reloaded {
+        revision: ConfigRevision,
+    },
+    Restarted {
+        revision: ConfigRevision,
+    },
+    RolledBack {
+        revision: ConfigRevision,
+        failed_apply: String,
+    },
+}
+
+fn decide(
+    managed: bool,
+    kind: CoreKind,
+    overlap_block: Option<OverlapBlock>,
+) -> Option<DegradeReason> {
     if !managed {
         return Some(DegradeReason::PassthroughMode);
     }
     if !matches!(kind, CoreKind::Mihomo) {
         return Some(DegradeReason::UnsupportedKind);
     }
-    if has_dns_listen {
-        return Some(DegradeReason::DnsListen);
+    if let Some(block) = overlap_block {
+        return Some(match block {
+            OverlapBlock::DnsListen => DegradeReason::DnsListen,
+            OverlapBlock::InboundSurface => DegradeReason::InboundConflict,
+        });
     }
     None
 }
@@ -75,6 +106,8 @@ struct Active {
     forwarder: tokio::task::JoinHandle<()>,
     source_spec: InstanceSpec,
     revision: ConfigRevision,
+    source_document: Mapping,
+    effective_document: Mapping,
 }
 
 struct PreparedLaunch {
@@ -83,6 +116,18 @@ struct PreparedLaunch {
     controller: ResolvedController,
     revision: ConfigRevision,
     restore: config::RestorePlan,
+    source_document: Mapping,
+    effective_document: Mapping,
+}
+
+struct PreparedApply {
+    source_spec: InstanceSpec,
+    effective_spec: InstanceSpec,
+    controller: ResolvedController,
+    revision: ConfigRevision,
+    source_document: Mapping,
+    effective_document: Mapping,
+    staged: StagedRuntimeConfig,
 }
 
 impl Inner {
@@ -187,6 +232,493 @@ impl CoreManager {
         self.inner.status_tx.borrow().clone()
     }
 
+    pub async fn apply_config(
+        &self,
+        input: InstanceSpec,
+        expected_revision: Option<RevisionId>,
+    ) -> Result<ApplyOutcome, Error> {
+        let mut ctrl = self.inner.ctrl.lock().await;
+        let current = ctrl.current.as_ref().ok_or(Error::NotStarted)?;
+        if current.instance.state().borrow().is_terminal() {
+            return Err(Error::NotStarted);
+        }
+        let actual_revision = current.revision.id();
+        if let Some(expected) = expected_revision
+            && expected != actual_revision
+        {
+            return Err(Error::RevisionConflict {
+                expected,
+                actual: Some(actual_revision),
+            });
+        }
+
+        let snapshot = ConfigSnapshot::load(&input.config_path).await?;
+        let prepared = self
+            .prepare_apply(current, input.clone(), &snapshot)
+            .await?;
+        let change = config_diff::classify(
+            &current.source_document,
+            &current.effective_document,
+            &current.source_spec,
+            &prepared.source_document,
+            &prepared.effective_document,
+            &prepared.source_spec,
+        )?;
+        if matches!(change, ConfigChange::Noop) {
+            return Ok(ApplyOutcome::Noop {
+                revision: current.revision.clone(),
+            });
+        }
+        if matches!(change, ConfigChange::Switch) {
+            drop(prepared);
+            return self
+                .switch_with_compensation(&mut ctrl, input, snapshot)
+                .await;
+        }
+
+        let backup = self
+            .inner
+            .store
+            .backup(current.revision.epoch, prepared.revision.generation)
+            .await?;
+        let PreparedApply {
+            source_spec,
+            effective_spec,
+            controller,
+            revision,
+            source_document,
+            effective_document,
+            staged,
+        } = prepared;
+        if let Err(error) = self
+            .inner
+            .store
+            .commit_replace(staged, revision.epoch)
+            .await
+        {
+            let _ = self.inner.store.remove_backup(backup).await;
+            return Err(error);
+        }
+        let desired = PreparedLaunch {
+            source_spec,
+            effective_spec,
+            controller,
+            revision,
+            restore: config::RestorePlan::default(),
+            source_document,
+            effective_document,
+        };
+
+        let reconciled = tokio::time::timeout(
+            self.inner.options.reconcile_timeout,
+            self.reconcile_in_place(current, &change, &desired),
+        )
+        .await
+        .unwrap_or(false);
+        if reconciled {
+            let revision = desired.revision.clone();
+            let outcome = match change {
+                ConfigChange::Patch { .. } => ApplyOutcome::Patched {
+                    revision: revision.clone(),
+                },
+                ConfigChange::Reload => ApplyOutcome::Reloaded {
+                    revision: revision.clone(),
+                },
+                ConfigChange::Noop | ConfigChange::Switch => unreachable!(),
+            };
+            let source_spec = {
+                let active = ctrl.current.as_mut().expect("current held by control lock");
+                active.source_spec = desired.source_spec;
+                active.revision = desired.revision;
+                active.source_document = desired.source_document;
+                active.effective_document = desired.effective_document;
+                self.inner.publish_active(
+                    active,
+                    CoreState::Running {
+                        epoch: revision.epoch,
+                        pid: active.instance.pid().unwrap_or_default(),
+                    },
+                );
+                active.source_spec.clone()
+            };
+            ctrl.last_spec = Some(source_spec);
+            if let Err(error) = self.inner.store.remove_backup(backup).await {
+                tracing::warn!("failed to remove successful apply backup: {error}");
+            }
+            return Ok(outcome);
+        }
+
+        self.restart_with_compensation(&mut ctrl, desired, backup)
+            .await
+    }
+
+    async fn prepare_apply(
+        &self,
+        current: &Active,
+        input: InstanceSpec,
+        snapshot: &ConfigSnapshot,
+    ) -> Result<PreparedApply, Error> {
+        if tokio::fs::metadata(&input.core.binary_path).await.is_err() {
+            return Err(Error::BinaryNotFound(input.core.binary_path.clone()));
+        }
+        input
+            .core
+            .kind
+            .run_args(&input.working_dir, &input.config_path)?;
+        let epoch = current.revision.epoch;
+        let prepared = snapshot.prepare(
+            &self.inner.options.controller_mode,
+            self.inner.store.dir(),
+            epoch,
+            DeriveMode::ControllerOnly,
+        )?;
+        let staged = self.inner.store.stage(epoch, &prepared.bytes).await?;
+        let mut check_spec = input.clone();
+        check_spec.config_path = staged.path().to_owned();
+        crate::kind::check_config(&check_spec).await?;
+
+        let runtime_path = current.revision.runtime_path.clone();
+        let mut effective_spec = input.clone();
+        effective_spec.config_path = runtime_path.clone();
+        effective_spec.pid_file = Some(self.inner.store.pid_path(epoch));
+        Ok(PreparedApply {
+            source_spec: input,
+            effective_spec,
+            controller: prepared.controller,
+            revision: ConfigRevision {
+                epoch,
+                generation: current.revision.generation + 1,
+                source_hash: prepared.source_hash,
+                effective_hash: prepared.effective_hash,
+                runtime_path,
+            },
+            source_document: snapshot.document().clone(),
+            effective_document: prepared.document,
+            staged,
+        })
+    }
+
+    async fn reconcile_in_place(
+        &self,
+        current: &Active,
+        change: &ConfigChange,
+        desired: &PreparedLaunch,
+    ) -> bool {
+        let client = match crate::health::build_control_client(
+            current.instance.controller(),
+            self.inner.options.control_timeout,
+        ) {
+            Ok(client) => client,
+            Err(error) => {
+                tracing::warn!("failed to build config control client: {error}");
+                return false;
+            }
+        };
+        match change {
+            ConfigChange::Patch { patch, projection } => {
+                if let Err(error) = client.patch_config(patch).await {
+                    tracing::warn!("config PATCH returned an uncertain result: {error}");
+                }
+                match client.configs().await {
+                    Ok(runtime) => match projection.verify(&runtime) {
+                        Ok(true) => {}
+                        Ok(false) => return false,
+                        Err(error) => {
+                            tracing::warn!("failed to verify config projection: {error}");
+                            return false;
+                        }
+                    },
+                    Err(error) => {
+                        tracing::warn!("GET /configs verification failed: {error}");
+                        return false;
+                    }
+                }
+            }
+            ConfigChange::Reload => {
+                let request = clash_api::UpdateConfigRequest::from_path(
+                    desired.revision.runtime_path.to_string(),
+                );
+                if let Err(error) = client
+                    .update_config(&request, clash_api::UpdateConfigOptions { force: true })
+                    .await
+                {
+                    tracing::warn!("config PUT failed: {error}");
+                    return false;
+                }
+            }
+            ConfigChange::Switch => return false,
+            ConfigChange::Noop => return true,
+        }
+        match crate::health::HealthCheck::new(current.instance.controller()) {
+            Ok(health) => health.probe_once().await,
+            Err(error) => {
+                tracing::warn!("failed to build post-apply health probe: {error}");
+                false
+            }
+        }
+    }
+
+    async fn restart_with_compensation(
+        &self,
+        ctrl: &mut Ctrl,
+        desired: PreparedLaunch,
+        backup: crate::RuntimeConfigBackup,
+    ) -> Result<ApplyOutcome, Error> {
+        let old = ctrl.current.take().expect("current held by control lock");
+        let old_effective_spec = old.instance.spec().clone();
+        let old_controller = old.instance.controller().clone();
+        let old_source_spec = old.source_spec.clone();
+        let old_revision = old.revision.clone();
+        let old_source_document = old.source_document.clone();
+        let old_effective_document = old.effective_document.clone();
+        abort_and_await(old.forwarder).await;
+        if let Err(error) = old
+            .instance
+            .stop_and_confirm_dead(self.inner.options.stop_timeout)
+            .await
+        {
+            let message = format!("failed to stop current epoch for reconcile: {error}");
+            self.publish_terminal_error(&Error::ApplyFailed(message.clone()));
+            return Err(Error::ApplyFailed(message));
+        }
+
+        match self
+            .spawn_replacement(
+                desired.effective_spec.clone(),
+                desired.revision.epoch,
+                desired.controller.clone(),
+            )
+            .await
+        {
+            Ok(instance) => {
+                let revision = desired.revision.clone();
+                let pid = instance.pid().unwrap_or_default();
+                let forwarder =
+                    spawn_forwarder(self.inner.clone(), instance.state(), revision.epoch);
+                ctrl.last_spec = Some(desired.source_spec.clone());
+                ctrl.current = Some(Active {
+                    instance,
+                    forwarder,
+                    source_spec: desired.source_spec,
+                    revision: desired.revision,
+                    source_document: desired.source_document,
+                    effective_document: desired.effective_document,
+                });
+                let active = ctrl.current.as_ref().expect("just installed");
+                self.inner.publish_active(
+                    active,
+                    CoreState::Running {
+                        epoch: revision.epoch,
+                        pid,
+                    },
+                );
+                if let Err(error) = self.inner.store.remove_backup(backup).await {
+                    tracing::warn!("failed to remove successful restart backup: {error}");
+                }
+                Ok(ApplyOutcome::Restarted { revision })
+            }
+            Err(apply_error) => {
+                let apply_text = apply_error.to_string();
+                if let Err(restore_error) = self.inner.store.restore(&backup).await {
+                    let error = Error::ApplyRollbackFailed {
+                        apply: apply_text,
+                        rollback: format!("runtime restore failed: {restore_error}"),
+                    };
+                    self.publish_terminal_error(&error);
+                    return Err(error);
+                }
+                match self
+                    .spawn_replacement(old_effective_spec, old_revision.epoch, old_controller)
+                    .await
+                {
+                    Ok(instance) => {
+                        let pid = instance.pid().unwrap_or_default();
+                        let forwarder = spawn_forwarder(
+                            self.inner.clone(),
+                            instance.state(),
+                            old_revision.epoch,
+                        );
+                        ctrl.last_spec = Some(old_source_spec.clone());
+                        ctrl.current = Some(Active {
+                            instance,
+                            forwarder,
+                            source_spec: old_source_spec,
+                            revision: old_revision.clone(),
+                            source_document: old_source_document,
+                            effective_document: old_effective_document,
+                        });
+                        let active = ctrl.current.as_ref().expect("rollback installed");
+                        self.inner.publish_active(
+                            active,
+                            CoreState::Running {
+                                epoch: old_revision.epoch,
+                                pid,
+                            },
+                        );
+                        if let Err(error) = self.inner.store.remove_backup(backup).await {
+                            tracing::warn!("failed to remove rollback backup: {error}");
+                        }
+                        Ok(ApplyOutcome::RolledBack {
+                            revision: old_revision,
+                            failed_apply: apply_text,
+                        })
+                    }
+                    Err(rollback_error) => {
+                        let error = Error::ApplyRollbackFailed {
+                            apply: apply_text,
+                            rollback: rollback_error.to_string(),
+                        };
+                        self.publish_terminal_error(&error);
+                        Err(error)
+                    }
+                }
+            }
+        }
+    }
+
+    async fn switch_with_compensation(
+        &self,
+        ctrl: &mut Ctrl,
+        input: InstanceSpec,
+        snapshot: ConfigSnapshot,
+    ) -> Result<ApplyOutcome, Error> {
+        let epoch = self.next_epoch();
+        let desired = self
+            .prepare_launch(&input, epoch, &snapshot, DeriveMode::ControllerOnly)
+            .await?;
+        let old = ctrl.current.take().expect("current held by control lock");
+        let old_epoch = old.revision.epoch;
+        let old_effective_spec = old.instance.spec().clone();
+        let old_controller = old.instance.controller().clone();
+        let old_source_spec = old.source_spec.clone();
+        let old_revision = old.revision.clone();
+        let old_source_document = old.source_document.clone();
+        let old_effective_document = old.effective_document.clone();
+        abort_and_await(old.forwarder).await;
+        if let Err(error) = old
+            .instance
+            .stop_and_confirm_dead(self.inner.options.stop_timeout)
+            .await
+        {
+            let _ = self.inner.store.cleanup_epoch(epoch).await;
+            let message = format!("failed to stop current epoch for switch: {error}");
+            self.publish_terminal_error(&Error::ApplyFailed(message.clone()));
+            return Err(Error::ApplyFailed(message));
+        }
+
+        match self
+            .spawn_replacement(
+                desired.effective_spec.clone(),
+                desired.revision.epoch,
+                desired.controller.clone(),
+            )
+            .await
+        {
+            Ok(instance) => {
+                let revision = desired.revision.clone();
+                let pid = instance.pid().unwrap_or_default();
+                let forwarder =
+                    spawn_forwarder(self.inner.clone(), instance.state(), revision.epoch);
+                ctrl.last_spec = Some(desired.source_spec.clone());
+                ctrl.current = Some(Active {
+                    instance,
+                    forwarder,
+                    source_spec: desired.source_spec,
+                    revision: desired.revision,
+                    source_document: desired.source_document,
+                    effective_document: desired.effective_document,
+                });
+                let active = ctrl.current.as_ref().expect("switch installed");
+                self.inner.publish_active(
+                    active,
+                    CoreState::Running {
+                        epoch: revision.epoch,
+                        pid,
+                    },
+                );
+                if let Err(error) = self.inner.store.cleanup_epoch(old_epoch).await {
+                    tracing::warn!("failed to clean switched-out epoch: {error}");
+                }
+                Ok(ApplyOutcome::Restarted { revision })
+            }
+            Err(apply_error) => {
+                let apply_text = apply_error.to_string();
+                if let Err(error) = self.inner.store.cleanup_epoch(epoch).await {
+                    tracing::warn!("failed to clean rejected desired epoch: {error}");
+                }
+                match self
+                    .spawn_replacement(old_effective_spec, old_revision.epoch, old_controller)
+                    .await
+                {
+                    Ok(instance) => {
+                        let pid = instance.pid().unwrap_or_default();
+                        let forwarder = spawn_forwarder(
+                            self.inner.clone(),
+                            instance.state(),
+                            old_revision.epoch,
+                        );
+                        ctrl.last_spec = Some(old_source_spec.clone());
+                        ctrl.current = Some(Active {
+                            instance,
+                            forwarder,
+                            source_spec: old_source_spec,
+                            revision: old_revision.clone(),
+                            source_document: old_source_document,
+                            effective_document: old_effective_document,
+                        });
+                        let active = ctrl.current.as_ref().expect("switch rollback installed");
+                        self.inner.publish_active(
+                            active,
+                            CoreState::Running {
+                                epoch: old_revision.epoch,
+                                pid,
+                            },
+                        );
+                        Ok(ApplyOutcome::RolledBack {
+                            revision: old_revision,
+                            failed_apply: apply_text,
+                        })
+                    }
+                    Err(rollback_error) => {
+                        let error = Error::ApplyRollbackFailed {
+                            apply: apply_text,
+                            rollback: rollback_error.to_string(),
+                        };
+                        self.publish_terminal_error(&error);
+                        Err(error)
+                    }
+                }
+            }
+        }
+    }
+
+    async fn spawn_replacement(
+        &self,
+        effective_spec: InstanceSpec,
+        epoch: u64,
+        controller: ResolvedController,
+    ) -> Result<Instance, Error> {
+        let instance = Instance::spawn(
+            effective_spec,
+            epoch,
+            controller,
+            self.inner.options.cancel_token.clone(),
+        )
+        .await?;
+        if let Err(error) = instance.wait_ready().await {
+            return match instance
+                .stop_and_confirm_dead(self.inner.options.stop_timeout)
+                .await
+            {
+                Ok(()) => Err(error),
+                Err(stop_error) => Err(Error::ApplyFailed(format!(
+                    "{error}; failed to stop rejected replacement: {stop_error}"
+                ))),
+            };
+        }
+        Ok(instance)
+    }
+
     fn next_epoch(&self) -> u64 {
         self.inner.epoch.fetch_add(1, Ordering::Relaxed) + 1
     }
@@ -233,6 +765,8 @@ impl CoreManager {
                 runtime_path,
             },
             restore: prepared.restore,
+            source_document: snapshot.document().clone(),
+            effective_document: prepared.document,
         })
     }
 
@@ -329,6 +863,8 @@ impl CoreManager {
             forwarder,
             source_spec: prepared.source_spec,
             revision: prepared.revision,
+            source_document: prepared.source_document,
+            effective_document: prepared.effective_document,
         });
         Ok(())
     }
@@ -385,7 +921,11 @@ impl CoreManager {
             self.inner.options.controller_mode,
             ControllerMode::Managed { .. }
         );
-        match decide(managed, spec.core.kind, snapshot.info().has_dns_listen) {
+        match decide(
+            managed,
+            spec.core.kind,
+            config_diff::overlap_block(snapshot.document()),
+        ) {
             Some(reason) => {
                 self.hard_switch(ctrl, spec, snapshot).await?;
                 Ok(SwitchOutcome::Hard { reason })
@@ -613,6 +1153,8 @@ impl CoreManager {
             forwarder,
             source_spec: prepared.source_spec,
             revision: prepared.revision,
+            source_document: prepared.source_document,
+            effective_document: prepared.effective_document,
         });
         Ok(SwitchOutcome::Graceful)
     }
@@ -627,6 +1169,7 @@ impl CoreManager {
             forwarder,
             source_spec,
             revision,
+            ..
         } = active;
         abort_and_await(forwarder).await;
         if instance.state().borrow().is_terminal() {
@@ -681,6 +1224,7 @@ impl CoreManager {
                 forwarder,
                 source_spec,
                 revision,
+                ..
             } = active;
             abort_and_await(forwarder).await;
             let epoch = instance.epoch();
@@ -771,18 +1315,18 @@ mod tests {
     #[test]
     fn switch_matrix_matches_the_spec() {
         assert_eq!(
-            decide(false, CoreKind::Mihomo, false),
+            decide(false, CoreKind::Mihomo, None),
             Some(DegradeReason::PassthroughMode)
         );
         assert_eq!(
-            decide(true, CoreKind::ClashRs, false),
+            decide(true, CoreKind::ClashRs, None),
             Some(DegradeReason::UnsupportedKind)
         );
         assert_eq!(
-            decide(true, CoreKind::Mihomo, true),
+            decide(true, CoreKind::Mihomo, Some(OverlapBlock::DnsListen)),
             Some(DegradeReason::DnsListen)
         );
-        assert_eq!(decide(true, CoreKind::Mihomo, false), None);
+        assert_eq!(decide(true, CoreKind::Mihomo, None), None);
     }
 
     #[test]

--- a/crates/nyanpasu-core-manager/src/manager.rs
+++ b/crates/nyanpasu-core-manager/src/manager.rs
@@ -258,6 +258,7 @@ impl CoreManager {
     }
 
     /// Test-only fault hook for the installed-but-parent-sync-failed branch.
+    #[cfg(feature = "test-hooks")]
     #[doc(hidden)]
     pub fn inject_runtime_parent_sync_failure_once_for_test(&self) {
         self.inner.store.inject_replace_parent_sync_failure_once();
@@ -1152,7 +1153,6 @@ impl CoreManager {
                 epoch: first_epoch,
                 reason: failures.join(" | "),
             };
-            self.publish_terminal_error(&error);
             return Err(error);
         }
         self.inner
@@ -1729,9 +1729,6 @@ fn with_durability_result(
 ) -> Result<ApplyOutcome, Error> {
     match (result, warning) {
         (Ok(outcome), warning) => Ok(with_durability_warning(outcome, warning)),
-        (Err(Error::StopUnconfirmed(message)), Some(warning)) => Err(Error::StopUnconfirmed(
-            format!("{message}; runtime durability warning: {warning}"),
-        )),
         (Err(error), Some(warning)) => Err(Error::DurabilityUncertain {
             source: Box::new(error),
             warning,
@@ -1759,9 +1756,6 @@ fn with_switch_durability_result(
 ) -> Result<SwitchOutcome, Error> {
     match (result, warning) {
         (Ok(outcome), warning) => Ok(with_switch_durability_warning(outcome, warning)),
-        (Err(Error::StopUnconfirmed(message)), Some(warning)) => Err(Error::StopUnconfirmed(
-            format!("{message}; runtime durability warning: {warning}"),
-        )),
         (Err(error), Some(warning)) => Err(Error::DurabilityUncertain {
             source: Box::new(error),
             warning,
@@ -1834,5 +1828,28 @@ mod tests {
         };
         assert!(matches!(*source, Error::ApplyRollbackFailed { .. }));
         assert_eq!(warning, "directory sync failed");
+    }
+
+    #[test]
+    fn durability_warning_wraps_stop_unconfirmed_without_flattening() {
+        let apply = with_durability_result(
+            Err(Error::StopUnconfirmed("apply stop uncertain".into())),
+            Some("apply sync warning".into()),
+        );
+        let Err(Error::DurabilityUncertain { source, warning }) = apply else {
+            panic!("apply stop uncertainty was not structurally wrapped")
+        };
+        assert!(matches!(*source, Error::StopUnconfirmed(_)));
+        assert_eq!(warning, "apply sync warning");
+
+        let switch = with_switch_durability_result(
+            Err(Error::StopUnconfirmed("switch stop uncertain".into())),
+            Some("switch sync warning".into()),
+        );
+        let Err(Error::DurabilityUncertain { source, warning }) = switch else {
+            panic!("switch stop uncertainty was not structurally wrapped")
+        };
+        assert!(matches!(*source, Error::StopUnconfirmed(_)));
+        assert_eq!(warning, "switch sync warning");
     }
 }

--- a/crates/nyanpasu-core-manager/src/manager.rs
+++ b/crates/nyanpasu-core-manager/src/manager.rs
@@ -1,12 +1,9 @@
 //! Cross-epoch orchestration: manager-owned artifacts, start/stop/switch, and
 //! atomic status publication.
 
-use std::{
-    sync::{
-        Arc,
-        atomic::{AtomicU64, Ordering},
-    },
-    time::Duration,
+use std::sync::{
+    Arc,
+    atomic::{AtomicU64, Ordering},
 };
 
 use nyanpasu_utils::process::reap_epoch_pid_file;
@@ -14,7 +11,7 @@ use serde_yaml_ng::Mapping;
 use tokio::sync::watch;
 
 use crate::{
-    config::{self, ConfigSnapshot, DeriveMode},
+    config::{self, ConfigSnapshot},
     config_diff::{self, ConfigChange, OverlapBlock},
     error::Error,
     instance::Instance,
@@ -63,7 +60,7 @@ pub enum ApplyOutcome {
     },
 }
 
-fn decide(
+fn graceful_degrade_reason(
     managed: bool,
     kind: CoreKind,
     overlap_block: Option<OverlapBlock>,
@@ -115,9 +112,14 @@ struct PreparedLaunch {
     effective_spec: InstanceSpec,
     controller: ResolvedController,
     revision: ConfigRevision,
-    restore: config::RestorePlan,
     source_document: Mapping,
     effective_document: Mapping,
+}
+
+struct PreparedGraceful {
+    launch: PreparedLaunch,
+    full_staged: StagedRuntimeConfig,
+    restoration: Option<(Box<clash_api::ConfigPatch>, config_diff::RuntimeProjection)>,
 }
 
 struct PreparedApply {
@@ -304,7 +306,6 @@ impl CoreManager {
             effective_spec,
             controller,
             revision,
-            restore: config::RestorePlan::default(),
             source_document,
             effective_document,
         };
@@ -366,11 +367,10 @@ impl CoreManager {
             .kind
             .run_args(&input.working_dir, &input.config_path)?;
         let epoch = current.revision.epoch;
-        let prepared = snapshot.prepare(
+        let prepared = snapshot.prepare_full(
             &self.inner.options.controller_mode,
             self.inner.store.dir(),
             epoch,
-            DeriveMode::ControllerOnly,
         )?;
         let staged = self.inner.store.stage(epoch, &prepared.bytes).await?;
         let mut check_spec = input.clone();
@@ -404,6 +404,17 @@ impl CoreManager {
         change: &ConfigChange,
         desired: &PreparedLaunch,
     ) -> bool {
+        if let ConfigChange::Patch { patch, projection } = change {
+            return self
+                .patch_and_verify(current.instance.controller(), patch, projection)
+                .await;
+        }
+        if matches!(change, ConfigChange::Switch) {
+            return false;
+        }
+        if matches!(change, ConfigChange::Noop) {
+            return true;
+        }
         let client = match crate::health::build_control_client(
             current.instance.controller(),
             self.inner.options.control_timeout,
@@ -415,25 +426,6 @@ impl CoreManager {
             }
         };
         match change {
-            ConfigChange::Patch { patch, projection } => {
-                if let Err(error) = client.patch_config(patch).await {
-                    tracing::warn!("config PATCH returned an uncertain result: {error}");
-                }
-                match client.configs().await {
-                    Ok(runtime) => match projection.verify(&runtime) {
-                        Ok(true) => {}
-                        Ok(false) => return false,
-                        Err(error) => {
-                            tracing::warn!("failed to verify config projection: {error}");
-                            return false;
-                        }
-                    },
-                    Err(error) => {
-                        tracing::warn!("GET /configs verification failed: {error}");
-                        return false;
-                    }
-                }
-            }
             ConfigChange::Reload => {
                 let request = clash_api::UpdateConfigRequest::from_path(
                     desired.revision.runtime_path.to_string(),
@@ -446,10 +438,51 @@ impl CoreManager {
                     return false;
                 }
             }
-            ConfigChange::Switch => return false,
-            ConfigChange::Noop => return true,
+            ConfigChange::Patch { .. } | ConfigChange::Switch | ConfigChange::Noop => {
+                unreachable!()
+            }
         }
-        match crate::health::HealthCheck::new(current.instance.controller()) {
+        self.probe_health(current.instance.controller()).await
+    }
+
+    async fn patch_and_verify(
+        &self,
+        controller: &ResolvedController,
+        patch: &clash_api::ConfigPatch,
+        projection: &config_diff::RuntimeProjection,
+    ) -> bool {
+        let client = match crate::health::build_control_client(
+            controller,
+            self.inner.options.control_timeout,
+        ) {
+            Ok(client) => client,
+            Err(error) => {
+                tracing::warn!("failed to build config control client: {error}");
+                return false;
+            }
+        };
+        if let Err(error) = client.patch_config(patch).await {
+            tracing::warn!("config PATCH returned an uncertain result: {error}");
+        }
+        match client.configs().await {
+            Ok(runtime) => match projection.verify(&runtime) {
+                Ok(true) => {}
+                Ok(false) => return false,
+                Err(error) => {
+                    tracing::warn!("failed to verify config projection: {error}");
+                    return false;
+                }
+            },
+            Err(error) => {
+                tracing::warn!("GET /configs verification failed: {error}");
+                return false;
+            }
+        }
+        self.probe_health(controller).await
+    }
+
+    async fn probe_health(&self, controller: &ResolvedController) -> bool {
+        match crate::health::HealthCheck::new(controller) {
             Ok(health) => health.probe_once().await,
             Err(error) => {
                 tracing::warn!("failed to build post-apply health probe: {error}");
@@ -583,9 +616,7 @@ impl CoreManager {
         snapshot: ConfigSnapshot,
     ) -> Result<ApplyOutcome, Error> {
         let epoch = self.next_epoch();
-        let desired = self
-            .prepare_launch(&input, epoch, &snapshot, DeriveMode::ControllerOnly)
-            .await?;
+        let desired = self.prepare_launch(&input, epoch, &snapshot).await?;
         let old = ctrl.current.take().expect("current held by control lock");
         let old_epoch = old.revision.epoch;
         let old_effective_spec = old.instance.spec().clone();
@@ -728,7 +759,6 @@ impl CoreManager {
         spec: &InstanceSpec,
         epoch: u64,
         snapshot: &ConfigSnapshot,
-        derive_mode: DeriveMode,
     ) -> Result<PreparedLaunch, Error> {
         debug_assert_eq!(snapshot.source_path(), spec.config_path);
         if tokio::fs::metadata(&spec.core.binary_path).await.is_err() {
@@ -737,11 +767,10 @@ impl CoreManager {
         spec.core
             .kind
             .run_args(&spec.working_dir, &spec.config_path)?;
-        let prepared = snapshot.prepare(
+        let prepared = snapshot.prepare_full(
             &self.inner.options.controller_mode,
             self.inner.store.dir(),
             epoch,
-            derive_mode,
         )?;
         let staged = self.inner.store.stage(epoch, &prepared.bytes).await?;
 
@@ -764,9 +793,73 @@ impl CoreManager {
                 effective_hash: prepared.effective_hash,
                 runtime_path,
             },
-            restore: prepared.restore,
             source_document: snapshot.document().clone(),
             effective_document: prepared.document,
+        })
+    }
+
+    async fn prepare_graceful(
+        &self,
+        spec: &InstanceSpec,
+        epoch: u64,
+        snapshot: &ConfigSnapshot,
+    ) -> Result<PreparedGraceful, Error> {
+        debug_assert_eq!(snapshot.source_path(), spec.config_path);
+        if tokio::fs::metadata(&spec.core.binary_path).await.is_err() {
+            return Err(Error::BinaryNotFound(spec.core.binary_path.clone()));
+        }
+        spec.core
+            .kind
+            .run_args(&spec.working_dir, &spec.config_path)?;
+        let full = snapshot.prepare_full(
+            &self.inner.options.controller_mode,
+            self.inner.store.dir(),
+            epoch,
+        )?;
+        let bootstrap = snapshot.prepare_bootstrap(
+            &self.inner.options.controller_mode,
+            self.inner.store.dir(),
+            epoch,
+        )?;
+        if full.controller.host != bootstrap.controller.host
+            || full.controller.secret != bootstrap.controller.secret
+        {
+            return Err(Error::InvalidConfig(
+                "full and bootstrap configs resolved different controllers".into(),
+            ));
+        }
+        let restoration = config_diff::restoration_patch(&bootstrap.document, &full.document)?;
+
+        let full_staged = self.inner.store.stage(epoch, &full.bytes).await?;
+        let mut check_spec = spec.clone();
+        check_spec.config_path = full_staged.path().to_owned();
+        crate::kind::check_config(&check_spec).await?;
+
+        let bootstrap_staged = self.inner.store.stage(epoch, &bootstrap.bytes).await?;
+        check_spec.config_path = bootstrap_staged.path().to_owned();
+        crate::kind::check_config(&check_spec).await?;
+        let runtime_path = self.inner.store.commit_new(bootstrap_staged, epoch).await?;
+
+        let mut effective_spec = spec.clone();
+        effective_spec.config_path = runtime_path.clone();
+        effective_spec.pid_file = Some(self.inner.store.pid_path(epoch));
+        Ok(PreparedGraceful {
+            launch: PreparedLaunch {
+                source_spec: spec.clone(),
+                effective_spec,
+                controller: full.controller,
+                revision: ConfigRevision {
+                    epoch,
+                    generation: 1,
+                    source_hash: full.source_hash,
+                    effective_hash: full.effective_hash,
+                    runtime_path,
+                },
+                source_document: snapshot.document().clone(),
+                effective_document: full.document,
+            },
+            full_staged,
+            restoration,
         })
     }
 
@@ -800,10 +893,7 @@ impl CoreManager {
                 return Err(error);
             }
         };
-        let prepared = match self
-            .prepare_launch(&spec, epoch, &snapshot, DeriveMode::ControllerOnly)
-            .await
-        {
+        let prepared = match self.prepare_launch(&spec, epoch, &snapshot).await {
             Ok(prepared) => prepared,
             Err(error) => {
                 let _ = self.inner.store.cleanup_epoch(epoch).await;
@@ -921,7 +1011,7 @@ impl CoreManager {
             self.inner.options.controller_mode,
             ControllerMode::Managed { .. }
         );
-        match decide(
+        match graceful_degrade_reason(
             managed,
             spec.core.kind,
             config_diff::overlap_block(snapshot.document()),
@@ -941,10 +1031,7 @@ impl CoreManager {
         snapshot: ConfigSnapshot,
     ) -> Result<(), Error> {
         let epoch = self.next_epoch();
-        let prepared = match self
-            .prepare_launch(&spec, epoch, &snapshot, DeriveMode::ControllerOnly)
-            .await
-        {
+        let prepared = match self.prepare_launch(&spec, epoch, &snapshot).await {
             Ok(prepared) => prepared,
             Err(error) => {
                 let _ = self.inner.store.cleanup_epoch(epoch).await;
@@ -990,6 +1077,27 @@ impl CoreManager {
         self.inner.publish_active(active, state);
     }
 
+    fn install_switched(&self, ctrl: &mut Ctrl, instance: Instance, prepared: PreparedLaunch) {
+        let epoch = prepared.revision.epoch;
+        let pid = instance.pid().unwrap_or_default();
+        self.inner.publish(
+            CoreState::Running { epoch, pid },
+            Some(spec_summary(&prepared.source_spec)),
+            Some(instance.controller().host.clone()),
+            Some(prepared.revision.clone()),
+        );
+        let forwarder = spawn_forwarder(self.inner.clone(), instance.state(), epoch);
+        ctrl.last_spec = Some(prepared.source_spec.clone());
+        ctrl.current = Some(Active {
+            instance,
+            forwarder,
+            source_spec: prepared.source_spec,
+            revision: prepared.revision,
+            source_document: prepared.source_document,
+            effective_document: prepared.effective_document,
+        });
+    }
+
     async fn graceful_switch(
         &self,
         ctrl: &mut Ctrl,
@@ -998,10 +1106,7 @@ impl CoreManager {
     ) -> Result<SwitchOutcome, Error> {
         let old_epoch = ctrl.current.as_ref().map(|active| active.instance.epoch());
         let epoch = self.next_epoch();
-        let prepared = match self
-            .prepare_launch(&spec, epoch, &snapshot, DeriveMode::ZeroListeners)
-            .await
-        {
+        let prepared = match self.prepare_graceful(&spec, epoch, &snapshot).await {
             Ok(prepared) => prepared,
             Err(error) => {
                 let _ = self.inner.store.cleanup_epoch(epoch).await;
@@ -1009,32 +1114,39 @@ impl CoreManager {
                 return Err(error);
             }
         };
+        let PreparedGraceful {
+            launch,
+            full_staged,
+            restoration,
+        } = prepared;
         self.inner.publish(
             CoreState::Switching {
                 from: old_epoch,
                 to: epoch,
             },
-            Some(spec_summary(&prepared.source_spec)),
-            Some(prepared.controller.host.clone()),
-            Some(prepared.revision.clone()),
+            Some(spec_summary(&launch.source_spec)),
+            Some(launch.controller.host.clone()),
+            Some(launch.revision.clone()),
         );
 
         let instance = match Instance::spawn(
-            prepared.effective_spec.clone(),
+            launch.effective_spec.clone(),
             epoch,
-            prepared.controller.clone(),
+            launch.controller.clone(),
             self.inner.options.cancel_token.clone(),
         )
         .await
         {
             Ok(instance) => instance,
             Err(error) => {
+                drop(full_staged);
                 let _ = self.inner.store.cleanup_epoch(epoch).await;
                 self.republish_retained(ctrl);
                 return Err(error);
             }
         };
         if let Err(error) = instance.wait_ready().await {
+            drop(full_staged);
             if instance
                 .stop_and_confirm_dead(self.inner.options.stop_timeout)
                 .await
@@ -1054,109 +1166,82 @@ impl CoreManager {
             .stop_and_confirm_dead(self.inner.options.stop_timeout)
             .await
         {
-            if instance
+            drop(full_staged);
+            let new_stop = instance
                 .stop_and_confirm_dead(self.inner.options.stop_timeout)
-                .await
-                .is_ok()
-            {
+                .await;
+            if new_stop.is_ok() {
                 let _ = self.inner.store.cleanup_epoch(epoch).await;
             }
-            self.publish_terminal_error(&error);
-            return Err(error);
-        }
-        if let Err(error) = self.inner.store.cleanup_epoch(old_epoch).await {
-            if instance
-                .stop_and_confirm_dead(self.inner.options.stop_timeout)
-                .await
-                .is_ok()
-            {
-                let _ = self.inner.store.cleanup_epoch(epoch).await;
-            }
+            let error = match new_stop {
+                Ok(()) => error,
+                Err(new_error) => Error::ApplyFailed(format!(
+                    "old epoch stop failed: {error}; new bootstrap stop also failed: {new_error}"
+                )),
+            };
             self.publish_terminal_error(&error);
             return Err(error);
         }
 
-        let patched = if prepared.restore.is_empty() {
-            true
-        } else {
-            let client = crate::health::build_control_client(
-                instance.controller(),
-                self.inner.options.control_timeout,
-            );
-            match client {
-                Ok(client) => {
-                    let patch = prepared.restore.to_patch();
-                    let mut patched = false;
-                    for attempt in 1..=3_u32 {
-                        match client.patch_config(&patch).await {
-                            Ok(()) => {
-                                patched = true;
-                                break;
-                            }
-                            Err(error) => {
-                                tracing::warn!(
-                                    "listener-restore patch attempt {attempt} failed: {error}"
-                                );
-                                if attempt < 3 {
-                                    tokio::time::sleep(Duration::from_millis(500)).await;
-                                }
-                            }
-                        }
-                    }
-                    patched
+        if let Err(error) = self.inner.store.commit_replace(full_staged, epoch).await {
+            let new_stop = instance
+                .stop_and_confirm_dead(self.inner.options.stop_timeout)
+                .await;
+            if new_stop.is_ok() {
+                let _ = self.inner.store.cleanup_epoch(epoch).await;
+            }
+            let error = match new_stop {
+                Ok(()) => error,
+                Err(new_error) => Error::ApplyFailed(format!(
+                    "full runtime commit failed: {error}; bootstrap stop also failed: {new_error}"
+                )),
+            };
+            self.publish_terminal_error(&error);
+            return Err(error);
+        }
+
+        let reconciled = tokio::time::timeout(self.inner.options.reconcile_timeout, async {
+            match restoration.as_ref() {
+                Some((patch, projection)) => {
+                    self.patch_and_verify(instance.controller(), patch, projection)
+                        .await
                 }
-                Err(error) => {
-                    tracing::warn!("failed to build listener-restore client: {error}");
-                    false
-                }
+                None => self.probe_health(instance.controller()).await,
+            }
+        })
+        .await
+        .unwrap_or(false);
+        if reconciled {
+            self.install_switched(ctrl, instance, launch);
+            self.inner.store.cleanup_epoch(old_epoch).await?;
+            return Ok(SwitchOutcome::Graceful);
+        }
+
+        let effective_spec = launch.effective_spec.clone();
+        let controller = launch.controller.clone();
+        if let Err(error) = instance
+            .stop_and_confirm_dead(self.inner.options.stop_timeout)
+            .await
+        {
+            self.publish_terminal_error(&error);
+            return Err(error);
+        }
+        let replacement = match self
+            .spawn_replacement(effective_spec, epoch, controller)
+            .await
+        {
+            Ok(replacement) => replacement,
+            Err(error) => {
+                let _ = self.inner.store.cleanup_epoch(epoch).await;
+                self.publish_terminal_error(&error);
+                return Err(error);
             }
         };
-        if !patched {
-            if let Err(error) = instance
-                .stop_and_confirm_dead(self.inner.options.stop_timeout)
-                .await
-            {
-                self.publish_terminal_error(&error);
-                return Err(error);
-            }
-            if let Err(error) = self.inner.store.cleanup_epoch(epoch).await {
-                self.publish_terminal_error(&error);
-                return Err(error);
-            }
-            let full = match self
-                .prepare_launch(&spec, epoch, &snapshot, DeriveMode::ControllerOnly)
-                .await
-            {
-                Ok(full) => full,
-                Err(error) => {
-                    self.publish_terminal_error(&error);
-                    return Err(error);
-                }
-            };
-            self.start_prepared(ctrl, full).await?;
-            return Ok(SwitchOutcome::Hard {
-                reason: DegradeReason::PatchFailed,
-            });
-        }
-
-        let pid = instance.pid().unwrap_or_default();
-        self.inner.publish(
-            CoreState::Running { epoch, pid },
-            Some(spec_summary(&prepared.source_spec)),
-            Some(instance.controller().host.clone()),
-            Some(prepared.revision.clone()),
-        );
-        let forwarder = spawn_forwarder(self.inner.clone(), instance.state(), epoch);
-        ctrl.last_spec = Some(prepared.source_spec.clone());
-        ctrl.current = Some(Active {
-            instance,
-            forwarder,
-            source_spec: prepared.source_spec,
-            revision: prepared.revision,
-            source_document: prepared.source_document,
-            effective_document: prepared.effective_document,
-        });
-        Ok(SwitchOutcome::Graceful)
+        self.install_switched(ctrl, replacement, launch);
+        self.inner.store.cleanup_epoch(old_epoch).await?;
+        Ok(SwitchOutcome::Hard {
+            reason: DegradeReason::PatchFailed,
+        })
     }
 
     pub async fn stop(&self) -> Result<(), Error> {
@@ -1315,18 +1400,18 @@ mod tests {
     #[test]
     fn switch_matrix_matches_the_spec() {
         assert_eq!(
-            decide(false, CoreKind::Mihomo, None),
+            graceful_degrade_reason(false, CoreKind::Mihomo, None),
             Some(DegradeReason::PassthroughMode)
         );
         assert_eq!(
-            decide(true, CoreKind::ClashRs, None),
+            graceful_degrade_reason(true, CoreKind::ClashRs, None),
             Some(DegradeReason::UnsupportedKind)
         );
         assert_eq!(
-            decide(true, CoreKind::Mihomo, Some(OverlapBlock::DnsListen)),
+            graceful_degrade_reason(true, CoreKind::Mihomo, Some(OverlapBlock::DnsListen)),
             Some(DegradeReason::DnsListen)
         );
-        assert_eq!(decide(true, CoreKind::Mihomo, None), None);
+        assert_eq!(graceful_degrade_reason(true, CoreKind::Mihomo, None), None);
     }
 
     #[test]

--- a/crates/nyanpasu-core-manager/src/manager.rs
+++ b/crates/nyanpasu-core-manager/src/manager.rs
@@ -34,10 +34,16 @@ pub enum DegradeReason {
     PatchFailed,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SwitchOutcome {
     Graceful,
-    Hard { reason: DegradeReason },
+    Hard {
+        reason: DegradeReason,
+    },
+    DurabilityUncertain {
+        outcome: Box<SwitchOutcome>,
+        warning: String,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -110,6 +116,7 @@ struct Ctrl {
 struct QuarantinedEpoch {
     epoch: u64,
     reason: String,
+    death_proven: bool,
 }
 
 struct Active {
@@ -248,6 +255,12 @@ impl CoreManager {
 
     pub fn status(&self) -> CoreStatus {
         self.inner.status_tx.borrow().clone()
+    }
+
+    /// Test-only fault hook for the installed-but-parent-sync-failed branch.
+    #[doc(hidden)]
+    pub fn inject_runtime_parent_sync_failure_once_for_test(&self) {
+        self.inner.store.inject_replace_parent_sync_failure_once();
     }
 
     pub async fn apply_config(
@@ -1083,32 +1096,64 @@ impl CoreManager {
             return Ok(());
         }
         let quarantined = ctrl.quarantine.clone();
+        let mut failures = Vec::new();
         for entry in quarantined {
-            let pid_path = self.inner.store.pid_path(entry.epoch);
-            match reap_epoch_pid_file(pid_path.as_std_path(), self.inner.store.dir().as_std_path())
+            if !entry.death_proven {
+                let pid_path = self.inner.store.pid_path(entry.epoch);
+                match reap_epoch_pid_file(
+                    pid_path.as_std_path(),
+                    self.inner.store.dir().as_std_path(),
+                )
                 .await
-            {
-                Ok(OrphanReapOutcome::AlreadyExited | OrphanReapOutcome::Killed) => {
-                    self.inner.store.cleanup_epoch(entry.epoch).await?;
-                    ctrl.quarantine
-                        .retain(|quarantine| quarantine.epoch != entry.epoch);
-                }
-                Ok(OrphanReapOutcome::NotFound) => {
-                    return Err(Error::ManagerQuarantined {
-                        epoch: entry.epoch,
-                        reason: format!(
-                            "{}; authoritative epoch pid record is unavailable",
-                            entry.reason
-                        ),
-                    });
-                }
-                Err(error) => {
-                    return Err(Error::ManagerQuarantined {
-                        epoch: entry.epoch,
-                        reason: format!("{}; recovery failed: {error}", entry.reason),
-                    });
+                {
+                    Ok(OrphanReapOutcome::AlreadyExited | OrphanReapOutcome::Killed) => {
+                        if let Some(quarantine) = ctrl
+                            .quarantine
+                            .iter_mut()
+                            .find(|quarantine| quarantine.epoch == entry.epoch)
+                        {
+                            quarantine.death_proven = true;
+                        }
+                    }
+                    Ok(OrphanReapOutcome::NotFound) => {
+                        failures.push(format!(
+                            "epoch {}: {}; authoritative epoch pid record is unavailable",
+                            entry.epoch, entry.reason
+                        ));
+                        continue;
+                    }
+                    Err(error) => {
+                        failures.push(format!(
+                            "epoch {}: {}; recovery failed: {error}",
+                            entry.epoch, entry.reason
+                        ));
+                        continue;
+                    }
                 }
             }
+
+            match self.inner.store.cleanup_epoch(entry.epoch).await {
+                Ok(()) => ctrl
+                    .quarantine
+                    .retain(|quarantine| quarantine.epoch != entry.epoch),
+                Err(error) => failures.push(format!(
+                    "epoch {}: {}; artifact cleanup failed: {error}",
+                    entry.epoch, entry.reason
+                )),
+            }
+        }
+        if !failures.is_empty() {
+            let first_epoch = ctrl
+                .quarantine
+                .first()
+                .map(|entry| entry.epoch)
+                .unwrap_or_default();
+            let error = Error::ManagerQuarantined {
+                epoch: first_epoch,
+                reason: failures.join(" | "),
+            };
+            self.publish_terminal_error(&error);
+            return Err(error);
         }
         self.inner
             .publish(CoreState::Stopped { reason: None }, None, None, None);
@@ -1378,7 +1423,8 @@ impl CoreManager {
                 return Err(error);
             }
         };
-        if let Some(warning) = commit.durability_warning() {
+        let durability_warning = commit.durability_warning().map(str::to_owned);
+        if let Some(warning) = durability_warning.as_deref() {
             tracing::warn!("graceful runtime replacement durability is uncertain: {warning}");
         }
 
@@ -1395,8 +1441,13 @@ impl CoreManager {
         .unwrap_or(false);
         if reconciled {
             self.install_switched(ctrl, instance, launch);
-            self.inner.store.cleanup_epoch(old_epoch).await?;
-            return Ok(SwitchOutcome::Graceful);
+            let result = self
+                .inner
+                .store
+                .cleanup_epoch(old_epoch)
+                .await
+                .map(|()| SwitchOutcome::Graceful);
+            return with_switch_durability_result(result, durability_warning);
         }
 
         let effective_spec = launch.effective_spec.clone();
@@ -1405,11 +1456,13 @@ impl CoreManager {
             .stop_and_confirm_dead(self.inner.options.stop_timeout)
             .await
         {
-            if matches!(error, Error::StopUnconfirmed(_)) {
-                return Err(self.latch_quarantine(ctrl, epoch, error));
-            }
-            self.publish_terminal_error(&error);
-            return Err(error);
+            let error = if matches!(error, Error::StopUnconfirmed(_)) {
+                self.latch_quarantine(ctrl, epoch, error)
+            } else {
+                self.publish_terminal_error(&error);
+                error
+            };
+            return with_switch_durability_result(Err(error), durability_warning);
         }
         let replacement = match self
             .spawn_replacement(effective_spec, epoch, controller)
@@ -1417,21 +1470,31 @@ impl CoreManager {
         {
             Ok(replacement) => replacement,
             Err(error @ Error::StopUnconfirmed(_)) => {
-                return Err(self.latch_quarantine(ctrl, epoch, error));
+                let error = self.latch_quarantine(ctrl, epoch, error);
+                return with_switch_durability_result(Err(error), durability_warning);
             }
             Err(error) => {
                 let _ = self.inner.store.cleanup_epoch(epoch).await;
                 self.publish_terminal_error(&error);
-                return Err(error);
+                return with_switch_durability_result(Err(error), durability_warning);
             }
         };
         self.install_switched(ctrl, replacement, launch);
-        self.inner.store.cleanup_epoch(old_epoch).await?;
-        Ok(SwitchOutcome::Hard {
-            reason: DegradeReason::PatchFailed,
-        })
+        let result =
+            self.inner
+                .store
+                .cleanup_epoch(old_epoch)
+                .await
+                .map(|()| SwitchOutcome::Hard {
+                    reason: DegradeReason::PatchFailed,
+                });
+        with_switch_durability_result(result, durability_warning)
     }
 
+    /// Stops the active instance even while another epoch is quarantined.
+    ///
+    /// This intentionally bypasses the quarantine gate so callers can reduce
+    /// the number of possibly live processes; it does not clear quarantine.
     pub async fn stop(&self) -> Result<(), Error> {
         let mut ctrl = self.inner.ctrl.lock().await;
         let Some(active) = ctrl.current.take() else {
@@ -1505,6 +1568,10 @@ impl CoreManager {
         crate::kind::check_config(spec).await
     }
 
+    /// Stops the active instance even while another epoch is quarantined.
+    ///
+    /// Like [`Self::stop`], shutdown intentionally bypasses the quarantine
+    /// gate and never treats an unrelated uncertain epoch as recovered.
     pub async fn shutdown(&self) -> Result<(), Error> {
         let mut ctrl = self.inner.ctrl.lock().await;
         if let Some(active) = ctrl.current.take() {
@@ -1577,7 +1644,11 @@ fn record_quarantine(ctrl: &mut Ctrl, epoch: u64, reason: String) {
     {
         existing.reason = reason;
     } else {
-        ctrl.quarantine.push(QuarantinedEpoch { epoch, reason });
+        ctrl.quarantine.push(QuarantinedEpoch {
+            epoch,
+            reason,
+            death_proven: false,
+        });
     }
 }
 
@@ -1661,9 +1732,40 @@ fn with_durability_result(
         (Err(Error::StopUnconfirmed(message)), Some(warning)) => Err(Error::StopUnconfirmed(
             format!("{message}; runtime durability warning: {warning}"),
         )),
-        (Err(error), Some(warning)) => Err(Error::ApplyFailed(format!(
-            "{error}; runtime durability warning: {warning}"
-        ))),
+        (Err(error), Some(warning)) => Err(Error::DurabilityUncertain {
+            source: Box::new(error),
+            warning,
+        }),
+        (Err(error), None) => Err(error),
+    }
+}
+
+fn with_switch_durability_warning(
+    outcome: SwitchOutcome,
+    warning: Option<String>,
+) -> SwitchOutcome {
+    match warning {
+        Some(warning) => SwitchOutcome::DurabilityUncertain {
+            outcome: Box::new(outcome),
+            warning,
+        },
+        None => outcome,
+    }
+}
+
+fn with_switch_durability_result(
+    result: Result<SwitchOutcome, Error>,
+    warning: Option<String>,
+) -> Result<SwitchOutcome, Error> {
+    match (result, warning) {
+        (Ok(outcome), warning) => Ok(with_switch_durability_warning(outcome, warning)),
+        (Err(Error::StopUnconfirmed(message)), Some(warning)) => Err(Error::StopUnconfirmed(
+            format!("{message}; runtime durability warning: {warning}"),
+        )),
+        (Err(error), Some(warning)) => Err(Error::DurabilityUncertain {
+            source: Box::new(error),
+            warning,
+        }),
         (Err(error), None) => Err(error),
     }
 }
@@ -1716,5 +1818,21 @@ mod tests {
                 CoreState::Running { epoch: 9, pid: 90 }
             ));
         }
+    }
+
+    #[test]
+    fn durability_warning_preserves_structured_apply_error() {
+        let result = with_durability_result(
+            Err(Error::ApplyRollbackFailed {
+                apply: "desired failed".into(),
+                rollback: "rollback failed".into(),
+            }),
+            Some("directory sync failed".into()),
+        );
+        let Err(Error::DurabilityUncertain { source, warning }) = result else {
+            panic!("structured error was flattened")
+        };
+        assert!(matches!(*source, Error::ApplyRollbackFailed { .. }));
+        assert_eq!(warning, "directory sync failed");
     }
 }

--- a/crates/nyanpasu-core-manager/src/manager.rs
+++ b/crates/nyanpasu-core-manager/src/manager.rs
@@ -16,7 +16,7 @@ use crate::{
     error::Error,
     instance::Instance,
     kind::CoreKind,
-    runtime_store::{RuntimeConfigStore, StagedRuntimeConfig},
+    runtime_store::{RuntimeConfigStore, RuntimeDirectoryLock, StagedRuntimeConfig},
     spec::{ControllerMode, InstanceSpec, ManagerOptions, ResolvedController},
     state::{
         ConfigRevision, CoreState, CoreStatus, InstanceState, RevisionId, SpecSummary, StopReason,
@@ -90,6 +90,9 @@ struct Inner {
     ctrl: tokio::sync::Mutex<Ctrl>,
     status_tx: watch::Sender<CoreStatus>,
     epoch: AtomicU64,
+    // Declared last so ordinary Inner destruction drops instances/tasks before
+    // releasing directory ownership.
+    _runtime_lock: RuntimeDirectoryLock,
 }
 
 #[derive(Default)]
@@ -194,6 +197,7 @@ impl CoreManager {
             }
         };
         let store = RuntimeConfigStore::new(runtime_dir).await?;
+        let runtime_lock = store.acquire_ownership().await?;
         let max_epoch = sweep_orphans(&store).await?;
 
         if let ControllerMode::Managed {
@@ -222,6 +226,7 @@ impl CoreManager {
                 ctrl: tokio::sync::Mutex::default(),
                 status_tx,
                 epoch: AtomicU64::new(max_epoch),
+                _runtime_lock: runtime_lock,
             }),
         })
     }
@@ -510,6 +515,10 @@ impl CoreManager {
             .stop_and_confirm_dead(self.inner.options.stop_timeout)
             .await
         {
+            if matches!(error, Error::StopUnconfirmed(_)) {
+                self.publish_terminal_error(&error);
+                return Err(error);
+            }
             let message = format!("failed to stop current epoch for reconcile: {error}");
             self.publish_terminal_error(&Error::ApplyFailed(message.clone()));
             return Err(Error::ApplyFailed(message));
@@ -549,6 +558,10 @@ impl CoreManager {
                     tracing::warn!("failed to remove successful restart backup: {error}");
                 }
                 Ok(ApplyOutcome::Restarted { revision })
+            }
+            Err(error @ Error::StopUnconfirmed(_)) => {
+                self.publish_terminal_error(&error);
+                Err(error)
             }
             Err(apply_error) => {
                 let apply_text = apply_error.to_string();
@@ -596,6 +609,13 @@ impl CoreManager {
                             failed_apply: apply_text,
                         })
                     }
+                    Err(rollback_error @ Error::StopUnconfirmed(_)) => {
+                        let error = Error::StopUnconfirmed(format!(
+                            "desired apply failed ({apply_text}); rollback replacement {rollback_error}"
+                        ));
+                        self.publish_terminal_error(&error);
+                        Err(error)
+                    }
                     Err(rollback_error) => {
                         let error = Error::ApplyRollbackFailed {
                             apply: apply_text,
@@ -632,6 +652,10 @@ impl CoreManager {
             .await
         {
             let _ = self.inner.store.cleanup_epoch(epoch).await;
+            if matches!(error, Error::StopUnconfirmed(_)) {
+                self.publish_terminal_error(&error);
+                return Err(error);
+            }
             let message = format!("failed to stop current epoch for switch: {error}");
             self.publish_terminal_error(&Error::ApplyFailed(message.clone()));
             return Err(Error::ApplyFailed(message));
@@ -672,6 +696,10 @@ impl CoreManager {
                 }
                 Ok(ApplyOutcome::Restarted { revision })
             }
+            Err(error @ Error::StopUnconfirmed(_)) => {
+                self.publish_terminal_error(&error);
+                Err(error)
+            }
             Err(apply_error) => {
                 let apply_text = apply_error.to_string();
                 if let Err(error) = self.inner.store.cleanup_epoch(epoch).await {
@@ -710,6 +738,13 @@ impl CoreManager {
                             failed_apply: apply_text,
                         })
                     }
+                    Err(rollback_error @ Error::StopUnconfirmed(_)) => {
+                        let error = Error::StopUnconfirmed(format!(
+                            "desired switch failed ({apply_text}); rollback replacement {rollback_error}"
+                        ));
+                        self.publish_terminal_error(&error);
+                        Err(error)
+                    }
                     Err(rollback_error) => {
                         let error = Error::ApplyRollbackFailed {
                             apply: apply_text,
@@ -742,7 +777,7 @@ impl CoreManager {
                 .await
             {
                 Ok(()) => Err(error),
-                Err(stop_error) => Err(Error::ApplyFailed(format!(
+                Err(stop_error) => Err(Error::StopUnconfirmed(format!(
                     "{error}; failed to stop rejected replacement: {stop_error}"
                 ))),
             };
@@ -1147,15 +1182,23 @@ impl CoreManager {
         };
         if let Err(error) = instance.wait_ready().await {
             drop(full_staged);
-            if instance
+            match instance
                 .stop_and_confirm_dead(self.inner.options.stop_timeout)
                 .await
-                .is_ok()
             {
-                let _ = self.inner.store.cleanup_epoch(epoch).await;
+                Ok(()) => {
+                    let _ = self.inner.store.cleanup_epoch(epoch).await;
+                    self.republish_retained(ctrl);
+                    return Err(error);
+                }
+                Err(stop_error) => {
+                    let error = Error::StopUnconfirmed(format!(
+                        "{error}; failed to stop rejected graceful bootstrap: {stop_error}"
+                    ));
+                    self.publish_terminal_error(&error);
+                    return Err(error);
+                }
             }
-            self.republish_retained(ctrl);
-            return Err(error);
         }
 
         let old = ctrl.current.take().expect("running checked by caller");
@@ -1175,7 +1218,7 @@ impl CoreManager {
             }
             let error = match new_stop {
                 Ok(()) => error,
-                Err(new_error) => Error::ApplyFailed(format!(
+                Err(new_error) => Error::StopUnconfirmed(format!(
                     "old epoch stop failed: {error}; new bootstrap stop also failed: {new_error}"
                 )),
             };
@@ -1192,7 +1235,7 @@ impl CoreManager {
             }
             let error = match new_stop {
                 Ok(()) => error,
-                Err(new_error) => Error::ApplyFailed(format!(
+                Err(new_error) => Error::StopUnconfirmed(format!(
                     "full runtime commit failed: {error}; bootstrap stop also failed: {new_error}"
                 )),
             };
@@ -1231,6 +1274,10 @@ impl CoreManager {
             .await
         {
             Ok(replacement) => replacement,
+            Err(error @ Error::StopUnconfirmed(_)) => {
+                self.publish_terminal_error(&error);
+                return Err(error);
+            }
             Err(error) => {
                 let _ = self.inner.store.cleanup_epoch(epoch).await;
                 self.publish_terminal_error(&error);
@@ -1256,9 +1303,16 @@ impl CoreManager {
             revision,
             ..
         } = active;
+        let captured_state = instance.state().borrow().clone();
         abort_and_await(forwarder).await;
-        if instance.state().borrow().is_terminal() {
+        if captured_state.is_terminal() {
             let epoch = instance.epoch();
+            self.inner.publish(
+                instance_core_state(epoch, &captured_state),
+                Some(spec_summary(&source_spec)),
+                Some(instance.controller().host.clone()),
+                Some(revision),
+            );
             instance
                 .stop_and_confirm_dead(self.inner.options.stop_timeout)
                 .await?;

--- a/crates/nyanpasu-core-manager/src/manager.rs
+++ b/crates/nyanpasu-core-manager/src/manager.rs
@@ -1,4 +1,5 @@
-//! Cross-epoch orchestration: start/stop/switch and status publication.
+//! Cross-epoch orchestration: manager-owned artifacts, start/stop/switch, and
+//! atomic status publication.
 
 use std::{
     sync::{
@@ -8,26 +9,27 @@ use std::{
     time::Duration,
 };
 
+use nyanpasu_utils::process::reap_epoch_pid_file;
 use tokio::sync::watch;
 
 use crate::{
-    config,
+    config::{self, ConfigSnapshot, DeriveMode},
     error::Error,
     instance::Instance,
     kind::CoreKind,
+    runtime_store::RuntimeConfigStore,
     spec::{ControllerMode, InstanceSpec, ManagerOptions, ResolvedController},
-    state::{CoreState, CoreStatus, InstanceState, SpecSummary, StopReason, now_ms},
+    state::{
+        ConfigRevision, CoreState, CoreStatus, InstanceState, SpecSummary, StopReason, now_ms,
+    },
 };
 
-/// Why a switch was executed as a hard stop→start instead of gracefully.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DegradeReason {
     NotRunning,
     PassthroughMode,
     UnsupportedKind,
     DnsListen,
-    /// Graceful overlap succeeded but the listener-restore PATCH kept failing;
-    /// converged via a hard restart on the full config.
     PatchFailed,
 }
 
@@ -37,7 +39,6 @@ pub enum SwitchOutcome {
     Hard { reason: DegradeReason },
 }
 
-/// Spec §6.3 degradation matrix. `None` means graceful-eligible.
 fn decide(managed: bool, kind: CoreKind, has_dns_listen: bool) -> Option<DegradeReason> {
     if !managed {
         return Some(DegradeReason::PassthroughMode);
@@ -57,6 +58,7 @@ pub struct CoreManager {
 
 struct Inner {
     options: ManagerOptions,
+    store: RuntimeConfigStore,
     ctrl: tokio::sync::Mutex<Ctrl>,
     status_tx: watch::Sender<CoreStatus>,
     epoch: AtomicU64,
@@ -71,39 +73,110 @@ struct Ctrl {
 struct Active {
     instance: Instance,
     forwarder: tokio::task::JoinHandle<()>,
-    derived_path: Option<camino::Utf8PathBuf>,
+    source_spec: InstanceSpec,
+    revision: ConfigRevision,
+}
+
+struct PreparedLaunch {
+    source_spec: InstanceSpec,
+    effective_spec: InstanceSpec,
+    controller: ResolvedController,
+    revision: ConfigRevision,
+    restore: config::RestorePlan,
 }
 
 impl Inner {
-    fn publish_state(&self, state: CoreState) {
+    fn publish(
+        &self,
+        state: CoreState,
+        spec: Option<SpecSummary>,
+        controller: Option<clash_api::Host>,
+        revision: Option<ConfigRevision>,
+    ) {
         self.status_tx.send_modify(|status| {
             status.state = state;
+            status.spec = spec;
+            status.controller = controller;
+            status.revision = revision;
             status.changed_at = now_ms();
         });
     }
 
-    fn publish_context(&self, spec: Option<SpecSummary>, controller: Option<clash_api::Host>) {
+    fn publish_active(&self, active: &Active, state: CoreState) {
+        self.publish(
+            state,
+            Some(spec_summary(&active.source_spec)),
+            Some(active.instance.controller().host.clone()),
+            Some(active.revision.clone()),
+        );
+    }
+
+    fn publish_epoch_state(&self, epoch: u64, state: CoreState) {
         self.status_tx.send_modify(|status| {
-            status.spec = spec;
-            status.controller = controller;
+            if apply_epoch_state(status, epoch, state.clone()) {
+                status.changed_at = now_ms();
+            }
         });
     }
 }
 
+fn apply_epoch_state(status: &mut CoreStatus, epoch: u64, state: CoreState) -> bool {
+    if status.revision.as_ref().map(|revision| revision.epoch) != Some(epoch) {
+        return false;
+    }
+    status.state = state;
+    true
+}
+
+fn spec_summary(spec: &InstanceSpec) -> SpecSummary {
+    SpecSummary {
+        kind: spec.core.kind,
+        config_path: spec.config_path.clone(),
+    }
+}
+
 impl CoreManager {
-    pub fn new(options: ManagerOptions) -> Self {
-        if let ControllerMode::Managed { derived_dir, .. } = &options.controller_mode {
-            sweep_derived_dir(derived_dir);
+    pub async fn new(options: ManagerOptions) -> Result<Self, Error> {
+        let runtime_dir = match (&options.runtime_dir, &options.controller_mode) {
+            (Some(runtime_dir), _) => runtime_dir.clone(),
+            (None, ControllerMode::Managed { derived_dir, .. }) => derived_dir.clone(),
+            (None, ControllerMode::Passthrough) => {
+                return Err(Error::InvalidManagerOptions(
+                    "Passthrough mode requires runtime_dir".into(),
+                ));
+            }
+        };
+        let store = RuntimeConfigStore::new(runtime_dir).await?;
+        let max_epoch = sweep_orphans(&store).await?;
+
+        if let ControllerMode::Managed {
+            controller_template,
+            ..
+        } = &options.controller_mode
+        {
+            config::validate_controller_template(controller_template.as_deref())?;
+        }
+        for (name, timeout) in [
+            ("control_timeout", options.control_timeout),
+            ("reconcile_timeout", options.reconcile_timeout),
+            ("stop_timeout", options.stop_timeout),
+        ] {
+            if timeout.is_zero() {
+                return Err(Error::InvalidManagerOptions(format!(
+                    "{name} must be greater than zero"
+                )));
+            }
         }
         let (status_tx, _) = watch::channel(CoreStatus::initial());
-        Self {
+        Ok(Self {
             inner: Arc::new(Inner {
                 options,
+                store,
                 ctrl: tokio::sync::Mutex::default(),
                 status_tx,
-                epoch: AtomicU64::new(0),
+                epoch: AtomicU64::new(max_epoch),
             }),
-        }
+        })
     }
 
     pub fn subscribe(&self) -> watch::Receiver<CoreStatus> {
@@ -118,52 +191,49 @@ impl CoreManager {
         self.inner.epoch.fetch_add(1, Ordering::Relaxed) + 1
     }
 
-    /// Mode-dependent launch preparation: the effective spec (Managed mode may
-    /// swap the config path for a derived one), the probe controller, and the
-    /// publicly advertised controller endpoint (Managed only), and the derived
-    /// config path retained for cleanup tracking (`None` in Passthrough mode).
-    async fn prepare(
+    async fn prepare_launch(
         &self,
         spec: &InstanceSpec,
         epoch: u64,
-    ) -> Result<
-        (
-            InstanceSpec,
-            ResolvedController,
-            Option<clash_api::Host>,
-            Option<camino::Utf8PathBuf>,
-        ),
-        Error,
-    > {
-        match &self.inner.options.controller_mode {
-            ControllerMode::Passthrough => {
-                let info = config::inspect(&spec.config_path).await?;
-                let controller = config::resolve_controller(&info)?;
-                Ok((spec.clone(), controller, None, None))
-            }
-            ControllerMode::Managed {
-                derived_dir,
-                controller_template,
-            } => {
-                let derived = config::derive(
-                    &spec.config_path,
-                    derived_dir,
-                    controller_template.as_deref(),
-                    epoch,
-                    config::DeriveMode::ControllerOnly,
-                )
-                .await?;
-                let mut effective = spec.clone();
-                effective.config_path = derived.path.clone();
-                let advertised = Some(derived.controller.host.clone());
-                Ok((
-                    effective,
-                    derived.controller,
-                    advertised,
-                    Some(derived.path),
-                ))
-            }
+        snapshot: &ConfigSnapshot,
+        derive_mode: DeriveMode,
+    ) -> Result<PreparedLaunch, Error> {
+        debug_assert_eq!(snapshot.source_path(), spec.config_path);
+        if tokio::fs::metadata(&spec.core.binary_path).await.is_err() {
+            return Err(Error::BinaryNotFound(spec.core.binary_path.clone()));
         }
+        spec.core
+            .kind
+            .run_args(&spec.working_dir, &spec.config_path)?;
+        let prepared = snapshot.prepare(
+            &self.inner.options.controller_mode,
+            self.inner.store.dir(),
+            epoch,
+            derive_mode,
+        )?;
+        let staged = self.inner.store.stage(epoch, &prepared.bytes).await?;
+
+        let mut check_spec = spec.clone();
+        check_spec.config_path = staged.path().to_owned();
+        crate::kind::check_config(&check_spec).await?;
+
+        let runtime_path = self.inner.store.commit_new(staged, epoch).await?;
+        let mut effective_spec = spec.clone();
+        effective_spec.config_path = runtime_path.clone();
+        effective_spec.pid_file = Some(self.inner.store.pid_path(epoch));
+        Ok(PreparedLaunch {
+            source_spec: spec.clone(),
+            effective_spec,
+            controller: prepared.controller,
+            revision: ConfigRevision {
+                epoch,
+                generation: 1,
+                source_hash: prepared.source_hash,
+                effective_hash: prepared.effective_hash,
+                runtime_path,
+            },
+            restore: prepared.restore,
+        })
     }
 
     pub async fn start(&self, spec: InstanceSpec) -> Result<(), Error> {
@@ -176,73 +246,102 @@ impl CoreManager {
             return Err(Error::AlreadyRunning);
         }
         if let Some(stale) = ctrl.current.take() {
-            stale.forwarder.abort();
-            cleanup_derived(stale.derived_path).await;
+            abort_and_await(stale.forwarder).await;
+            let epoch = stale.instance.epoch();
+            stale
+                .instance
+                .stop_and_confirm_dead(self.inner.options.stop_timeout)
+                .await?;
+            self.inner.store.cleanup_epoch(epoch).await?;
         }
         self.start_locked(&mut ctrl, spec).await
     }
 
     async fn start_locked(&self, ctrl: &mut Ctrl, spec: InstanceSpec) -> Result<(), Error> {
-        self.start_locked_with_epoch(ctrl, spec, None).await
+        let epoch = self.next_epoch();
+        let snapshot = match ConfigSnapshot::load(&spec.config_path).await {
+            Ok(snapshot) => snapshot,
+            Err(error) => {
+                self.publish_terminal_error(&error);
+                return Err(error);
+            }
+        };
+        let prepared = match self
+            .prepare_launch(&spec, epoch, &snapshot, DeriveMode::ControllerOnly)
+            .await
+        {
+            Ok(prepared) => prepared,
+            Err(error) => {
+                let _ = self.inner.store.cleanup_epoch(epoch).await;
+                self.publish_terminal_error(&error);
+                return Err(error);
+            }
+        };
+        self.start_prepared(ctrl, prepared).await
     }
 
-    async fn start_locked_with_epoch(
-        &self,
-        ctrl: &mut Ctrl,
-        spec: InstanceSpec,
-        epoch_override: Option<u64>,
-    ) -> Result<(), Error> {
-        let epoch = epoch_override.unwrap_or_else(|| self.next_epoch());
-        let (effective_spec, controller, advertised, derived_path) =
-            self.prepare(&spec, epoch).await?;
-        self.inner.publish_context(
-            Some(SpecSummary {
-                kind: spec.core.kind,
-                config_path: spec.config_path.clone(),
-            }),
-            advertised,
+    async fn start_prepared(&self, ctrl: &mut Ctrl, prepared: PreparedLaunch) -> Result<(), Error> {
+        let epoch = prepared.revision.epoch;
+        self.inner.publish(
+            CoreState::Starting { epoch },
+            Some(spec_summary(&prepared.source_spec)),
+            Some(prepared.controller.host.clone()),
+            Some(prepared.revision.clone()),
         );
-        self.inner.publish_state(CoreState::Starting { epoch });
-
         let instance = match Instance::spawn(
-            effective_spec,
+            prepared.effective_spec,
             epoch,
-            controller,
+            prepared.controller,
             self.inner.options.cancel_token.clone(),
         )
         .await
         {
             Ok(instance) => instance,
             Err(error) => {
-                self.inner.publish_state(CoreState::Stopped {
-                    reason: Some(StopReason::Error(error.to_string())),
-                });
-                cleanup_derived(derived_path).await;
+                let _ = self.inner.store.cleanup_epoch(epoch).await;
+                self.publish_terminal_error(&error);
                 return Err(error);
             }
         };
 
-        match instance.wait_ready().await {
-            Ok(()) => {
-                let pid = instance.pid().unwrap_or_default();
-                self.inner.publish_state(CoreState::Running { epoch, pid });
-                let forwarder = spawn_forwarder(self.inner.clone(), instance.state(), epoch);
-                ctrl.current = Some(Active {
-                    instance,
-                    forwarder,
-                    derived_path,
-                });
-                ctrl.last_spec = Some(spec);
-                Ok(())
+        if let Err(error) = instance.wait_ready().await {
+            let stopped = instance
+                .stop_and_confirm_dead(self.inner.options.stop_timeout)
+                .await;
+            if stopped.is_ok() {
+                let _ = self.inner.store.cleanup_epoch(epoch).await;
             }
-            Err(error) => {
-                self.inner.publish_state(CoreState::Stopped {
-                    reason: Some(StopReason::Error(error.to_string())),
-                });
-                cleanup_derived(derived_path).await;
-                Err(error)
-            }
+            self.publish_terminal_error(&error);
+            return Err(error);
         }
+
+        let pid = instance.pid().unwrap_or_default();
+        self.inner.publish(
+            CoreState::Running { epoch, pid },
+            Some(spec_summary(&prepared.source_spec)),
+            Some(instance.controller().host.clone()),
+            Some(prepared.revision.clone()),
+        );
+        let forwarder = spawn_forwarder(self.inner.clone(), instance.state(), epoch);
+        ctrl.last_spec = Some(prepared.source_spec.clone());
+        ctrl.current = Some(Active {
+            instance,
+            forwarder,
+            source_spec: prepared.source_spec,
+            revision: prepared.revision,
+        });
+        Ok(())
+    }
+
+    fn publish_terminal_error(&self, error: &Error) {
+        self.inner.publish(
+            CoreState::Stopped {
+                reason: Some(StopReason::Error(error.to_string())),
+            },
+            None,
+            None,
+            None,
+        );
     }
 
     pub async fn restart(&self) -> Result<SwitchOutcome, Error> {
@@ -267,236 +366,254 @@ impl CoreManager {
             .is_some_and(|active| !active.instance.state().borrow().is_terminal());
         if !running {
             if let Some(stale) = ctrl.current.take() {
-                stale.forwarder.abort();
-                cleanup_derived(stale.derived_path).await;
+                abort_and_await(stale.forwarder).await;
+                let epoch = stale.instance.epoch();
+                stale
+                    .instance
+                    .stop_and_confirm_dead(self.inner.options.stop_timeout)
+                    .await?;
+                self.inner.store.cleanup_epoch(epoch).await?;
             }
             self.start_locked(ctrl, spec).await?;
             return Ok(SwitchOutcome::Hard {
                 reason: DegradeReason::NotRunning,
             });
         }
+
+        let snapshot = ConfigSnapshot::load(&spec.config_path).await?;
         let managed = matches!(
             self.inner.options.controller_mode,
             ControllerMode::Managed { .. }
         );
-        let info = config::inspect(&spec.config_path).await?;
-        match decide(managed, spec.core.kind, info.has_dns_listen) {
+        match decide(managed, spec.core.kind, snapshot.info().has_dns_listen) {
             Some(reason) => {
-                self.hard_switch(ctrl, spec).await?;
+                self.hard_switch(ctrl, spec, snapshot).await?;
                 Ok(SwitchOutcome::Hard { reason })
             }
-            None => self.graceful_switch(ctrl, spec).await,
+            None => self.graceful_switch(ctrl, spec, snapshot).await,
         }
     }
 
-    async fn hard_switch(&self, ctrl: &mut Ctrl, spec: InstanceSpec) -> Result<(), Error> {
-        let active = ctrl.current.take().expect("running checked by caller");
-        active.forwarder.abort();
-        let from = active.instance.epoch();
-        // Safe peek: `epoch` only advances under the ctrl lock we hold.
-        let to = self.inner.epoch.load(Ordering::Relaxed) + 1;
-        self.inner.publish_state(CoreState::Switching {
-            from: Some(from),
-            to,
-        });
-        match active.instance.stop().await {
-            Ok(()) => {}
+    async fn hard_switch(
+        &self,
+        ctrl: &mut Ctrl,
+        spec: InstanceSpec,
+        snapshot: ConfigSnapshot,
+    ) -> Result<(), Error> {
+        let epoch = self.next_epoch();
+        let prepared = match self
+            .prepare_launch(&spec, epoch, &snapshot, DeriveMode::ControllerOnly)
+            .await
+        {
+            Ok(prepared) => prepared,
             Err(error) => {
-                self.inner.publish_state(CoreState::Stopped {
-                    reason: Some(StopReason::Error(format!(
-                        "switch aborted: failed to stop the old core: {error}"
-                    ))),
-                });
-                cleanup_derived(active.derived_path).await;
+                let _ = self.inner.store.cleanup_epoch(epoch).await;
+                self.republish_retained(ctrl);
                 return Err(error);
             }
+        };
+        let old_epoch = ctrl.current.as_ref().map(|active| active.instance.epoch());
+        self.inner.publish(
+            CoreState::Switching {
+                from: old_epoch,
+                to: epoch,
+            },
+            Some(spec_summary(&prepared.source_spec)),
+            Some(prepared.controller.host.clone()),
+            Some(prepared.revision.clone()),
+        );
+
+        let old = ctrl.current.take().expect("running checked by caller");
+        abort_and_await(old.forwarder).await;
+        let old_epoch = old.instance.epoch();
+        if let Err(error) = old
+            .instance
+            .stop_and_confirm_dead(self.inner.options.stop_timeout)
+            .await
+        {
+            let _ = self.inner.store.cleanup_epoch(epoch).await;
+            self.publish_terminal_error(&error);
+            return Err(error);
         }
-        cleanup_derived(active.derived_path).await;
-        self.start_locked(ctrl, spec).await
+        if let Err(error) = self.inner.store.cleanup_epoch(old_epoch).await {
+            self.publish_terminal_error(&error);
+            return Err(error);
+        }
+        self.start_prepared(ctrl, prepared).await
     }
 
-    async fn rollback_republish_retained(&self, ctrl: &mut Ctrl) {
-        {
-            let active = ctrl
-                .current
-                .as_mut()
-                .expect("old core retained during rollback");
-            active.forwarder.abort();
-            let _ = (&mut active.forwarder).await;
-        }
-
-        let (epoch, mut state_rx) = {
-            let active = ctrl
-                .current
-                .as_ref()
-                .expect("old core retained during rollback");
-            (active.instance.epoch(), active.instance.state())
+    fn republish_retained(&self, ctrl: &Ctrl) {
+        let Some(active) = ctrl.current.as_ref() else {
+            return;
         };
-        let state = state_rx.borrow_and_update();
-        let terminal = state.is_terminal();
-        let core_state = match &*state {
-            InstanceState::Starting => CoreState::Starting { epoch },
-            InstanceState::Running { pid } => CoreState::Running { epoch, pid: *pid },
-            InstanceState::Restarting { attempt } => CoreState::Restarting {
-                epoch,
-                attempt: *attempt,
-            },
-            InstanceState::Stopping => CoreState::Stopping { epoch },
-            InstanceState::Stopped(reason) => CoreState::Stopped {
-                reason: Some(reason.clone()),
-            },
-        };
-        drop(state);
-
-        self.inner.publish_state(core_state);
-        if !terminal {
-            let active = ctrl
-                .current
-                .as_mut()
-                .expect("old core retained during rollback");
-            active.forwarder = spawn_forwarder(self.inner.clone(), state_rx, epoch);
-        }
+        let state = instance_core_state(active.instance.epoch(), &active.instance.state().borrow());
+        self.inner.publish_active(active, state);
     }
 
     async fn graceful_switch(
         &self,
         ctrl: &mut Ctrl,
         spec: InstanceSpec,
+        snapshot: ConfigSnapshot,
     ) -> Result<SwitchOutcome, Error> {
-        let ControllerMode::Managed {
-            derived_dir,
-            controller_template,
-        } = self.inner.options.controller_mode.clone()
-        else {
-            unreachable!("decide() only selects graceful in Managed mode");
-        };
-        let old_epoch = ctrl.current.as_ref().map(|a| a.instance.epoch());
+        let old_epoch = ctrl.current.as_ref().map(|active| active.instance.epoch());
         let epoch = self.next_epoch();
-        self.inner.publish_state(CoreState::Switching {
-            from: old_epoch,
-            to: epoch,
-        });
+        let prepared = match self
+            .prepare_launch(&spec, epoch, &snapshot, DeriveMode::ZeroListeners)
+            .await
+        {
+            Ok(prepared) => prepared,
+            Err(error) => {
+                let _ = self.inner.store.cleanup_epoch(epoch).await;
+                self.republish_retained(ctrl);
+                return Err(error);
+            }
+        };
+        self.inner.publish(
+            CoreState::Switching {
+                from: old_epoch,
+                to: epoch,
+            },
+            Some(spec_summary(&prepared.source_spec)),
+            Some(prepared.controller.host.clone()),
+            Some(prepared.revision.clone()),
+        );
 
-        // 1. Derive B' (listeners zeroed, epoch endpoint injected) and start it
-        //    while the old core keeps serving.
-        let derived = match config::derive(
-            &spec.config_path,
-            &derived_dir,
-            controller_template.as_deref(),
+        let instance = match Instance::spawn(
+            prepared.effective_spec.clone(),
             epoch,
-            config::DeriveMode::ZeroListeners,
+            prepared.controller.clone(),
+            self.inner.options.cancel_token.clone(),
         )
         .await
         {
-            Ok(derived) => derived,
-            Err(error) => {
-                self.rollback_republish_retained(ctrl).await;
-                return Err(error);
-            }
-        };
-        let mut effective = spec.clone();
-        effective.config_path = derived.path.clone();
-        let started = async {
-            let instance = Instance::spawn(
-                effective,
-                epoch,
-                derived.controller.clone(),
-                self.inner.options.cancel_token.clone(),
-            )
-            .await?;
-            instance.wait_ready().await?;
-            Ok::<Instance, Error>(instance)
-        }
-        .await;
-        let instance = match started {
             Ok(instance) => instance,
             Err(error) => {
-                // Safe rollback: the old core was never touched.
-                cleanup_derived(Some(derived.path)).await;
-                self.rollback_republish_retained(ctrl).await;
+                let _ = self.inner.store.cleanup_epoch(epoch).await;
+                self.republish_retained(ctrl);
                 return Err(error);
             }
         };
-
-        // 2. Point of no return: stop the old core, releasing its listeners.
-        let old = ctrl.current.take().expect("running checked by caller");
-        old.forwarder.abort();
-        let old_derived = old.derived_path.clone();
-        match old.instance.stop().await {
-            Ok(()) => {}
-            Err(error) => {
-                instance.stop().await.ok();
-                cleanup_derived(Some(derived.path)).await;
-                cleanup_derived(old_derived).await;
-                self.inner.publish_state(CoreState::Stopped {
-                    reason: Some(StopReason::Error(format!(
-                        "switch aborted: failed to stop the old core: {error}"
-                    ))),
-                });
-                return Err(error);
+        if let Err(error) = instance.wait_ready().await {
+            if instance
+                .stop_and_confirm_dead(self.inner.options.stop_timeout)
+                .await
+                .is_ok()
+            {
+                let _ = self.inner.store.cleanup_epoch(epoch).await;
             }
+            self.republish_retained(ctrl);
+            return Err(error);
         }
-        cleanup_derived(old_derived).await;
 
-        // 3. Restore the original listeners on the new core (3 tries × 500ms).
-        let patched = if derived.restore.is_empty() {
+        let old = ctrl.current.take().expect("running checked by caller");
+        abort_and_await(old.forwarder).await;
+        let old_epoch = old.instance.epoch();
+        if let Err(error) = old
+            .instance
+            .stop_and_confirm_dead(self.inner.options.stop_timeout)
+            .await
+        {
+            if instance
+                .stop_and_confirm_dead(self.inner.options.stop_timeout)
+                .await
+                .is_ok()
+            {
+                let _ = self.inner.store.cleanup_epoch(epoch).await;
+            }
+            self.publish_terminal_error(&error);
+            return Err(error);
+        }
+        if let Err(error) = self.inner.store.cleanup_epoch(old_epoch).await {
+            if instance
+                .stop_and_confirm_dead(self.inner.options.stop_timeout)
+                .await
+                .is_ok()
+            {
+                let _ = self.inner.store.cleanup_epoch(epoch).await;
+            }
+            self.publish_terminal_error(&error);
+            return Err(error);
+        }
+
+        let patched = if prepared.restore.is_empty() {
             true
         } else {
-            let client = match crate::health::build_client(instance.controller()) {
-                Ok(client) => client,
-                Err(error) => {
-                    tracing::warn!(
-                        "failed to build the listener-restore client: {error}; falling back to a hard restart"
-                    );
-                    instance.stop().await.ok();
-                    cleanup_derived(Some(derived.path)).await;
-                    self.start_locked_with_epoch(ctrl, spec, Some(epoch))
-                        .await?;
-                    return Ok(SwitchOutcome::Hard {
-                        reason: DegradeReason::PatchFailed,
-                    });
-                }
-            };
-            let patch = derived.restore.to_patch();
-            let mut ok = false;
-            for attempt in 1..=3u32 {
-                match client.patch_config(&patch).await {
-                    Ok(()) => {
-                        ok = true;
-                        break;
-                    }
-                    Err(error) => {
-                        tracing::warn!("listener-restore patch attempt {attempt} failed: {error}");
-                        if attempt < 3 {
-                            tokio::time::sleep(Duration::from_millis(500)).await;
+            let client = crate::health::build_control_client(
+                instance.controller(),
+                self.inner.options.control_timeout,
+            );
+            match client {
+                Ok(client) => {
+                    let patch = prepared.restore.to_patch();
+                    let mut patched = false;
+                    for attempt in 1..=3_u32 {
+                        match client.patch_config(&patch).await {
+                            Ok(()) => {
+                                patched = true;
+                                break;
+                            }
+                            Err(error) => {
+                                tracing::warn!(
+                                    "listener-restore patch attempt {attempt} failed: {error}"
+                                );
+                                if attempt < 3 {
+                                    tokio::time::sleep(Duration::from_millis(500)).await;
+                                }
+                            }
                         }
                     }
+                    patched
+                }
+                Err(error) => {
+                    tracing::warn!("failed to build listener-restore client: {error}");
+                    false
                 }
             }
-            ok
         };
         if !patched {
-            // 4. Fallback: the old core is dead and its ports are free — hard
-            //    restart the new instance on the full config, same epoch.
-            instance.stop().await.ok();
-            cleanup_derived(Some(derived.path)).await;
-            self.start_locked_with_epoch(ctrl, spec, Some(epoch))
-                .await?;
+            if let Err(error) = instance
+                .stop_and_confirm_dead(self.inner.options.stop_timeout)
+                .await
+            {
+                self.publish_terminal_error(&error);
+                return Err(error);
+            }
+            if let Err(error) = self.inner.store.cleanup_epoch(epoch).await {
+                self.publish_terminal_error(&error);
+                return Err(error);
+            }
+            let full = match self
+                .prepare_launch(&spec, epoch, &snapshot, DeriveMode::ControllerOnly)
+                .await
+            {
+                Ok(full) => full,
+                Err(error) => {
+                    self.publish_terminal_error(&error);
+                    return Err(error);
+                }
+            };
+            self.start_prepared(ctrl, full).await?;
             return Ok(SwitchOutcome::Hard {
                 reason: DegradeReason::PatchFailed,
             });
         }
 
-        // 5. Install the new core.
         let pid = instance.pid().unwrap_or_default();
-        self.inner.publish_state(CoreState::Running { epoch, pid });
+        self.inner.publish(
+            CoreState::Running { epoch, pid },
+            Some(spec_summary(&prepared.source_spec)),
+            Some(instance.controller().host.clone()),
+            Some(prepared.revision.clone()),
+        );
         let forwarder = spawn_forwarder(self.inner.clone(), instance.state(), epoch);
+        ctrl.last_spec = Some(prepared.source_spec.clone());
         ctrl.current = Some(Active {
             instance,
             forwarder,
-            derived_path: Some(derived.path),
+            source_spec: prepared.source_spec,
+            revision: prepared.revision,
         });
-        ctrl.last_spec = Some(spec);
         Ok(SwitchOutcome::Graceful)
     }
 
@@ -505,111 +622,144 @@ impl CoreManager {
         let Some(active) = ctrl.current.take() else {
             return Err(Error::NotStarted);
         };
-        active.forwarder.abort();
-        if active.instance.state().borrow().is_terminal() {
-            cleanup_derived(active.derived_path).await;
-            return Err(Error::NotStarted);
-        }
-        let epoch = active.instance.epoch();
-        self.inner.publish_state(CoreState::Stopping { epoch });
-        match active.instance.stop().await {
-            Ok(()) => {}
-            Err(error) => {
-                self.inner.publish_state(CoreState::Stopped {
-                    reason: Some(StopReason::Error(format!("stop failed: {error}"))),
-                });
-                cleanup_derived(active.derived_path).await;
+        let Active {
+            instance,
+            forwarder,
+            source_spec,
+            revision,
+        } = active;
+        abort_and_await(forwarder).await;
+        if instance.state().borrow().is_terminal() {
+            let epoch = instance.epoch();
+            instance
+                .stop_and_confirm_dead(self.inner.options.stop_timeout)
+                .await?;
+            if let Err(error) = self.inner.store.cleanup_epoch(epoch).await {
+                self.publish_terminal_error(&error);
                 return Err(error);
             }
+            return Err(Error::NotStarted);
         }
-        cleanup_derived(active.derived_path).await;
-        self.inner.publish_state(CoreState::Stopped {
-            reason: Some(StopReason::User),
-        });
+        let epoch = instance.epoch();
+        self.inner.publish(
+            CoreState::Stopping { epoch },
+            Some(spec_summary(&source_spec)),
+            Some(instance.controller().host.clone()),
+            Some(revision),
+        );
+        if let Err(error) = instance
+            .stop_and_confirm_dead(self.inner.options.stop_timeout)
+            .await
+        {
+            self.publish_terminal_error(&error);
+            return Err(error);
+        }
+        if let Err(error) = self.inner.store.cleanup_epoch(epoch).await {
+            self.publish_terminal_error(&error);
+            return Err(error);
+        }
+        self.inner.publish(
+            CoreState::Stopped {
+                reason: Some(StopReason::User),
+            },
+            None,
+            None,
+            None,
+        );
         Ok(())
     }
 
-    /// One-shot `-t` validation of a spec's config (spec §6.1 convenience).
     pub async fn check_config(&self, spec: &InstanceSpec) -> Result<(), Error> {
         crate::kind::check_config(spec).await
     }
 
-    /// Service-shutdown teardown: stop whatever is running, tolerate nothing running.
     pub async fn shutdown(&self) -> Result<(), Error> {
         let mut ctrl = self.inner.ctrl.lock().await;
         if let Some(active) = ctrl.current.take() {
-            active.forwarder.abort();
-            if !active.instance.state().borrow().is_terminal() {
-                let epoch = active.instance.epoch();
-                self.inner.publish_state(CoreState::Stopping { epoch });
-                match active.instance.stop().await {
-                    Ok(()) => {}
-                    Err(error) => {
-                        self.inner.publish_state(CoreState::Stopped {
-                            reason: Some(StopReason::Error(format!("stop failed: {error}"))),
-                        });
-                        cleanup_derived(active.derived_path).await;
-                        return Err(error);
-                    }
-                }
+            let Active {
+                instance,
+                forwarder,
+                source_spec,
+                revision,
+            } = active;
+            abort_and_await(forwarder).await;
+            let epoch = instance.epoch();
+            self.inner.publish(
+                CoreState::Stopping { epoch },
+                Some(spec_summary(&source_spec)),
+                Some(instance.controller().host.clone()),
+                Some(revision),
+            );
+            if let Err(error) = instance
+                .stop_and_confirm_dead(self.inner.options.stop_timeout)
+                .await
+            {
+                self.publish_terminal_error(&error);
+                return Err(error);
             }
-            cleanup_derived(active.derived_path).await;
-            self.inner.publish_state(CoreState::Stopped {
-                reason: Some(StopReason::User),
-            });
+            if let Err(error) = self.inner.store.cleanup_epoch(epoch).await {
+                self.publish_terminal_error(&error);
+                return Err(error);
+            }
+            self.inner.publish(
+                CoreState::Stopped {
+                    reason: Some(StopReason::User),
+                },
+                None,
+                None,
+                None,
+            );
         }
         Ok(())
     }
 }
 
-/// Removes runtime artifacts left behind by a previous manager process.
-fn sweep_derived_dir(derived_dir: &camino::Utf8Path) {
-    let Ok(entries) = std::fs::read_dir(derived_dir) else {
-        return;
-    };
-    for entry in entries.flatten() {
-        let name = entry.file_name();
-        let name = name.to_string_lossy();
-        let stale = (name.starts_with("epoch-") && name.ends_with(".yaml"))
-            || (name.starts_with("core-") && name.ends_with(".sock"));
-        if stale && let Err(error) = std::fs::remove_file(entry.path()) {
-            tracing::warn!("failed to sweep stale derived artifact {name}: {error}");
+async fn sweep_orphans(store: &RuntimeConfigStore) -> Result<u64, Error> {
+    let epochs = store.artifact_epochs().await?;
+    let max_epoch = epochs.iter().copied().max().unwrap_or(0);
+    for epoch in epochs {
+        let pid_path = store.pid_path(epoch);
+        if tokio::fs::try_exists(&pid_path).await? {
+            reap_epoch_pid_file(pid_path.as_std_path(), store.dir().as_std_path()).await?;
         }
+        store.cleanup_epoch(epoch).await?;
+    }
+    Ok(max_epoch)
+}
+
+async fn abort_and_await(mut forwarder: tokio::task::JoinHandle<()>) {
+    forwarder.abort();
+    let _ = (&mut forwarder).await;
+}
+
+fn instance_core_state(epoch: u64, state: &InstanceState) -> CoreState {
+    match state {
+        InstanceState::Starting => CoreState::Starting { epoch },
+        InstanceState::Running { pid } => CoreState::Running { epoch, pid: *pid },
+        InstanceState::Restarting { attempt } => CoreState::Restarting {
+            epoch,
+            attempt: *attempt,
+        },
+        InstanceState::Stopping => CoreState::Stopping { epoch },
+        InstanceState::Stopped(reason) => CoreState::Stopped {
+            reason: Some(reason.clone()),
+        },
     }
 }
 
-async fn cleanup_derived(path: Option<camino::Utf8PathBuf>) {
-    if let Some(path) = path {
-        let _ = tokio::fs::remove_file(&path).await;
-    }
-}
-
-/// Steady-state bridge: instance transitions → manager status. Installed only
-/// once a start/switch confirmed `Running`; aborted before any control action.
 fn spawn_forwarder(
     inner: Arc<Inner>,
     mut state_rx: watch::Receiver<InstanceState>,
     epoch: u64,
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
-        loop {
-            if state_rx.changed().await.is_err() {
+        while state_rx.changed().await.is_ok() {
+            let state = state_rx.borrow_and_update().clone();
+            let terminal = state.is_terminal();
+            inner.publish_epoch_state(epoch, instance_core_state(epoch, &state));
+            if terminal {
                 break;
             }
-            let state = state_rx.borrow_and_update().clone();
-            let core_state = match state {
-                InstanceState::Starting => CoreState::Starting { epoch },
-                InstanceState::Running { pid } => CoreState::Running { epoch, pid },
-                InstanceState::Restarting { attempt } => CoreState::Restarting { epoch, attempt },
-                InstanceState::Stopping => CoreState::Stopping { epoch },
-                InstanceState::Stopped(reason) => {
-                    inner.publish_state(CoreState::Stopped {
-                        reason: Some(reason),
-                    });
-                    break;
-                }
-            };
-            inner.publish_state(core_state);
         }
     })
 }
@@ -617,7 +767,6 @@ fn spawn_forwarder(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::kind::CoreKind;
 
     #[test]
     fn switch_matrix_matches_the_spec() {
@@ -630,13 +779,38 @@ mod tests {
             Some(DegradeReason::UnsupportedKind)
         );
         assert_eq!(
-            decide(true, CoreKind::ClashPremium, false),
-            Some(DegradeReason::UnsupportedKind)
-        );
-        assert_eq!(
             decide(true, CoreKind::Mihomo, true),
             Some(DegradeReason::DnsListen)
         );
         assert_eq!(decide(true, CoreKind::Mihomo, false), None);
+    }
+
+    #[test]
+    fn old_epoch_events_cannot_overwrite_new_epoch_status() {
+        let mut status = CoreStatus::initial();
+        status.revision = Some(ConfigRevision {
+            epoch: 9,
+            generation: 1,
+            source_hash: "source".into(),
+            effective_hash: "effective".into(),
+            runtime_path: "config-9.yaml".into(),
+        });
+        status.state = CoreState::Running { epoch: 9, pid: 90 };
+        for stale in [
+            CoreState::Running { epoch: 8, pid: 80 },
+            CoreState::Restarting {
+                epoch: 8,
+                attempt: 2,
+            },
+            CoreState::Stopped {
+                reason: Some(StopReason::Finished),
+            },
+        ] {
+            assert!(!apply_epoch_state(&mut status, 8, stale));
+            assert!(matches!(
+                status.state,
+                CoreState::Running { epoch: 9, pid: 90 }
+            ));
+        }
     }
 }

--- a/crates/nyanpasu-core-manager/src/runtime_store.rs
+++ b/crates/nyanpasu-core-manager/src/runtime_store.rs
@@ -45,6 +45,35 @@ pub struct RuntimeConfigBackup {
     epoch: u64,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RuntimeCommitDurability {
+    Durable,
+    Uncertain(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeConfigCommit {
+    path: Utf8PathBuf,
+    durability: RuntimeCommitDurability,
+}
+
+impl RuntimeConfigCommit {
+    pub fn path(&self) -> &Utf8Path {
+        &self.path
+    }
+
+    pub fn durability(&self) -> &RuntimeCommitDurability {
+        &self.durability
+    }
+
+    pub fn durability_warning(&self) -> Option<&str> {
+        match &self.durability {
+            RuntimeCommitDurability::Durable => None,
+            RuntimeCommitDurability::Uncertain(warning) => Some(warning),
+        }
+    }
+}
+
 impl RuntimeConfigBackup {
     pub fn path(&self) -> &Utf8Path {
         &self.path
@@ -160,7 +189,7 @@ impl RuntimeConfigStore {
         Ok(target)
     }
 
-    pub async fn replace(&self, epoch: u64, contents: &[u8]) -> Result<Utf8PathBuf, Error> {
+    pub async fn replace(&self, epoch: u64, contents: &[u8]) -> Result<RuntimeConfigCommit, Error> {
         let staged = self.stage(epoch, contents).await?;
         self.commit_replace(staged, epoch).await
     }
@@ -172,14 +201,13 @@ impl RuntimeConfigStore {
         &self,
         mut staged: StagedRuntimeConfig,
         epoch: u64,
-    ) -> Result<Utf8PathBuf, Error> {
+    ) -> Result<RuntimeConfigCommit, Error> {
         self.validate_staged(&staged, epoch).await?;
         let target = self.runtime_path(epoch);
         validate_existing_regular_target(&target).await?;
         atomic_replace(&staged.path, &target).await?;
         staged.consumed = true;
-        sync_parent(&self.dir).await?;
-        Ok(target)
+        Ok(installed_commit(target, sync_parent(&self.dir).await))
     }
 
     pub async fn backup(&self, epoch: u64, generation: u64) -> Result<RuntimeConfigBackup, Error> {
@@ -200,7 +228,10 @@ impl RuntimeConfigStore {
         })
     }
 
-    pub async fn restore(&self, backup: &RuntimeConfigBackup) -> Result<Utf8PathBuf, Error> {
+    pub async fn restore(
+        &self,
+        backup: &RuntimeConfigBackup,
+    ) -> Result<RuntimeConfigCommit, Error> {
         validate_existing_regular_target(&backup.path).await?;
         let contents = tokio::fs::read(&backup.path).await?;
         self.replace(backup.epoch, &contents).await
@@ -218,13 +249,17 @@ impl RuntimeConfigStore {
 
         let prefix = format!("config-{epoch}.yaml.backup-");
         let temp_prefix = format!(".config-{epoch}.yaml.tmp-");
+        let pid_temp_prefix = format!("core-{epoch}.pid.tmp-");
         let mut entries = tokio::fs::read_dir(&self.dir).await?;
         while let Some(entry) = entries.next_entry().await? {
             let name = entry.file_name();
             let Some(name) = name.to_str() else {
                 continue;
             };
-            if name.starts_with(&prefix) || name.starts_with(&temp_prefix) {
+            if name.starts_with(&prefix)
+                || name.starts_with(&temp_prefix)
+                || name.starts_with(&pid_temp_prefix)
+            {
                 let path = Utf8PathBuf::from_path_buf(entry.path())
                     .map_err(|_| Error::UnsafeRuntimeArtifact(self.dir.clone()))?;
                 remove_regular_file(&path).await?;
@@ -351,8 +386,22 @@ fn artifact_epoch(name: &str) -> Option<u64> {
         .or_else(|| {
             name.strip_prefix(".config-")
                 .and_then(|value| value.split_once(".yaml.tmp-").map(|(epoch, _)| epoch))
+        })
+        .or_else(|| {
+            name.strip_prefix("core-")
+                .and_then(|value| value.split_once(".pid.tmp-").map(|(epoch, _)| epoch))
         })?;
     rest.parse().ok()
+}
+
+fn installed_commit(path: Utf8PathBuf, parent_sync: std::io::Result<()>) -> RuntimeConfigCommit {
+    let durability = match parent_sync {
+        Ok(()) => RuntimeCommitDurability::Durable,
+        Err(error) => RuntimeCommitDurability::Uncertain(format!(
+            "runtime config was atomically installed, but parent-directory synchronization failed: {error}"
+        )),
+    };
+    RuntimeConfigCommit { path, durability }
 }
 
 fn validate_directory_metadata(path: &Utf8Path, metadata: &std::fs::Metadata) -> Result<(), Error> {
@@ -833,5 +882,20 @@ mod tests {
 
         store.cleanup_epoch(9).await.unwrap();
         assert!(!socket_path.exists());
+    }
+
+    #[test]
+    fn installed_commit_reports_parent_sync_uncertainty_without_becoming_an_error() {
+        let path = Utf8PathBuf::from("config-4.yaml");
+        let commit = installed_commit(
+            path.clone(),
+            Err(std::io::Error::other("injected directory fsync failure")),
+        );
+        assert_eq!(commit.path(), path);
+        assert!(matches!(
+            commit.durability(),
+            RuntimeCommitDurability::Uncertain(message)
+                if message.contains("atomically installed") && message.contains("injected")
+        ));
     }
 }

--- a/crates/nyanpasu-core-manager/src/runtime_store.rs
+++ b/crates/nyanpasu-core-manager/src/runtime_store.rs
@@ -15,6 +15,11 @@ pub struct RuntimeConfigStore {
 }
 
 #[derive(Debug)]
+pub(crate) struct RuntimeDirectoryLock {
+    _file: std::fs::File,
+}
+
+#[derive(Debug)]
 pub struct StagedRuntimeConfig {
     path: Utf8PathBuf,
     consumed: bool,
@@ -90,6 +95,13 @@ impl RuntimeConfigStore {
 
     pub fn socket_path(&self, epoch: u64) -> Utf8PathBuf {
         self.dir.join(format!("core-{epoch}.sock"))
+    }
+
+    pub(crate) async fn acquire_ownership(&self) -> Result<RuntimeDirectoryLock, Error> {
+        let path = self.dir.join(".manager.lock");
+        tokio::task::spawn_blocking(move || acquire_runtime_directory_lock(&path))
+            .await
+            .map_err(std::io::Error::other)?
     }
 
     pub async fn stage(&self, epoch: u64, contents: &[u8]) -> Result<StagedRuntimeConfig, Error> {
@@ -199,13 +211,10 @@ impl RuntimeConfigStore {
     }
 
     pub async fn cleanup_epoch(&self, epoch: u64) -> Result<(), Error> {
-        for path in [
-            self.runtime_path(epoch),
-            self.pid_path(epoch),
-            self.socket_path(epoch),
-        ] {
+        for path in [self.runtime_path(epoch), self.pid_path(epoch)] {
             remove_regular_file(&path).await?;
         }
+        remove_socket_artifact(&self.socket_path(epoch)).await?;
 
         let prefix = format!("config-{epoch}.yaml.backup-");
         let temp_prefix = format!(".config-{epoch}.yaml.tmp-");
@@ -252,6 +261,76 @@ impl RuntimeConfigStore {
         }
         validate_existing_regular_target(&staged.path).await
     }
+}
+
+fn acquire_runtime_directory_lock(path: &Utf8Path) -> Result<RuntimeDirectoryLock, Error> {
+    match std::fs::symlink_metadata(path) {
+        Ok(metadata)
+            if metadata.file_type().is_symlink()
+                || !metadata.is_file()
+                || is_reparse_point(&metadata) =>
+        {
+            return Err(Error::UnsafeRuntimeArtifact(path.to_owned()));
+        }
+        Ok(_) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error.into()),
+    }
+
+    let mut options = std::fs::OpenOptions::new();
+    options.create(true).read(true).write(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::OpenOptionsExt;
+        options.share_mode(0);
+    }
+    let file = options.open(path).map_err(|error| {
+        if runtime_lock_is_contended(&error) {
+            Error::RuntimeDirectoryOwned(path.to_owned())
+        } else {
+            error.into()
+        }
+    })?;
+
+    #[cfg(unix)]
+    {
+        use std::os::{fd::AsRawFd, raw::c_int};
+
+        const LOCK_EX: c_int = 2;
+        const LOCK_NB: c_int = 4;
+        unsafe extern "C" {
+            fn flock(fd: c_int, operation: c_int) -> c_int;
+        }
+        // SAFETY: file owns a valid descriptor for the duration of the call.
+        if unsafe { flock(file.as_raw_fd(), LOCK_EX | LOCK_NB) } != 0 {
+            let error = std::io::Error::last_os_error();
+            return Err(if runtime_lock_is_contended(&error) {
+                Error::RuntimeDirectoryOwned(path.to_owned())
+            } else {
+                error.into()
+            });
+        }
+    }
+
+    Ok(RuntimeDirectoryLock { _file: file })
+}
+
+#[cfg(unix)]
+fn runtime_lock_is_contended(error: &std::io::Error) -> bool {
+    matches!(
+        error.kind(),
+        std::io::ErrorKind::WouldBlock | std::io::ErrorKind::PermissionDenied
+    )
+}
+
+#[cfg(windows)]
+fn runtime_lock_is_contended(error: &std::io::Error) -> bool {
+    matches!(error.raw_os_error(), Some(5 | 32 | 33))
 }
 
 fn artifact_epoch(name: &str) -> Option<u64> {
@@ -319,6 +398,26 @@ async fn remove_regular_file(path: &Utf8Path) -> Result<(), Error> {
         {
             Err(Error::UnsafeRuntimeArtifact(path.to_owned()))
         }
+        Ok(_) => {
+            tokio::fs::remove_file(path).await?;
+            Ok(())
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error.into()),
+    }
+}
+
+async fn remove_socket_artifact(path: &Utf8Path) -> Result<(), Error> {
+    match tokio::fs::symlink_metadata(path).await {
+        Ok(metadata) if metadata.file_type().is_symlink() || is_reparse_point(&metadata) => {
+            Err(Error::UnsafeRuntimeArtifact(path.to_owned()))
+        }
+        #[cfg(unix)]
+        Ok(metadata) if !std::os::unix::fs::FileTypeExt::is_socket(&metadata.file_type()) => {
+            Err(Error::UnsafeRuntimeArtifact(path.to_owned()))
+        }
+        #[cfg(windows)]
+        Ok(metadata) if !metadata.is_file() => Err(Error::UnsafeRuntimeArtifact(path.to_owned())),
         Ok(_) => {
             tokio::fs::remove_file(path).await?;
             Ok(())
@@ -638,8 +737,10 @@ async fn sync_parent(dir: &Utf8Path) -> std::io::Result<()> {
 
 #[cfg(windows)]
 async fn sync_parent(_dir: &Utf8Path) -> std::io::Result<()> {
-    // MoveFileExW/ReplaceFileW use write-through; opening directories for fsync
-    // is not supported by std on Windows.
+    // MoveFileExW requests write-through for first publication. Microsoft
+    // documents ReplaceFileW's WRITE_THROUGH flag as unsupported, and std
+    // cannot fsync a Windows directory, so replacement power-loss durability
+    // is not asserted here.
     Ok(())
 }
 
@@ -711,5 +812,26 @@ mod tests {
         store.remove_backup(backup).await.unwrap();
         store.cleanup_epoch(3).await.unwrap();
         assert!(!path.exists());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn cleanup_epoch_removes_a_real_unix_socket() {
+        use std::os::unix::{fs::FileTypeExt, net::UnixListener};
+
+        let (_guard, dir) = temp_store_dir();
+        let store = RuntimeConfigStore::new(dir).await.unwrap();
+        let socket_path = store.socket_path(9);
+        let listener = UnixListener::bind(&socket_path).unwrap();
+        assert!(
+            std::fs::symlink_metadata(&socket_path)
+                .unwrap()
+                .file_type()
+                .is_socket()
+        );
+        drop(listener);
+
+        store.cleanup_epoch(9).await.unwrap();
+        assert!(!socket_path.exists());
     }
 }

--- a/crates/nyanpasu-core-manager/src/runtime_store.rs
+++ b/crates/nyanpasu-core-manager/src/runtime_store.rs
@@ -1,6 +1,9 @@
 //! Durable, manager-owned runtime configuration artifacts.
 
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{
+    Arc,
+    atomic::{AtomicU64, Ordering},
+};
 
 use camino::{Utf8Path, Utf8PathBuf};
 use tokio::io::AsyncWriteExt;
@@ -12,6 +15,7 @@ static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 #[derive(Debug, Clone)]
 pub struct RuntimeConfigStore {
     dir: Utf8PathBuf,
+    replace_parent_sync_failure: Arc<parking_lot::Mutex<Option<String>>>,
 }
 
 #[derive(Debug)]
@@ -107,7 +111,10 @@ impl RuntimeConfigStore {
         let metadata = tokio::fs::symlink_metadata(&dir).await?;
         validate_directory_metadata(&dir, &metadata)?;
 
-        Ok(Self { dir })
+        Ok(Self {
+            dir,
+            replace_parent_sync_failure: Arc::new(parking_lot::Mutex::new(None)),
+        })
     }
 
     pub fn dir(&self) -> &Utf8Path {
@@ -124,6 +131,11 @@ impl RuntimeConfigStore {
 
     pub fn socket_path(&self, epoch: u64) -> Utf8PathBuf {
         self.dir.join(format!("core-{epoch}.sock"))
+    }
+
+    pub(crate) fn inject_replace_parent_sync_failure_once(&self) {
+        *self.replace_parent_sync_failure.lock() =
+            Some("injected parent-directory synchronization failure".into());
     }
 
     pub(crate) async fn acquire_ownership(&self) -> Result<RuntimeDirectoryLock, Error> {
@@ -207,7 +219,12 @@ impl RuntimeConfigStore {
         validate_existing_regular_target(&target).await?;
         atomic_replace(&staged.path, &target).await?;
         staged.consumed = true;
-        Ok(installed_commit(target, sync_parent(&self.dir).await))
+        let injected_failure = self.replace_parent_sync_failure.lock().take();
+        let parent_sync = match injected_failure {
+            Some(message) => Err(std::io::Error::other(message)),
+            None => sync_parent(&self.dir).await,
+        };
+        Ok(installed_commit(target, parent_sync))
     }
 
     pub async fn backup(&self, epoch: u64, generation: u64) -> Result<RuntimeConfigBackup, Error> {

--- a/crates/nyanpasu-core-manager/src/runtime_store.rs
+++ b/crates/nyanpasu-core-manager/src/runtime_store.rs
@@ -149,7 +149,18 @@ impl RuntimeConfigStore {
     }
 
     pub async fn replace(&self, epoch: u64, contents: &[u8]) -> Result<Utf8PathBuf, Error> {
-        let mut staged = self.stage(epoch, contents).await?;
+        let staged = self.stage(epoch, contents).await?;
+        self.commit_replace(staged, epoch).await
+    }
+
+    /// Replaces the stable epoch file with bytes that were already staged and
+    /// validated. The staged file remains in the runtime directory, so the
+    /// atomicity guarantees are identical to [`Self::replace`].
+    pub async fn commit_replace(
+        &self,
+        mut staged: StagedRuntimeConfig,
+        epoch: u64,
+    ) -> Result<Utf8PathBuf, Error> {
         self.validate_staged(&staged, epoch).await?;
         let target = self.runtime_path(epoch);
         validate_existing_regular_target(&target).await?;

--- a/crates/nyanpasu-core-manager/src/runtime_store.rs
+++ b/crates/nyanpasu-core-manager/src/runtime_store.rs
@@ -1,9 +1,9 @@
 //! Durable, manager-owned runtime configuration artifacts.
 
-use std::sync::{
-    Arc,
-    atomic::{AtomicU64, Ordering},
-};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+#[cfg(feature = "test-hooks")]
+use std::sync::{Arc, atomic::AtomicUsize};
 
 use camino::{Utf8Path, Utf8PathBuf};
 use tokio::io::AsyncWriteExt;
@@ -15,7 +15,8 @@ static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 #[derive(Debug, Clone)]
 pub struct RuntimeConfigStore {
     dir: Utf8PathBuf,
-    replace_parent_sync_failure: Arc<parking_lot::Mutex<Option<String>>>,
+    #[cfg(feature = "test-hooks")]
+    replace_parent_sync_failures: Arc<AtomicUsize>,
 }
 
 #[derive(Debug)]
@@ -113,7 +114,8 @@ impl RuntimeConfigStore {
 
         Ok(Self {
             dir,
-            replace_parent_sync_failure: Arc::new(parking_lot::Mutex::new(None)),
+            #[cfg(feature = "test-hooks")]
+            replace_parent_sync_failures: Arc::new(AtomicUsize::new(0)),
         })
     }
 
@@ -133,9 +135,10 @@ impl RuntimeConfigStore {
         self.dir.join(format!("core-{epoch}.sock"))
     }
 
+    #[cfg(feature = "test-hooks")]
     pub(crate) fn inject_replace_parent_sync_failure_once(&self) {
-        *self.replace_parent_sync_failure.lock() =
-            Some("injected parent-directory synchronization failure".into());
+        self.replace_parent_sync_failures
+            .fetch_add(1, Ordering::Relaxed);
     }
 
     pub(crate) async fn acquire_ownership(&self) -> Result<RuntimeDirectoryLock, Error> {
@@ -219,11 +222,23 @@ impl RuntimeConfigStore {
         validate_existing_regular_target(&target).await?;
         atomic_replace(&staged.path, &target).await?;
         staged.consumed = true;
-        let injected_failure = self.replace_parent_sync_failure.lock().take();
-        let parent_sync = match injected_failure {
-            Some(message) => Err(std::io::Error::other(message)),
-            None => sync_parent(&self.dir).await,
+        #[cfg(feature = "test-hooks")]
+        let injected_failure = self
+            .replace_parent_sync_failures
+            .try_update(Ordering::Relaxed, Ordering::Relaxed, |remaining| {
+                remaining.checked_sub(1)
+            })
+            .is_ok();
+        #[cfg(feature = "test-hooks")]
+        let parent_sync = if injected_failure {
+            Err(std::io::Error::other(
+                "injected parent-directory synchronization failure",
+            ))
+        } else {
+            sync_parent(&self.dir).await
         };
+        #[cfg(not(feature = "test-hooks"))]
+        let parent_sync = sync_parent(&self.dir).await;
         Ok(installed_commit(target, parent_sync))
     }
 

--- a/crates/nyanpasu-core-manager/src/runtime_store.rs
+++ b/crates/nyanpasu-core-manager/src/runtime_store.rs
@@ -1,0 +1,704 @@
+//! Durable, manager-owned runtime configuration artifacts.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use camino::{Utf8Path, Utf8PathBuf};
+use tokio::io::AsyncWriteExt;
+
+use crate::Error;
+
+static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Debug, Clone)]
+pub struct RuntimeConfigStore {
+    dir: Utf8PathBuf,
+}
+
+#[derive(Debug)]
+pub struct StagedRuntimeConfig {
+    path: Utf8PathBuf,
+    consumed: bool,
+}
+
+impl StagedRuntimeConfig {
+    pub fn path(&self) -> &Utf8Path {
+        &self.path
+    }
+}
+
+impl Drop for StagedRuntimeConfig {
+    fn drop(&mut self) {
+        if !self.consumed {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct RuntimeConfigBackup {
+    path: Utf8PathBuf,
+    epoch: u64,
+}
+
+impl RuntimeConfigBackup {
+    pub fn path(&self) -> &Utf8Path {
+        &self.path
+    }
+}
+
+impl RuntimeConfigStore {
+    pub async fn new(dir: Utf8PathBuf) -> Result<Self, Error> {
+        match tokio::fs::symlink_metadata(&dir).await {
+            Ok(metadata) => validate_directory_metadata(&dir, &metadata)?,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                tokio::fs::create_dir_all(&dir).await?;
+            }
+            Err(error) => return Err(error.into()),
+        }
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            tokio::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700)).await?;
+        }
+        #[cfg(windows)]
+        {
+            harden_windows_directory_acl(&dir)?;
+            verify_windows_directory_acl(&dir)?;
+        }
+
+        let canonical = tokio::fs::canonicalize(&dir).await?;
+        let dir = Utf8PathBuf::from_path_buf(canonical)
+            .map_err(|_| Error::InvalidManagerOptions("runtime directory is not UTF-8".into()))?;
+        let metadata = tokio::fs::symlink_metadata(&dir).await?;
+        validate_directory_metadata(&dir, &metadata)?;
+
+        Ok(Self { dir })
+    }
+
+    pub fn dir(&self) -> &Utf8Path {
+        &self.dir
+    }
+
+    pub fn runtime_path(&self, epoch: u64) -> Utf8PathBuf {
+        self.dir.join(format!("config-{epoch}.yaml"))
+    }
+
+    pub fn pid_path(&self, epoch: u64) -> Utf8PathBuf {
+        self.dir.join(format!("core-{epoch}.pid"))
+    }
+
+    pub fn socket_path(&self, epoch: u64) -> Utf8PathBuf {
+        self.dir.join(format!("core-{epoch}.sock"))
+    }
+
+    pub async fn stage(&self, epoch: u64, contents: &[u8]) -> Result<StagedRuntimeConfig, Error> {
+        let counter = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let path = self.dir.join(format!(
+            ".config-{epoch}.yaml.tmp-{}-{counter}",
+            std::process::id()
+        ));
+        validate_absent_regular_target(&path).await?;
+
+        let mut options = tokio::fs::OpenOptions::new();
+        options.create_new(true).write(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        let mut file = options.open(&path).await?;
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            file.set_permissions(std::fs::Permissions::from_mode(0o600))
+                .await?;
+        }
+
+        if let Err(error) = async {
+            file.write_all(contents).await?;
+            file.flush().await?;
+            file.sync_all().await
+        }
+        .await
+        {
+            drop(file);
+            let _ = tokio::fs::remove_file(&path).await;
+            return Err(error.into());
+        }
+        drop(file);
+        Ok(StagedRuntimeConfig {
+            path,
+            consumed: false,
+        })
+    }
+
+    pub async fn commit_new(
+        &self,
+        mut staged: StagedRuntimeConfig,
+        epoch: u64,
+    ) -> Result<Utf8PathBuf, Error> {
+        self.validate_staged(&staged, epoch).await?;
+        let target = self.runtime_path(epoch);
+        validate_absent_regular_target(&target).await?;
+        atomic_move_new(&staged.path, &target).await?;
+        staged.consumed = true;
+        sync_parent(&self.dir).await?;
+        Ok(target)
+    }
+
+    pub async fn replace(&self, epoch: u64, contents: &[u8]) -> Result<Utf8PathBuf, Error> {
+        let mut staged = self.stage(epoch, contents).await?;
+        self.validate_staged(&staged, epoch).await?;
+        let target = self.runtime_path(epoch);
+        validate_existing_regular_target(&target).await?;
+        atomic_replace(&staged.path, &target).await?;
+        staged.consumed = true;
+        sync_parent(&self.dir).await?;
+        Ok(target)
+    }
+
+    pub async fn backup(&self, epoch: u64, generation: u64) -> Result<RuntimeConfigBackup, Error> {
+        let target = self.runtime_path(epoch);
+        validate_existing_regular_target(&target).await?;
+        let contents = tokio::fs::read(&target).await?;
+        let mut staged = self.stage(epoch, &contents).await?;
+        let backup_path = self
+            .dir
+            .join(format!("config-{epoch}.yaml.backup-{generation}"));
+        validate_absent_regular_target(&backup_path).await?;
+        atomic_move_new(&staged.path, &backup_path).await?;
+        staged.consumed = true;
+        sync_parent(&self.dir).await?;
+        Ok(RuntimeConfigBackup {
+            path: backup_path,
+            epoch,
+        })
+    }
+
+    pub async fn restore(&self, backup: &RuntimeConfigBackup) -> Result<Utf8PathBuf, Error> {
+        validate_existing_regular_target(&backup.path).await?;
+        let contents = tokio::fs::read(&backup.path).await?;
+        self.replace(backup.epoch, &contents).await
+    }
+
+    pub async fn remove_backup(&self, backup: RuntimeConfigBackup) -> Result<(), Error> {
+        remove_regular_file(&backup.path).await
+    }
+
+    pub async fn cleanup_epoch(&self, epoch: u64) -> Result<(), Error> {
+        for path in [
+            self.runtime_path(epoch),
+            self.pid_path(epoch),
+            self.socket_path(epoch),
+        ] {
+            remove_regular_file(&path).await?;
+        }
+
+        let prefix = format!("config-{epoch}.yaml.backup-");
+        let temp_prefix = format!(".config-{epoch}.yaml.tmp-");
+        let mut entries = tokio::fs::read_dir(&self.dir).await?;
+        while let Some(entry) = entries.next_entry().await? {
+            let name = entry.file_name();
+            let Some(name) = name.to_str() else {
+                continue;
+            };
+            if name.starts_with(&prefix) || name.starts_with(&temp_prefix) {
+                let path = Utf8PathBuf::from_path_buf(entry.path())
+                    .map_err(|_| Error::UnsafeRuntimeArtifact(self.dir.clone()))?;
+                remove_regular_file(&path).await?;
+            }
+        }
+        sync_parent(&self.dir).await?;
+        Ok(())
+    }
+
+    pub async fn artifact_epochs(&self) -> Result<Vec<u64>, Error> {
+        let mut epochs = Vec::new();
+        let mut entries = tokio::fs::read_dir(&self.dir).await?;
+        while let Some(entry) = entries.next_entry().await? {
+            let Some(name) = entry.file_name().to_str().map(str::to_owned) else {
+                continue;
+            };
+            if let Some(epoch) = artifact_epoch(&name) {
+                epochs.push(epoch);
+            }
+        }
+        epochs.sort_unstable();
+        epochs.dedup();
+        Ok(epochs)
+    }
+
+    async fn validate_staged(&self, staged: &StagedRuntimeConfig, epoch: u64) -> Result<(), Error> {
+        if staged.path.parent() != Some(self.dir.as_path())
+            || !staged
+                .path
+                .file_name()
+                .is_some_and(|name| name.starts_with(&format!(".config-{epoch}.yaml.tmp-")))
+        {
+            return Err(Error::UnsafeRuntimeArtifact(staged.path.clone()));
+        }
+        validate_existing_regular_target(&staged.path).await
+    }
+}
+
+fn artifact_epoch(name: &str) -> Option<u64> {
+    let rest = name
+        .strip_prefix("core-")
+        .and_then(|value| value.strip_suffix(".pid"))
+        .or_else(|| {
+            name.strip_prefix("core-")
+                .and_then(|value| value.strip_suffix(".sock"))
+        })
+        .or_else(|| {
+            name.strip_prefix("config-").and_then(|value| {
+                value
+                    .strip_suffix(".yaml")
+                    .or_else(|| value.split_once(".yaml.backup-").map(|(epoch, _)| epoch))
+            })
+        })
+        .or_else(|| {
+            name.strip_prefix(".config-")
+                .and_then(|value| value.split_once(".yaml.tmp-").map(|(epoch, _)| epoch))
+        })?;
+    rest.parse().ok()
+}
+
+fn validate_directory_metadata(path: &Utf8Path, metadata: &std::fs::Metadata) -> Result<(), Error> {
+    if metadata.file_type().is_symlink() || !metadata.is_dir() || is_reparse_point(metadata) {
+        return Err(Error::UnsafeRuntimeArtifact(path.to_owned()));
+    }
+    Ok(())
+}
+
+async fn validate_absent_regular_target(path: &Utf8Path) -> Result<(), Error> {
+    match tokio::fs::symlink_metadata(path).await {
+        Ok(metadata)
+            if metadata.file_type().is_symlink()
+                || !metadata.is_file()
+                || is_reparse_point(&metadata) =>
+        {
+            Err(Error::UnsafeRuntimeArtifact(path.to_owned()))
+        }
+        Ok(_) => Err(std::io::Error::new(
+            std::io::ErrorKind::AlreadyExists,
+            format!("runtime artifact already exists: {path}"),
+        )
+        .into()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error.into()),
+    }
+}
+
+async fn validate_existing_regular_target(path: &Utf8Path) -> Result<(), Error> {
+    let metadata = tokio::fs::symlink_metadata(path).await?;
+    if metadata.file_type().is_symlink() || !metadata.is_file() || is_reparse_point(&metadata) {
+        return Err(Error::UnsafeRuntimeArtifact(path.to_owned()));
+    }
+    Ok(())
+}
+
+async fn remove_regular_file(path: &Utf8Path) -> Result<(), Error> {
+    match tokio::fs::symlink_metadata(path).await {
+        Ok(metadata)
+            if metadata.file_type().is_symlink()
+                || !metadata.is_file()
+                || is_reparse_point(&metadata) =>
+        {
+            Err(Error::UnsafeRuntimeArtifact(path.to_owned()))
+        }
+        Ok(_) => {
+            tokio::fs::remove_file(path).await?;
+            Ok(())
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error.into()),
+    }
+}
+
+#[cfg(windows)]
+fn is_reparse_point(metadata: &std::fs::Metadata) -> bool {
+    use std::os::windows::fs::MetadataExt;
+    metadata.file_attributes() & 0x400 != 0
+}
+
+#[cfg(not(windows))]
+fn is_reparse_point(_metadata: &std::fs::Metadata) -> bool {
+    false
+}
+
+#[cfg(windows)]
+fn harden_windows_directory_acl(path: &Utf8Path) -> Result<(), Error> {
+    use std::{iter, os::windows::ffi::OsStrExt};
+
+    const SDDL_REVISION_1: u32 = 1;
+    const DACL_SECURITY_INFORMATION: u32 = 0x0000_0004;
+    #[link(name = "Advapi32")]
+    unsafe extern "system" {
+        fn ConvertStringSecurityDescriptorToSecurityDescriptorW(
+            source: *const u16,
+            revision: u32,
+            descriptor: *mut *mut core::ffi::c_void,
+            size: *mut u32,
+        ) -> i32;
+        fn SetFileSecurityW(
+            file_name: *const u16,
+            information: u32,
+            descriptor: *mut core::ffi::c_void,
+        ) -> i32;
+    }
+    #[link(name = "Kernel32")]
+    unsafe extern "system" {
+        fn LocalFree(memory: *mut core::ffi::c_void) -> *mut core::ffi::c_void;
+    }
+
+    let sddl: Vec<u16> = "D:P(A;OICI;FA;;;OW)(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)"
+        .encode_utf16()
+        .chain(iter::once(0))
+        .collect();
+    let path: Vec<u16> = path
+        .as_std_path()
+        .as_os_str()
+        .encode_wide()
+        .chain(iter::once(0))
+        .collect();
+    let mut descriptor = std::ptr::null_mut();
+    // SAFETY: the SDDL string is valid, NUL-terminated UTF-16 and the output
+    // pointer remains owned by LocalAlloc until LocalFree below.
+    if unsafe {
+        ConvertStringSecurityDescriptorToSecurityDescriptorW(
+            sddl.as_ptr(),
+            SDDL_REVISION_1,
+            &mut descriptor,
+            std::ptr::null_mut(),
+        )
+    } == 0
+    {
+        return Err(std::io::Error::last_os_error().into());
+    }
+    // SAFETY: both path and descriptor are valid for the duration of the call.
+    let result = unsafe { SetFileSecurityW(path.as_ptr(), DACL_SECURITY_INFORMATION, descriptor) };
+    // SAFETY: descriptor was allocated by the conversion API above.
+    unsafe { LocalFree(descriptor) };
+    if result == 0 {
+        Err(std::io::Error::last_os_error().into())
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(windows)]
+fn verify_windows_directory_acl(path: &Utf8Path) -> Result<(), Error> {
+    use std::{iter, os::windows::ffi::OsStrExt};
+
+    const SDDL_REVISION_1: u32 = 1;
+    const DACL_SECURITY_INFORMATION: u32 = 0x0000_0004;
+    const SE_DACL_PROTECTED: u16 = 0x1000;
+    #[link(name = "Advapi32")]
+    unsafe extern "system" {
+        fn GetFileSecurityW(
+            file_name: *const u16,
+            information: u32,
+            descriptor: *mut core::ffi::c_void,
+            length: u32,
+            needed: *mut u32,
+        ) -> i32;
+        fn GetSecurityDescriptorControl(
+            descriptor: *const core::ffi::c_void,
+            control: *mut u16,
+            revision: *mut u32,
+        ) -> i32;
+        fn ConvertSecurityDescriptorToStringSecurityDescriptorW(
+            descriptor: *const core::ffi::c_void,
+            revision: u32,
+            information: u32,
+            output: *mut *mut u16,
+            length: *mut u32,
+        ) -> i32;
+    }
+    #[link(name = "Kernel32")]
+    unsafe extern "system" {
+        fn LocalFree(memory: *mut core::ffi::c_void) -> *mut core::ffi::c_void;
+    }
+
+    let path_wide: Vec<u16> = path
+        .as_std_path()
+        .as_os_str()
+        .encode_wide()
+        .chain(iter::once(0))
+        .collect();
+    let mut needed = 0_u32;
+    // SAFETY: null output with length zero is the documented size query.
+    unsafe {
+        GetFileSecurityW(
+            path_wide.as_ptr(),
+            DACL_SECURITY_INFORMATION,
+            std::ptr::null_mut(),
+            0,
+            &mut needed,
+        );
+    }
+    if needed == 0 {
+        return Err(std::io::Error::last_os_error().into());
+    }
+    let words = (needed as usize).div_ceil(std::mem::size_of::<usize>());
+    let mut descriptor = vec![0_usize; words];
+    // SAFETY: descriptor has at least `needed` writable bytes and path is NUL-terminated.
+    if unsafe {
+        GetFileSecurityW(
+            path_wide.as_ptr(),
+            DACL_SECURITY_INFORMATION,
+            descriptor.as_mut_ptr().cast(),
+            needed,
+            &mut needed,
+        )
+    } == 0
+    {
+        return Err(std::io::Error::last_os_error().into());
+    }
+
+    let mut control = 0_u16;
+    let mut revision = 0_u32;
+    // SAFETY: descriptor contains a security descriptor returned by GetFileSecurityW.
+    if unsafe {
+        GetSecurityDescriptorControl(descriptor.as_ptr().cast(), &mut control, &mut revision)
+    } == 0
+    {
+        return Err(std::io::Error::last_os_error().into());
+    }
+    if control & SE_DACL_PROTECTED == 0 {
+        return Err(Error::UnsafeRuntimeArtifact(path.to_owned()));
+    }
+
+    let mut sddl = std::ptr::null_mut();
+    let mut sddl_len = 0_u32;
+    // SAFETY: descriptor is valid; the output is LocalAlloc-owned on success.
+    if unsafe {
+        ConvertSecurityDescriptorToStringSecurityDescriptorW(
+            descriptor.as_ptr().cast(),
+            SDDL_REVISION_1,
+            DACL_SECURITY_INFORMATION,
+            &mut sddl,
+            &mut sddl_len,
+        )
+    } == 0
+    {
+        return Err(std::io::Error::last_os_error().into());
+    }
+    // SAFETY: conversion returned `sddl_len` initialized UTF-16 code units.
+    let text =
+        String::from_utf16_lossy(unsafe { std::slice::from_raw_parts(sddl, sddl_len as usize) });
+    // SAFETY: sddl was allocated by the conversion API above.
+    unsafe { LocalFree(sddl.cast()) };
+    let broad_principals = [";;;WD)", ";;;AU)", ";;;BU)", ";;;IU)", ";;;AN)", ";;;NU)"];
+    if broad_principals
+        .iter()
+        .any(|principal| text.contains(principal))
+    {
+        return Err(Error::UnsafeRuntimeArtifact(path.to_owned()));
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+async fn atomic_move_new(source: &Utf8Path, target: &Utf8Path) -> std::io::Result<()> {
+    // Linking publishes the already-fsynced inode atomically and fails if the
+    // destination appeared after validation; removing the staging name does
+    // not affect readers of the committed target.
+    tokio::fs::hard_link(source, target).await?;
+    tokio::fs::remove_file(source).await
+}
+
+#[cfg(unix)]
+async fn atomic_replace(source: &Utf8Path, target: &Utf8Path) -> std::io::Result<()> {
+    tokio::fs::rename(source, target).await
+}
+
+#[cfg(windows)]
+async fn atomic_move_new(source: &Utf8Path, target: &Utf8Path) -> std::io::Result<()> {
+    windows_move_file(source, target, false)
+}
+
+#[cfg(windows)]
+async fn atomic_replace(source: &Utf8Path, target: &Utf8Path) -> std::io::Result<()> {
+    const RETRIES: usize = 20;
+    for attempt in 0..RETRIES {
+        match windows_replace_file(source, target) {
+            Ok(()) => return Ok(()),
+            Err(error)
+                if matches!(error.raw_os_error(), Some(5 | 32 | 33)) && attempt + 1 < RETRIES =>
+            {
+                tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+            }
+            Err(error) => return Err(error),
+        }
+    }
+    unreachable!("bounded retry loop returns on its final attempt")
+}
+
+#[cfg(windows)]
+fn windows_move_file(source: &Utf8Path, target: &Utf8Path, replace: bool) -> std::io::Result<()> {
+    use std::{iter, os::windows::ffi::OsStrExt};
+
+    const MOVEFILE_REPLACE_EXISTING: u32 = 0x1;
+    const MOVEFILE_WRITE_THROUGH: u32 = 0x8;
+    unsafe extern "system" {
+        fn MoveFileExW(existing: *const u16, new: *const u16, flags: u32) -> i32;
+    }
+    let source: Vec<u16> = source
+        .as_std_path()
+        .as_os_str()
+        .encode_wide()
+        .chain(iter::once(0))
+        .collect();
+    let target: Vec<u16> = target
+        .as_std_path()
+        .as_os_str()
+        .encode_wide()
+        .chain(iter::once(0))
+        .collect();
+    let flags = MOVEFILE_WRITE_THROUGH
+        | if replace {
+            MOVEFILE_REPLACE_EXISTING
+        } else {
+            0
+        };
+    // SAFETY: both arguments are valid, NUL-terminated UTF-16 strings for the duration of the call.
+    if unsafe { MoveFileExW(source.as_ptr(), target.as_ptr(), flags) } == 0 {
+        Err(std::io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(windows)]
+fn windows_replace_file(source: &Utf8Path, target: &Utf8Path) -> std::io::Result<()> {
+    use std::{iter, os::windows::ffi::OsStrExt};
+
+    const REPLACEFILE_WRITE_THROUGH: u32 = 0x1;
+    unsafe extern "system" {
+        fn ReplaceFileW(
+            replaced: *const u16,
+            replacement: *const u16,
+            backup: *const u16,
+            flags: u32,
+            exclude: *mut core::ffi::c_void,
+            reserved: *mut core::ffi::c_void,
+        ) -> i32;
+    }
+    let source: Vec<u16> = source
+        .as_std_path()
+        .as_os_str()
+        .encode_wide()
+        .chain(iter::once(0))
+        .collect();
+    let target: Vec<u16> = target
+        .as_std_path()
+        .as_os_str()
+        .encode_wide()
+        .chain(iter::once(0))
+        .collect();
+    // SAFETY: path arguments are valid NUL-terminated UTF-16 strings; optional pointers are null.
+    if unsafe {
+        ReplaceFileW(
+            target.as_ptr(),
+            source.as_ptr(),
+            std::ptr::null(),
+            REPLACEFILE_WRITE_THROUGH,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+        )
+    } == 0
+    {
+        Err(std::io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(unix)]
+async fn sync_parent(dir: &Utf8Path) -> std::io::Result<()> {
+    let dir = dir.to_owned();
+    tokio::task::spawn_blocking(move || std::fs::File::open(dir)?.sync_all())
+        .await
+        .map_err(std::io::Error::other)?
+}
+
+#[cfg(windows)]
+async fn sync_parent(_dir: &Utf8Path) -> std::io::Result<()> {
+    // MoveFileExW/ReplaceFileW use write-through; opening directories for fsync
+    // is not supported by std on Windows.
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_store_dir() -> (tempfile::TempDir, Utf8PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = Utf8PathBuf::from_path_buf(dir.path().join("runtime")).unwrap();
+        (dir, path)
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn atomic_replace_readers_only_observe_complete_documents() {
+        let (_guard, dir) = temp_store_dir();
+        let store = RuntimeConfigStore::new(dir).await.unwrap();
+        let old = b"marker: old\npayload: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n";
+        let new = b"marker: new\npayload: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n";
+        let staged = store.stage(7, old).await.unwrap();
+        let path = store.commit_new(staged, 7).await.unwrap();
+
+        let mut readers = Vec::new();
+        for _ in 0..8 {
+            let path = path.clone();
+            let old = old.to_vec();
+            let new = new.to_vec();
+            readers.push(tokio::spawn(async move {
+                for _ in 0..500 {
+                    let observed = loop {
+                        match tokio::fs::read(&path).await {
+                            Ok(observed) => break observed,
+                            #[cfg(windows)]
+                            Err(error) if matches!(error.raw_os_error(), Some(2 | 5 | 32 | 33)) => {
+                                tokio::task::yield_now().await;
+                            }
+                            Err(error) => panic!("runtime read failed: {error}"),
+                        }
+                    };
+                    assert!(observed == old || observed == new, "partial YAML observed");
+                    tokio::task::yield_now().await;
+                }
+            }));
+        }
+        for round in 0..100 {
+            store
+                .replace(7, if round % 2 == 0 { new } else { old })
+                .await
+                .unwrap();
+        }
+        for reader in readers {
+            reader.await.unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn backup_restore_and_cleanup_preserve_complete_versions() {
+        let (_guard, dir) = temp_store_dir();
+        let store = RuntimeConfigStore::new(dir).await.unwrap();
+        let staged = store.stage(3, b"value: old\n").await.unwrap();
+        let path = store.commit_new(staged, 3).await.unwrap();
+        let backup = store.backup(3, 1).await.unwrap();
+        store.replace(3, b"value: new\n").await.unwrap();
+        store.restore(&backup).await.unwrap();
+        assert_eq!(
+            tokio::fs::read_to_string(&path).await.unwrap(),
+            "value: old\n"
+        );
+        store.remove_backup(backup).await.unwrap();
+        store.cleanup_epoch(3).await.unwrap();
+        assert!(!path.exists());
+    }
+}

--- a/crates/nyanpasu-core-manager/src/runtime_store.rs
+++ b/crates/nyanpasu-core-manager/src/runtime_store.rs
@@ -851,16 +851,20 @@ mod tests {
             let new = new.to_vec();
             readers.push(tokio::spawn(async move {
                 for _ in 0..500 {
+                    #[cfg(windows)]
                     let observed = loop {
                         match tokio::fs::read(&path).await {
                             Ok(observed) => break observed,
-                            #[cfg(windows)]
                             Err(error) if matches!(error.raw_os_error(), Some(2 | 5 | 32 | 33)) => {
                                 tokio::task::yield_now().await;
                             }
                             Err(error) => panic!("runtime read failed: {error}"),
                         }
                     };
+                    #[cfg(not(windows))]
+                    let observed = tokio::fs::read(&path)
+                        .await
+                        .unwrap_or_else(|error| panic!("runtime read failed: {error}"));
                     assert!(observed == old || observed == new, "partial YAML observed");
                     tokio::task::yield_now().await;
                 }

--- a/crates/nyanpasu-core-manager/src/spec.rs
+++ b/crates/nyanpasu-core-manager/src/spec.rs
@@ -73,10 +73,29 @@ pub enum ControllerMode {
     },
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct ManagerOptions {
     pub controller_mode: ControllerMode,
+    /// Manager-owned runtime artifact directory. Required for Passthrough;
+    /// Managed mode falls back to `derived_dir` for compatibility.
+    pub runtime_dir: Option<Utf8PathBuf>,
+    pub control_timeout: Duration,
+    pub reconcile_timeout: Duration,
+    pub stop_timeout: Duration,
     pub cancel_token: CancellationToken,
+}
+
+impl Default for ManagerOptions {
+    fn default() -> Self {
+        Self {
+            controller_mode: ControllerMode::default(),
+            runtime_dir: None,
+            control_timeout: Duration::from_secs(10),
+            reconcile_timeout: Duration::from_secs(30),
+            stop_timeout: Duration::from_secs(10),
+            cancel_token: CancellationToken::new(),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/nyanpasu-core-manager/src/state.rs
+++ b/crates/nyanpasu-core-manager/src/state.rs
@@ -85,6 +85,33 @@ pub struct ConfigRevision {
     pub runtime_path: Utf8PathBuf,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RevisionId {
+    pub epoch: u64,
+    pub generation: u64,
+    pub effective_hash: String,
+}
+
+impl ConfigRevision {
+    pub fn id(&self) -> RevisionId {
+        RevisionId {
+            epoch: self.epoch,
+            generation: self.generation,
+            effective_hash: self.effective_hash.clone(),
+        }
+    }
+}
+
+impl std::fmt::Display for RevisionId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "epoch {} generation {} ({})",
+            self.epoch, self.generation, self.effective_hash
+        )
+    }
+}
+
 /// Snapshot published on the manager's watch channel.
 #[derive(Debug, Clone)]
 pub struct CoreStatus {

--- a/crates/nyanpasu-core-manager/src/state.rs
+++ b/crates/nyanpasu-core-manager/src/state.rs
@@ -76,6 +76,15 @@ pub struct SpecSummary {
     pub config_path: Utf8PathBuf,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConfigRevision {
+    pub epoch: u64,
+    pub generation: u64,
+    pub source_hash: String,
+    pub effective_hash: String,
+    pub runtime_path: Utf8PathBuf,
+}
+
 /// Snapshot published on the manager's watch channel.
 #[derive(Debug, Clone)]
 pub struct CoreStatus {
@@ -83,8 +92,9 @@ pub struct CoreStatus {
     /// Unix milliseconds of the last state transition (feeds IPC `state_changed_at`).
     pub changed_at: i64,
     pub spec: Option<SpecSummary>,
-    /// The managed controller endpoint, when `ControllerMode::Managed` is active.
+    /// The controller endpoint owned by the active epoch in either mode.
     pub controller: Option<clash_api::Host>,
+    pub revision: Option<ConfigRevision>,
 }
 
 impl CoreStatus {
@@ -94,6 +104,7 @@ impl CoreStatus {
             changed_at: now_ms(),
             spec: None,
             controller: None,
+            revision: None,
         }
     }
 }

--- a/crates/nyanpasu-core-manager/tests/config_apply.rs
+++ b/crates/nyanpasu-core-manager/tests/config_apply.rs
@@ -93,6 +93,35 @@ async fn apply_patch_updates_the_revision_without_restarting() {
 }
 
 #[tokio::test]
+async fn installed_apply_with_parent_sync_failure_reports_real_outcome() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let port = common::free_port();
+    let first = write_named(&dir, "first.yaml", &passthrough_yaml(port, ""));
+    let desired = write_named(
+        &dir,
+        "desired.yaml",
+        &passthrough_yaml(port, "allow-lan: true\n"),
+    );
+    let manager = manager(&dir, Duration::from_secs(1)).await;
+    manager.start(spec(&dir, first)).await.expect("start");
+    let before = running(&manager);
+    manager.inject_runtime_parent_sync_failure_once_for_test();
+
+    let outcome = manager
+        .apply_config(spec(&dir, desired), None)
+        .await
+        .expect("installed apply must reconcile despite sync uncertainty");
+
+    let ApplyOutcome::DurabilityUncertain { outcome, warning } = outcome else {
+        panic!("expected durability wrapper")
+    };
+    assert!(matches!(*outcome, ApplyOutcome::Patched { .. }));
+    assert!(warning.contains("injected"), "{warning}");
+    assert_eq!(running(&manager), before);
+    manager.shutdown().await.expect("shutdown");
+}
+
+#[tokio::test]
 async fn apply_reload_uses_put_without_restarting() {
     let (_guard, dir) = common::utf8_tempdir();
     let port = common::free_port();

--- a/crates/nyanpasu-core-manager/tests/config_apply.rs
+++ b/crates/nyanpasu-core-manager/tests/config_apply.rs
@@ -431,11 +431,14 @@ async fn unconfirmed_replacement_stop_never_cleans_or_reuses_its_epoch() {
         .await
         .expect("construct manager"),
     );
-    manager.start(spec(&dir, first)).await.expect("start");
+    manager
+        .start(spec(&dir, first.clone()))
+        .await
+        .expect("start");
 
     let apply = {
         let manager = manager.clone();
-        let mut desired_spec = spec(&dir, desired);
+        let mut desired_spec = spec(&dir, desired.clone());
         desired_spec.options.startup_timeout = Duration::from_millis(300);
         tokio::spawn(async move { manager.apply_config(desired_spec, None).await })
     };
@@ -447,6 +450,7 @@ async fn unconfirmed_replacement_stop_never_cleans_or_reuses_its_epoch() {
     })
     .await
     .expect("replacement pid record never appeared");
+    let valid_pid_record = std::fs::read_to_string(&rejected_pid).unwrap();
     std::fs::write(&rejected_pid, "identity deliberately unavailable\n").unwrap();
 
     let result = apply.await.unwrap();
@@ -461,4 +465,105 @@ async fn unconfirmed_replacement_stop_never_cleans_or_reuses_its_epoch() {
         manager.status().state,
         CoreState::Stopped { reason: Some(_) }
     ));
+
+    let CoreState::Stopped {
+        reason: Some(reason),
+    } = manager.status().state
+    else {
+        panic!("quarantine was not published")
+    };
+    let status_reason = reason.to_string();
+    assert!(status_reason.contains("quarantin"), "{status_reason}");
+    let start_error = manager
+        .start(spec(&dir, first.clone()))
+        .await
+        .expect_err("quarantine must reject start");
+    assert!(
+        start_error.to_string().contains("quarantin"),
+        "{start_error}"
+    );
+    let apply_error = manager
+        .apply_config(spec(&dir, desired), None)
+        .await
+        .expect_err("quarantine must reject apply");
+    assert!(
+        apply_error.to_string().contains("quarantin"),
+        "{apply_error}"
+    );
+    assert!(matches!(
+        manager.switch(spec(&dir, first.clone())).await,
+        Err(Error::ManagerQuarantined { .. })
+    ));
+    assert!(matches!(
+        manager.restart().await,
+        Err(Error::ManagerQuarantined { .. })
+    ));
+
+    std::fs::write(rejected_pid, valid_pid_record).unwrap();
+    common::wait_port_refused(port).await;
+    manager
+        .recover_quarantine()
+        .await
+        .expect("identity-verified recovery");
+    assert!(!runtime_dir.join("config-2.yaml").exists());
+    manager
+        .start(spec(&dir, first))
+        .await
+        .expect("start after quarantine recovery");
+    manager.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn compensation_publishes_restart_before_replacement_is_ready() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let port = common::free_port();
+    let launches = dir.join("launch-count.txt");
+    let launch_path = launches.as_str().replace('\\', "/");
+    let behavior = format!(
+        "x-fake-core:\n  patch-no-effect: true\n  ready-delay-ms: 700\n  launch-count-file: '{launch_path}'\n  fail-after-launches: 99\n"
+    );
+    let first = write_named(
+        &dir,
+        "first.yaml",
+        &passthrough_yaml(port, &format!("allow-lan: false\n{behavior}")),
+    );
+    let desired = write_named(
+        &dir,
+        "desired.yaml",
+        &passthrough_yaml(port, &format!("allow-lan: true\n{behavior}")),
+    );
+    let manager = std::sync::Arc::new(manager(&dir, Duration::from_secs(1)).await);
+    manager.start(spec(&dir, first)).await.expect("start");
+    let CoreState::Running { pid: old_pid, .. } = manager.status().state else {
+        panic!("initial core not running")
+    };
+
+    let apply = {
+        let manager = manager.clone();
+        tokio::spawn(async move { manager.apply_config(spec(&dir, desired), None).await })
+    };
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            if std::fs::read_to_string(&launches)
+                .ok()
+                .and_then(|value| value.trim().parse::<u64>().ok())
+                == Some(2)
+            {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+    })
+    .await
+    .expect("replacement never launched");
+    assert!(
+        matches!(manager.status().state, CoreState::Restarting { .. }),
+        "dead pid {old_pid} remained published as {:?}",
+        manager.status().state
+    );
+    assert!(matches!(
+        apply.await.unwrap().unwrap(),
+        ApplyOutcome::Restarted { .. }
+    ));
+    manager.shutdown().await.unwrap();
 }

--- a/crates/nyanpasu-core-manager/tests/config_apply.rs
+++ b/crates/nyanpasu-core-manager/tests/config_apply.rs
@@ -224,6 +224,37 @@ async fn failed_desired_restart_restores_and_restarts_the_old_revision() {
 }
 
 #[tokio::test]
+async fn desired_and_rollback_commits_preserve_both_durability_warnings() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let port = common::free_port();
+    let behavior = "x-fake-core:\n  patch-no-effect: true\n  fail-start-when-allow-lan: true\n";
+    let first = write_named(&dir, "first.yaml", &passthrough_yaml(port, behavior));
+    let desired = write_named(
+        &dir,
+        "desired.yaml",
+        &passthrough_yaml(port, &format!("allow-lan: true\n{behavior}")),
+    );
+    let manager = manager(&dir, Duration::from_secs(1)).await;
+    manager.start(spec(&dir, first)).await.expect("start");
+    manager.inject_runtime_parent_sync_failure_once_for_test();
+    manager.inject_runtime_parent_sync_failure_once_for_test();
+
+    let outcome = manager
+        .apply_config(spec(&dir, desired), None)
+        .await
+        .expect("rollback succeeds despite both durability warnings");
+
+    let ApplyOutcome::DurabilityUncertain { outcome, .. } = outcome else {
+        panic!("desired commit warning was lost")
+    };
+    let ApplyOutcome::DurabilityUncertain { outcome, .. } = *outcome else {
+        panic!("rollback commit warning was lost")
+    };
+    assert!(matches!(*outcome, ApplyOutcome::RolledBack { .. }));
+    manager.shutdown().await.expect("shutdown");
+}
+
+#[tokio::test]
 async fn revision_conflict_has_zero_process_file_and_status_side_effects() {
     let (_guard, dir) = common::utf8_tempdir();
     let port = common::free_port();

--- a/crates/nyanpasu-core-manager/tests/config_apply.rs
+++ b/crates/nyanpasu-core-manager/tests/config_apply.rs
@@ -1,0 +1,395 @@
+mod common;
+
+use std::time::Duration;
+
+use nyanpasu_core_manager::{
+    ApplyOutcome, CoreManager, CoreState, Error, InstanceSpec, ManagerOptions, RevisionId,
+};
+
+async fn manager(dir: &camino::Utf8Path, control_timeout: Duration) -> CoreManager {
+    CoreManager::new(ManagerOptions {
+        runtime_dir: Some(dir.join("runtime")),
+        control_timeout,
+        reconcile_timeout: Duration::from_secs(5),
+        ..ManagerOptions::default()
+    })
+    .await
+    .expect("construct manager")
+}
+
+fn write_named(dir: &camino::Utf8Path, name: &str, body: &str) -> camino::Utf8PathBuf {
+    let path = dir.join(name);
+    std::fs::write(&path, body).expect("write config");
+    path
+}
+
+fn running(manager: &CoreManager) -> (u64, u32) {
+    match manager.status().state {
+        CoreState::Running { epoch, pid } => (epoch, pid),
+        state => panic!("expected running, got {state:?}"),
+    }
+}
+
+fn spec(dir: &camino::Utf8Path, path: camino::Utf8PathBuf) -> InstanceSpec {
+    common::mihomo_spec(dir, path)
+}
+
+fn passthrough_yaml(port: u16, extra: &str) -> String {
+    format!("external-controller: 127.0.0.1:{port}\nmode: rule\n{extra}")
+}
+
+#[tokio::test]
+async fn apply_noop_keeps_the_current_revision_and_process() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let port = common::free_port();
+    let body = passthrough_yaml(port, "rules:\n  - MATCH,DIRECT\n");
+    let first = write_named(&dir, "first.yaml", &body);
+    let reordered = write_named(
+        &dir,
+        "same.yaml",
+        &format!("rules: ['MATCH,DIRECT']\nexternal-controller: 127.0.0.1:{port}\nmode: rule\n"),
+    );
+    let manager = manager(&dir, Duration::from_secs(1)).await;
+    manager.start(spec(&dir, first)).await.expect("start");
+    let before_process = running(&manager);
+    let before_revision = manager.status().revision.expect("revision");
+
+    let outcome = manager
+        .apply_config(spec(&dir, reordered), Some(before_revision.id()))
+        .await
+        .expect("apply noop");
+
+    assert!(matches!(outcome, ApplyOutcome::Noop { .. }));
+    assert_eq!(running(&manager), before_process);
+    assert_eq!(manager.status().revision, Some(before_revision));
+    manager.shutdown().await.expect("shutdown");
+}
+
+#[tokio::test]
+async fn apply_patch_updates_the_revision_without_restarting() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let port = common::free_port();
+    let first = write_named(&dir, "first.yaml", &passthrough_yaml(port, ""));
+    let desired = write_named(
+        &dir,
+        "desired.yaml",
+        &passthrough_yaml(port, "allow-lan: true\n"),
+    );
+    let manager = manager(&dir, Duration::from_secs(1)).await;
+    manager.start(spec(&dir, first)).await.expect("start");
+    let before = running(&manager);
+
+    let outcome = manager
+        .apply_config(spec(&dir, desired), None)
+        .await
+        .expect("patch");
+
+    let ApplyOutcome::Patched { revision } = outcome else {
+        panic!("expected Patched")
+    };
+    assert_eq!(running(&manager), before);
+    assert_eq!(revision.generation, 2);
+    manager.shutdown().await.expect("shutdown");
+}
+
+#[tokio::test]
+async fn apply_reload_uses_put_without_restarting() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let port = common::free_port();
+    let first = write_named(
+        &dir,
+        "first.yaml",
+        &passthrough_yaml(port, "rules:\n  - MATCH,DIRECT\n"),
+    );
+    let desired = write_named(
+        &dir,
+        "desired.yaml",
+        &passthrough_yaml(port, "rules:\n  - MATCH,REJECT\n"),
+    );
+    let manager = manager(&dir, Duration::from_secs(1)).await;
+    manager.start(spec(&dir, first)).await.expect("start");
+    let before = running(&manager);
+
+    let outcome = manager
+        .apply_config(spec(&dir, desired), None)
+        .await
+        .expect("reload");
+
+    assert!(
+        matches!(outcome, ApplyOutcome::Reloaded { .. }),
+        "got {outcome:?}"
+    );
+    assert_eq!(running(&manager), before);
+    manager.shutdown().await.expect("shutdown");
+}
+
+#[tokio::test]
+async fn apply_unknown_change_restarts_to_the_committed_desired_config() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let port = common::free_port();
+    let first = write_named(
+        &dir,
+        "first.yaml",
+        &passthrough_yaml(port, "x-setting: old\n"),
+    );
+    let desired = write_named(
+        &dir,
+        "desired.yaml",
+        &passthrough_yaml(port, "x-setting: new\n"),
+    );
+    let manager = manager(&dir, Duration::from_secs(1)).await;
+    manager.start(spec(&dir, first)).await.expect("start");
+    let before = running(&manager);
+
+    let outcome = manager
+        .apply_config(spec(&dir, desired), None)
+        .await
+        .expect("restart");
+
+    assert!(matches!(outcome, ApplyOutcome::Restarted { .. }));
+    let after = running(&manager);
+    assert!(after.0 > before.0, "switch-class change gets a new epoch");
+    assert_ne!(after.1, before.1);
+    manager.shutdown().await.expect("shutdown");
+}
+
+#[tokio::test]
+async fn failed_desired_restart_restores_and_restarts_the_old_revision() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let port = common::free_port();
+    let behavior = "x-fake-core:\n  patch-no-effect: true\n  fail-start-when-allow-lan: true\n";
+    let first = write_named(&dir, "first.yaml", &passthrough_yaml(port, behavior));
+    let desired = write_named(
+        &dir,
+        "desired.yaml",
+        &passthrough_yaml(port, &format!("allow-lan: true\n{behavior}")),
+    );
+    let manager = manager(&dir, Duration::from_secs(1)).await;
+    manager.start(spec(&dir, first)).await.expect("start");
+    let old_revision = manager.status().revision.expect("old revision");
+
+    let outcome = manager
+        .apply_config(spec(&dir, desired), None)
+        .await
+        .expect("rollback succeeds");
+
+    let ApplyOutcome::RolledBack {
+        revision,
+        failed_apply,
+    } = outcome
+    else {
+        panic!("expected RolledBack")
+    };
+    assert_eq!(revision, old_revision);
+    assert!(!failed_apply.is_empty());
+    let restored: serde_yaml_ng::Mapping =
+        serde_yaml_ng::from_str(&std::fs::read_to_string(&revision.runtime_path).unwrap()).unwrap();
+    assert_ne!(
+        restored
+            .get(serde_yaml_ng::Value::String("allow-lan".into()))
+            .and_then(serde_yaml_ng::Value::as_bool),
+        Some(true)
+    );
+    assert!(matches!(manager.status().state, CoreState::Running { .. }));
+    manager.shutdown().await.expect("shutdown");
+}
+
+#[tokio::test]
+async fn revision_conflict_has_zero_process_file_and_status_side_effects() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let port = common::free_port();
+    let first = write_named(&dir, "first.yaml", &passthrough_yaml(port, ""));
+    let desired = write_named(
+        &dir,
+        "desired.yaml",
+        &passthrough_yaml(port, "allow-lan: true\n"),
+    );
+    let manager = manager(&dir, Duration::from_secs(1)).await;
+    manager.start(spec(&dir, first)).await.expect("start");
+    let before_status = manager.status();
+    let before_runtime = std::fs::read(
+        &before_status
+            .revision
+            .as_ref()
+            .expect("revision")
+            .runtime_path,
+    )
+    .unwrap();
+    let mut stale = before_status.revision.as_ref().unwrap().id();
+    stale.generation += 1;
+
+    let error = manager
+        .apply_config(spec(&dir, desired), Some(stale))
+        .await
+        .expect_err("CAS conflict");
+
+    assert!(matches!(error, Error::RevisionConflict { .. }));
+    assert_eq!(manager.status().revision, before_status.revision);
+    assert_eq!(manager.status().state, before_status.state);
+    assert_eq!(
+        running(&manager),
+        match before_status.state {
+            CoreState::Running { epoch, pid } => (epoch, pid),
+            _ => unreachable!(),
+        }
+    );
+    assert_eq!(
+        std::fs::read(manager.status().revision.unwrap().runtime_path).unwrap(),
+        before_runtime
+    );
+    manager.shutdown().await.expect("shutdown");
+}
+
+#[tokio::test]
+async fn patch_timeout_with_verified_effect_does_not_restart() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let port = common::free_port();
+    let behavior = "x-fake-core:\n  patch-delay-ms: 250\n";
+    let first = write_named(&dir, "first.yaml", &passthrough_yaml(port, behavior));
+    let desired = write_named(
+        &dir,
+        "desired.yaml",
+        &passthrough_yaml(port, &format!("allow-lan: true\n{behavior}")),
+    );
+    let manager = manager(&dir, Duration::from_millis(50)).await;
+    manager.start(spec(&dir, first)).await.expect("start");
+    let before = running(&manager);
+
+    let outcome = manager
+        .apply_config(spec(&dir, desired), None)
+        .await
+        .expect("verified timed-out patch");
+
+    assert!(matches!(outcome, ApplyOutcome::Patched { .. }));
+    assert_eq!(
+        running(&manager),
+        before,
+        "verified effect must avoid restart"
+    );
+    manager.shutdown().await.expect("shutdown");
+}
+
+#[tokio::test]
+async fn patch_success_with_get_mismatch_restarts_desired() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let port = common::free_port();
+    let behavior = "x-fake-core:\n  patch-no-effect: true\n";
+    let first = write_named(&dir, "first.yaml", &passthrough_yaml(port, behavior));
+    let desired = write_named(
+        &dir,
+        "desired.yaml",
+        &passthrough_yaml(port, &format!("allow-lan: true\n{behavior}")),
+    );
+    let manager = manager(&dir, Duration::from_secs(1)).await;
+    manager.start(spec(&dir, first)).await.expect("start");
+    let before = running(&manager);
+
+    let outcome = manager
+        .apply_config(spec(&dir, desired), None)
+        .await
+        .expect("restart desired");
+
+    assert!(matches!(outcome, ApplyOutcome::Restarted { .. }));
+    assert_ne!(running(&manager).1, before.1);
+    manager.shutdown().await.expect("shutdown");
+}
+
+#[test]
+fn revision_id_is_an_explicit_cas_token() {
+    let token = RevisionId {
+        epoch: 4,
+        generation: 8,
+        effective_hash: "hash".into(),
+    };
+    assert_eq!(token.epoch, 4);
+}
+
+#[tokio::test]
+async fn source_mutation_during_staged_check_cannot_change_the_apply() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let port = common::free_port();
+    let behavior = "x-fake-core:\n  check-delay-ms: 300\n";
+    let first = write_named(
+        &dir,
+        "first.yaml",
+        &passthrough_yaml(port, &format!("x-setting: old\n{behavior}")),
+    );
+    let desired = write_named(
+        &dir,
+        "desired.yaml",
+        &passthrough_yaml(port, &format!("x-setting: desired\n{behavior}")),
+    );
+    let manager = std::sync::Arc::new(manager(&dir, Duration::from_secs(1)).await);
+    manager
+        .start(spec(&dir, first))
+        .await
+        .expect("start delayed-check config");
+
+    let apply = {
+        let manager = manager.clone();
+        let apply_spec = spec(&dir, desired.clone());
+        tokio::spawn(async move { manager.apply_config(apply_spec, None).await })
+    };
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    std::fs::write(
+        &desired,
+        passthrough_yaml(port, "x-setting: mutated\nx-fake-core:\n  exit-code: 91\n"),
+    )
+    .unwrap();
+
+    let outcome = apply.await.unwrap().expect("snapshot apply");
+    assert!(matches!(outcome, ApplyOutcome::Restarted { .. }));
+    let runtime =
+        std::fs::read_to_string(manager.status().revision.expect("revision").runtime_path).unwrap();
+    assert!(runtime.contains("x-setting: desired"));
+    assert!(!runtime.contains("exit-code"));
+    assert!(matches!(manager.status().state, CoreState::Running { .. }));
+    manager.shutdown().await.expect("shutdown");
+}
+
+#[tokio::test]
+async fn desired_and_rollback_restart_failures_report_both_errors() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let port = common::free_port();
+    let counter = dir.join("launch-count.txt");
+    let behavior = format!(
+        "x-fake-core:\n  launch-count-file: '{}'\n  fail-after-launches: 1\n",
+        counter.as_str().replace('\\', "/")
+    );
+    let first = write_named(
+        &dir,
+        "first.yaml",
+        &passthrough_yaml(port, &format!("x-setting: old\n{behavior}")),
+    );
+    let desired = write_named(
+        &dir,
+        "desired.yaml",
+        &passthrough_yaml(
+            port,
+            &format!("x-setting: desired\n{behavior}  exit-code: 23\n"),
+        ),
+    );
+    let manager = manager(&dir, Duration::from_secs(1)).await;
+    manager
+        .start(spec(&dir, first))
+        .await
+        .expect("initial start");
+
+    let error = manager
+        .apply_config(spec(&dir, desired), None)
+        .await
+        .expect_err("both restart attempts fail");
+
+    let Error::ApplyRollbackFailed { apply, rollback } = error else {
+        panic!("expected combined error")
+    };
+    assert!(!apply.is_empty() && !rollback.is_empty());
+    let CoreState::Stopped {
+        reason: Some(reason),
+    } = manager.status().state
+    else {
+        panic!("expected terminal error state")
+    };
+    let text = reason.to_string();
+    assert!(text.contains("rollback also failed"), "{text}");
+}

--- a/crates/nyanpasu-core-manager/tests/config_apply.rs
+++ b/crates/nyanpasu-core-manager/tests/config_apply.rs
@@ -393,3 +393,72 @@ async fn desired_and_rollback_restart_failures_report_both_errors() {
     let text = reason.to_string();
     assert!(text.contains("rollback also failed"), "{text}");
 }
+
+#[tokio::test]
+async fn unconfirmed_replacement_stop_never_cleans_or_reuses_its_epoch() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let runtime_dir = dir.join("runtime");
+    let port = common::free_port();
+    let counter = dir.join("launch-count.txt");
+    let counter_path = counter.as_str().replace('\\', "/");
+    let first = write_named(
+        &dir,
+        "first.yaml",
+        &passthrough_yaml(
+            port,
+            &format!(
+                "x-setting: old\nx-fake-core:\n  launch-count-file: '{counter_path}'\n  fail-after-launches: 99\n"
+            ),
+        ),
+    );
+    let desired = write_named(
+        &dir,
+        "desired.yaml",
+        &passthrough_yaml(
+            port,
+            &format!(
+                "x-setting: desired\nx-fake-core:\n  launch-count-file: '{counter_path}'\n  fail-after-launches: 99\n  never-ready: true\n"
+            ),
+        ),
+    );
+    let manager = std::sync::Arc::new(
+        CoreManager::new(ManagerOptions {
+            runtime_dir: Some(runtime_dir.clone()),
+            stop_timeout: Duration::from_secs(1),
+            reconcile_timeout: Duration::from_secs(3),
+            ..ManagerOptions::default()
+        })
+        .await
+        .expect("construct manager"),
+    );
+    manager.start(spec(&dir, first)).await.expect("start");
+
+    let apply = {
+        let manager = manager.clone();
+        let mut desired_spec = spec(&dir, desired);
+        desired_spec.options.startup_timeout = Duration::from_millis(300);
+        tokio::spawn(async move { manager.apply_config(desired_spec, None).await })
+    };
+    let rejected_pid = runtime_dir.join("core-2.pid");
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while !tokio::fs::try_exists(&rejected_pid).await.unwrap() {
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+    })
+    .await
+    .expect("replacement pid record never appeared");
+    std::fs::write(&rejected_pid, "identity deliberately unavailable\n").unwrap();
+
+    let result = apply.await.unwrap();
+    assert!(
+        matches!(result, Err(Error::StopUnconfirmed(_))),
+        "unexpected compensation result: {result:?}"
+    );
+    assert!(runtime_dir.join("config-2.yaml").exists());
+    assert!(rejected_pid.exists());
+    assert_eq!(std::fs::read_to_string(counter).unwrap().trim(), "2");
+    assert!(matches!(
+        manager.status().state,
+        CoreState::Stopped { reason: Some(_) }
+    ));
+}

--- a/crates/nyanpasu-core-manager/tests/graceful_switch.rs
+++ b/crates/nyanpasu-core-manager/tests/graceful_switch.rs
@@ -24,7 +24,7 @@ fn unique_template() -> Option<String> {
     }
 }
 
-fn managed_manager(derived_dir: camino::Utf8PathBuf) -> CoreManager {
+async fn managed_manager(derived_dir: camino::Utf8PathBuf) -> CoreManager {
     CoreManager::new(ManagerOptions {
         controller_mode: ControllerMode::Managed {
             derived_dir,
@@ -32,6 +32,8 @@ fn managed_manager(derived_dir: camino::Utf8PathBuf) -> CoreManager {
         },
         ..Default::default()
     })
+    .await
+    .expect("construct manager")
 }
 
 #[tokio::test]
@@ -40,13 +42,13 @@ async fn managed_start_injects_the_epoch_endpoint_and_advertises_it() {
     let derived_dir = dir.join("derived");
     // Stale artifacts from a "previous run" must be swept by CoreManager::new.
     std::fs::create_dir_all(&derived_dir).unwrap();
-    std::fs::write(derived_dir.join("epoch-99.yaml"), "stale").unwrap();
+    std::fs::write(derived_dir.join("config-99.yaml"), "stale").unwrap();
 
     // No external-controller in the user config — Managed mode injects one.
     let config = common::write_config(&dir, "mixed-port: 0\n");
-    let manager = managed_manager(derived_dir.clone());
+    let manager = managed_manager(derived_dir.clone()).await;
     assert!(
-        !derived_dir.join("epoch-99.yaml").exists(),
+        !derived_dir.join("config-99.yaml").exists(),
         "stale derived config swept on construction"
     );
 
@@ -62,11 +64,11 @@ async fn managed_start_injects_the_epoch_endpoint_and_advertises_it() {
         endpoint.contains('1'),
         "endpoint should embed the epoch: {endpoint}"
     );
-    assert!(derived_dir.join("epoch-1.yaml").exists());
+    assert!(derived_dir.join("config-100.yaml").exists());
 
     manager.shutdown().await.expect("shutdown");
     assert!(
-        !derived_dir.join("epoch-1.yaml").exists(),
+        !derived_dir.join("config-100.yaml").exists(),
         "derived config removed after shutdown"
     );
     let _ = Duration::ZERO;
@@ -77,7 +79,7 @@ async fn managed_spawn_error_removes_secret_derived_config() {
     let (_guard, dir) = common::utf8_tempdir();
     let derived_dir = dir.join("derived");
     let config = common::write_config(&dir, "mixed-port: 0\nsecret: test-secret\n");
-    let manager = managed_manager(derived_dir.clone());
+    let manager = managed_manager(derived_dir.clone()).await;
     let mut spec = common::mihomo_spec(&dir, config);
     spec.core.kind = CoreKind::Meow;
 
@@ -93,7 +95,7 @@ async fn managed_spawn_error_removes_secret_derived_config() {
         }
     ));
     assert!(
-        !derived_dir.join("epoch-1.yaml").exists(),
+        !derived_dir.join("config-1.yaml").exists(),
         "secret-bearing derived config must be removed"
     );
 }
@@ -109,7 +111,7 @@ async fn stop_cleans_derived_config_for_terminal_instance() {
             "mixed-port: 0\nx-fake-core:\n  crash-after-ms: 100\n  crash-times: 99\n  state-file: {state_file}\n"
         ),
     );
-    let manager = managed_manager(derived_dir.clone());
+    let manager = managed_manager(derived_dir.clone()).await;
     let mut rx = manager.subscribe();
 
     manager
@@ -134,12 +136,12 @@ async fn stop_cleans_derived_config_for_terminal_instance() {
     .expect("core never exhausted its restart budget");
 
     assert!(
-        derived_dir.join("epoch-1.yaml").exists(),
+        derived_dir.join("config-1.yaml").exists(),
         "derived config must exist before terminal stop cleanup"
     );
     assert!(matches!(manager.stop().await, Err(Error::NotStarted)));
     assert!(
-        !derived_dir.join("epoch-1.yaml").exists(),
+        !derived_dir.join("config-1.yaml").exists(),
         "derived config must be removed after terminal stop"
     );
     manager.shutdown().await.expect("shutdown");
@@ -164,12 +166,12 @@ async fn graceful_switch_overlaps_and_restores_listeners() {
     )
     .unwrap();
 
-    let manager = managed_manager(derived_dir.clone());
+    let manager = managed_manager(derived_dir.clone()).await;
     manager
         .start(common::mihomo_spec(&dir, config_a))
         .await
         .expect("start A");
-    assert!(derived_dir.join("epoch-1.yaml").exists());
+    assert!(derived_dir.join("config-1.yaml").exists());
     tokio::net::TcpStream::connect(("127.0.0.1", mixed))
         .await
         .expect("A holds the mixed port");
@@ -188,7 +190,7 @@ async fn graceful_switch_overlaps_and_restores_listeners() {
 
     let mut spec_b = common::mihomo_spec(&dir, config_b_path.clone());
     spec_b.config_path = config_b_path;
-    let outcome = manager.switch(spec_b).await.expect("switch");
+    let outcome = manager.switch(spec_b.clone()).await.expect("switch");
     assert_eq!(outcome, SwitchOutcome::Graceful);
     recorder.abort();
 
@@ -218,16 +220,29 @@ async fn graceful_switch_overlaps_and_restores_listeners() {
         .await
         .expect("B serves the mixed port after the switch");
 
-    let CoreState::Running { epoch, .. } = manager.status().state else {
+    let status = manager.status();
+    let CoreState::Running { epoch, .. } = status.state else {
         panic!("not running after switch")
     };
     assert_eq!(epoch, 2);
+    assert_eq!(
+        status
+            .spec
+            .as_ref()
+            .map(|summary| summary.config_path.clone()),
+        Some(spec_b.config_path)
+    );
+    assert_eq!(
+        status.revision.as_ref().map(|revision| revision.epoch),
+        Some(2)
+    );
+    assert!(status.controller.is_some());
     assert!(
-        !derived_dir.join("epoch-1.yaml").exists(),
+        !derived_dir.join("config-1.yaml").exists(),
         "old derived config must be removed after switch"
     );
     assert!(
-        derived_dir.join("epoch-2.yaml").exists(),
+        derived_dir.join("config-2.yaml").exists(),
         "new derived config must remain active"
     );
     manager.shutdown().await.expect("shutdown");
@@ -240,13 +255,13 @@ async fn managed_hard_switch_removes_old_derived_config() {
     let config_a = common::write_config(&dir, "mixed-port: 0\n");
     let config_b_path = dir.join("config-b.yaml");
     std::fs::write(&config_b_path, "dns:\n  listen: 127.0.0.1:0\n").unwrap();
-    let manager = managed_manager(derived_dir.clone());
+    let manager = managed_manager(derived_dir.clone()).await;
 
     manager
         .start(common::mihomo_spec(&dir, config_a))
         .await
         .expect("start A");
-    assert!(derived_dir.join("epoch-1.yaml").exists());
+    assert!(derived_dir.join("config-1.yaml").exists());
 
     let outcome = manager
         .switch(common::mihomo_spec(&dir, config_b_path))
@@ -259,10 +274,10 @@ async fn managed_hard_switch_removes_old_derived_config() {
         }
     );
     assert!(
-        !derived_dir.join("epoch-1.yaml").exists(),
+        !derived_dir.join("config-1.yaml").exists(),
         "old derived config must be removed after hard switch"
     );
-    assert!(derived_dir.join("epoch-2.yaml").exists());
+    assert!(derived_dir.join("config-2.yaml").exists());
     assert!(matches!(
         manager.status().state,
         CoreState::Running { epoch: 2, .. }
@@ -277,8 +292,8 @@ async fn derive_failure_republishes_old_running_state() {
     let mixed = common::free_port();
     let config_a = common::write_config(&dir, &format!("mixed-port: {mixed}\n"));
     let config_b_path = dir.join("config-b.yaml");
-    std::fs::write(&config_b_path, format!("mixed-port: {mixed}\n")).unwrap();
-    let manager = managed_manager(derived_dir.clone());
+    std::fs::write(&config_b_path, format!("mixed-port: {mixed}\n1: invalid\n")).unwrap();
+    let manager = managed_manager(derived_dir.clone()).await;
 
     manager
         .start(common::mihomo_spec(&dir, config_a))
@@ -292,17 +307,11 @@ async fn derive_failure_republishes_old_running_state() {
         panic!("not running")
     };
 
-    for entry in std::fs::read_dir(&derived_dir).unwrap() {
-        std::fs::remove_file(entry.unwrap().path()).unwrap();
-    }
-    std::fs::remove_dir(&derived_dir).unwrap();
-    std::fs::write(&derived_dir, "not a directory").unwrap();
-
     let error = manager
         .switch(common::mihomo_spec(&dir, config_b_path))
         .await
         .expect_err("derive must fail");
-    assert!(matches!(error, Error::Io(_)), "got {error}");
+    assert!(matches!(error, Error::InvalidConfig(_)), "got {error}");
     assert_eq!(
         manager.status().state,
         CoreState::Running {
@@ -324,7 +333,7 @@ async fn failed_new_core_while_old_restarting_republishes_actual_state() {
     let config_a = common::write_config(
         &dir,
         &format!(
-            "mixed-port: 0\nx-fake-core:\n  crash-after-ms: 100\n  crash-times: 1\n  state-file: {state_file}\n"
+            "mixed-port: 0\nx-fake-core:\n  crash-after-ms: 400\n  crash-times: 1\n  state-file: {state_file}\n"
         ),
     );
     let config_b_path = dir.join("config-b.yaml");
@@ -336,7 +345,10 @@ async fn failed_new_core_while_old_restarting_republishes_actual_state() {
             controller_template: unique_template(),
         },
         cancel_token: cancel_token.clone(),
-    });
+        ..Default::default()
+    })
+    .await
+    .expect("construct manager");
     let mut spec_a = common::mihomo_spec(&dir, config_a);
     spec_a.options.backoff = nyanpasu_utils::process::Backoff::exponential(
         Duration::from_secs(60),
@@ -399,7 +411,7 @@ async fn failed_new_core_rolls_back_without_touching_the_old_one() {
     let config_b_path = dir.join("config-b.yaml");
     std::fs::write(&config_b_path, "x-fake-core:\n  never-ready: true\n").unwrap();
 
-    let manager = managed_manager(dir.join("derived"));
+    let manager = managed_manager(dir.join("derived")).await;
     manager
         .start(common::mihomo_spec(&dir, config_a))
         .await
@@ -442,7 +454,7 @@ async fn rejected_patch_falls_back_to_a_hard_restart() {
     )
     .unwrap();
 
-    let manager = managed_manager(dir.join("derived"));
+    let manager = managed_manager(dir.join("derived")).await;
     manager
         .start(common::mihomo_spec(&dir, config_a))
         .await

--- a/crates/nyanpasu-core-manager/tests/graceful_switch.rs
+++ b/crates/nyanpasu-core-manager/tests/graceful_switch.rs
@@ -108,7 +108,7 @@ async fn stop_cleans_derived_config_for_terminal_instance() {
     let config = common::write_config(
         &dir,
         &format!(
-            "mixed-port: 0\nx-fake-core:\n  crash-after-ms: 100\n  crash-times: 99\n  state-file: {state_file}\n"
+            "mixed-port: 0\nx-fake-core:\n  crash-after-ms: 500\n  crash-times: 99\n  state-file: {state_file}\n"
         ),
     );
     let manager = managed_manager(derived_dir.clone()).await;
@@ -245,6 +245,258 @@ async fn graceful_switch_overlaps_and_restores_listeners() {
         derived_dir.join("config-2.yaml").exists(),
         "new derived config must remain active"
     );
+    manager.shutdown().await.expect("shutdown");
+}
+
+#[tokio::test]
+async fn graceful_respawn_loads_the_full_committed_runtime_config() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let derived_dir = dir.join("derived");
+    let ports = std::array::from_fn::<_, 5, _>(|_| common::free_port());
+    let [port, socks, redir, tproxy, mixed] = ports;
+    let config_a = common::write_config(&dir, &format!("mixed-port: {mixed}\n"));
+    let config_b = dir.join("config-b.yaml");
+    std::fs::write(
+        &config_b,
+        format!(
+            "port: {port}\nsocks-port: {socks}\nredir-port: {redir}\ntproxy-port: {tproxy}\nmixed-port: {mixed}\ntun:\n  enable: true\n"
+        ),
+    )
+    .unwrap();
+
+    let manager = managed_manager(derived_dir.clone()).await;
+    manager
+        .start(common::mihomo_spec(&dir, config_a))
+        .await
+        .expect("start old core");
+    manager
+        .switch(common::mihomo_spec(&dir, config_b))
+        .await
+        .expect("graceful switch");
+
+    let mut status_rx = manager.subscribe();
+    let status = manager.status();
+    let CoreState::Running {
+        epoch,
+        pid: first_pid,
+    } = status.state
+    else {
+        panic!("new core is not running")
+    };
+    assert_eq!(epoch, 2);
+    nyanpasu_utils::os::kill_pid::<String>(first_pid, None)
+        .await
+        .expect("kill new core process");
+
+    let second_pid = tokio::time::timeout(Duration::from_secs(10), async {
+        loop {
+            let state = status_rx.borrow_and_update().state.clone();
+            if let CoreState::Running { epoch: 2, pid } = state
+                && pid != first_pid
+            {
+                break pid;
+            }
+            status_rx.changed().await.expect("status channel open");
+        }
+    })
+    .await
+    .expect("new core did not respawn");
+    assert_ne!(second_pid, first_pid);
+
+    tokio::net::TcpStream::connect(("127.0.0.1", mixed))
+        .await
+        .expect("respawn restored mixed-port");
+    let client = clash_api::Client::builder(manager.status().controller.unwrap())
+        .build()
+        .unwrap();
+    let runtime = client.configs().await.expect("GET respawned config");
+    assert_eq!(runtime.port, i64::from(port));
+    assert_eq!(runtime.socks_port, i64::from(socks));
+    assert_eq!(runtime.redir_port, i64::from(redir));
+    assert_eq!(runtime.tproxy_port, i64::from(tproxy));
+    assert_eq!(runtime.mixed_port, i64::from(mixed));
+    assert!(runtime.tun.enable, "respawn must restore TUN enablement");
+
+    let runtime_file = std::fs::read_to_string(derived_dir.join("config-2.yaml")).unwrap();
+    assert!(runtime_file.contains(&format!("port: {port}")));
+    assert!(runtime_file.contains(&format!("socks-port: {socks}")));
+    assert!(runtime_file.contains(&format!("redir-port: {redir}")));
+    assert!(runtime_file.contains(&format!("tproxy-port: {tproxy}")));
+    assert!(runtime_file.contains(&format!("mixed-port: {mixed}")));
+    assert!(runtime_file.contains("enable: true"));
+    manager.shutdown().await.expect("shutdown");
+}
+
+#[tokio::test]
+async fn graceful_success_publishes_only_the_new_epoch_context() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let derived_dir = dir.join("derived");
+    let mixed = common::free_port();
+    let config_a = common::write_config(&dir, &format!("mixed-port: {mixed}\n"));
+    let config_b = dir.join("config-b.yaml");
+    std::fs::write(&config_b, format!("mixed-port: {mixed}\n")).unwrap();
+    let manager = managed_manager(derived_dir).await;
+    manager
+        .start(common::mihomo_spec(&dir, config_a))
+        .await
+        .expect("start old core");
+    let old_controller = manager.status().controller.expect("old controller");
+    let mut status_rx = manager.subscribe();
+    let observed = Arc::new(Mutex::new(Vec::new()));
+    let observed_ = observed.clone();
+    let recorder = tokio::spawn(async move {
+        while status_rx.changed().await.is_ok() {
+            observed_.lock().push(status_rx.borrow_and_update().clone());
+        }
+    });
+
+    let spec_b = common::mihomo_spec(&dir, config_b.clone());
+    manager
+        .switch(spec_b.clone())
+        .await
+        .expect("graceful switch");
+    recorder.abort();
+    let _ = recorder.await;
+
+    let status = manager.status();
+    let new_controller = status.controller.clone().expect("new controller");
+    assert_ne!(format!("{new_controller:?}"), format!("{old_controller:?}"));
+    assert_eq!(
+        status.spec.as_ref().map(|spec| spec.config_path.clone()),
+        Some(spec_b.config_path)
+    );
+    assert_eq!(
+        status.revision.as_ref().map(|revision| revision.epoch),
+        Some(2)
+    );
+    assert!(matches!(status.state, CoreState::Running { epoch: 2, .. }));
+    for status in observed.lock().iter() {
+        let published_epoch = match status.state {
+            CoreState::Running { epoch, .. }
+            | CoreState::Starting { epoch }
+            | CoreState::Restarting { epoch, .. }
+            | CoreState::Stopping { epoch } => Some(epoch),
+            CoreState::Switching { to, .. } => Some(to),
+            CoreState::Stopped { .. } => None,
+            _ => None,
+        };
+        if published_epoch == Some(2) {
+            assert_eq!(status.controller.as_ref(), Some(&new_controller));
+            assert_eq!(
+                status.revision.as_ref().map(|revision| revision.epoch),
+                Some(2)
+            );
+        }
+    }
+    manager.shutdown().await.expect("shutdown");
+}
+
+#[tokio::test]
+async fn graceful_patch_timeout_with_matching_get_is_success() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let derived_dir = dir.join("derived");
+    let mixed = common::free_port();
+    let config_a = common::write_config(&dir, &format!("mixed-port: {mixed}\n"));
+    let config_b = dir.join("config-b.yaml");
+    std::fs::write(
+        &config_b,
+        format!("mixed-port: {mixed}\nx-fake-core:\n  patch-delay-ms: 250\n"),
+    )
+    .unwrap();
+    let manager = CoreManager::new(ManagerOptions {
+        controller_mode: ControllerMode::Managed {
+            derived_dir,
+            controller_template: unique_template(),
+        },
+        control_timeout: Duration::from_millis(50),
+        reconcile_timeout: Duration::from_secs(3),
+        ..Default::default()
+    })
+    .await
+    .expect("construct manager");
+    manager
+        .start(common::mihomo_spec(&dir, config_a))
+        .await
+        .expect("start old core");
+
+    let CoreState::Running {
+        pid: before_pid, ..
+    } = manager.status().state
+    else {
+        panic!("old core is not running")
+    };
+    let outcome = manager
+        .switch(common::mihomo_spec(&dir, config_b))
+        .await
+        .expect("switch converges");
+
+    assert_eq!(outcome, SwitchOutcome::Graceful);
+    let CoreState::Running { epoch, pid } = manager.status().state else {
+        panic!("new core is not running")
+    };
+    assert_eq!(epoch, 2);
+    assert_ne!(pid, before_pid);
+    tokio::net::TcpStream::connect(("127.0.0.1", mixed))
+        .await
+        .expect("verified timed-out patch restored listener");
+    manager.shutdown().await.expect("shutdown");
+}
+
+#[tokio::test]
+async fn graceful_overlap_keeps_both_epoch_pid_records_without_miskilling_old() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let derived_dir = dir.join("derived");
+    let mixed = common::free_port();
+    let config_a = common::write_config(&dir, &format!("mixed-port: {mixed}\n"));
+    let config_b = dir.join("config-b.yaml");
+    std::fs::write(
+        &config_b,
+        format!("mixed-port: {mixed}\nx-fake-core:\n  ready-delay-ms: 750\n"),
+    )
+    .unwrap();
+    let manager = Arc::new(managed_manager(derived_dir.clone()).await);
+    manager
+        .start(common::mihomo_spec(&dir, config_a))
+        .await
+        .expect("start old core");
+    let CoreState::Running { pid: old_pid, .. } = manager.status().state else {
+        panic!("old core is not running")
+    };
+
+    let switching = {
+        let manager = manager.clone();
+        let spec_b = common::mihomo_spec(&dir, config_b);
+        tokio::spawn(async move { manager.switch(spec_b).await })
+    };
+    let (old_record, new_record) = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let old = nyanpasu_utils::process::read_epoch_pid_file(
+                derived_dir.join("core-1.pid").as_std_path(),
+            )
+            .await
+            .ok()
+            .flatten();
+            let new = nyanpasu_utils::process::read_epoch_pid_file(
+                derived_dir.join("core-2.pid").as_std_path(),
+            )
+            .await
+            .ok()
+            .flatten();
+            if let (Some(old), Some(new)) = (old, new) {
+                break (old, new);
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .expect("epoch pid files never overlapped");
+    assert_eq!(old_record.pid, old_pid);
+    assert_ne!(old_record.pid, new_record.pid);
+    tokio::net::TcpStream::connect(("127.0.0.1", mixed))
+        .await
+        .expect("old core still serves during overlap");
+
+    assert_eq!(switching.await.unwrap().unwrap(), SwitchOutcome::Graceful);
     manager.shutdown().await.expect("shutdown");
 }
 

--- a/crates/nyanpasu-core-manager/tests/graceful_switch.rs
+++ b/crates/nyanpasu-core-manager/tests/graceful_switch.rs
@@ -249,6 +249,34 @@ async fn graceful_switch_overlaps_and_restores_listeners() {
 }
 
 #[tokio::test]
+async fn graceful_switch_surfaces_installed_but_uncertain_durability() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let derived_dir = dir.join("derived");
+    let mixed = common::free_port();
+    let config_a = common::write_config(&dir, &format!("mixed-port: {mixed}\n"));
+    let config_b = dir.join("config-b.yaml");
+    std::fs::write(&config_b, format!("mixed-port: {mixed}\n")).unwrap();
+    let manager = managed_manager(derived_dir).await;
+    manager
+        .start(common::mihomo_spec(&dir, config_a))
+        .await
+        .expect("start old core");
+    manager.inject_runtime_parent_sync_failure_once_for_test();
+
+    let outcome = manager
+        .switch(common::mihomo_spec(&dir, config_b))
+        .await
+        .expect("graceful switch");
+
+    let SwitchOutcome::DurabilityUncertain { outcome, warning } = outcome else {
+        panic!("expected durability wrapper")
+    };
+    assert_eq!(*outcome, SwitchOutcome::Graceful);
+    assert!(warning.contains("injected"), "{warning}");
+    manager.shutdown().await.expect("shutdown");
+}
+
+#[tokio::test]
 async fn graceful_respawn_loads_the_full_committed_runtime_config() {
     let (_guard, dir) = common::utf8_tempdir();
     let derived_dir = dir.join("derived");
@@ -498,6 +526,74 @@ async fn graceful_overlap_keeps_both_epoch_pid_records_without_miskilling_old() 
 
     assert_eq!(switching.await.unwrap().unwrap(), SwitchOutcome::Graceful);
     manager.shutdown().await.expect("shutdown");
+}
+
+#[tokio::test]
+async fn quarantine_recovery_continues_after_an_independent_epoch_failure() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let derived_dir = dir.join("derived");
+    let config_a = common::write_config(&dir, "mixed-port: 0\n");
+    let config_b = dir.join("config-b.yaml");
+    std::fs::write(
+        &config_b,
+        "mixed-port: 0\nx-fake-core:\n  ready-delay-ms: 700\n",
+    )
+    .unwrap();
+    let manager = Arc::new(
+        CoreManager::new(ManagerOptions {
+            controller_mode: ControllerMode::Managed {
+                derived_dir: derived_dir.clone(),
+                controller_template: unique_template(),
+            },
+            stop_timeout: Duration::from_secs(1),
+            ..Default::default()
+        })
+        .await
+        .unwrap(),
+    );
+    manager
+        .start(common::mihomo_spec(&dir, config_a))
+        .await
+        .unwrap();
+
+    let spec_b = common::mihomo_spec(&dir, config_b);
+    let switching = {
+        let manager = manager.clone();
+        tokio::spawn(async move { manager.switch(spec_b).await })
+    };
+    let first_pid = derived_dir.join("core-1.pid");
+    let second_pid = derived_dir.join("core-2.pid");
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while !second_pid.exists() {
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+    })
+    .await
+    .expect("new epoch record never appeared");
+    let first_record = std::fs::read_to_string(&first_pid).unwrap();
+    let second_record = std::fs::read_to_string(&second_pid).unwrap();
+    std::fs::write(&first_pid, "unverifiable first epoch\n").unwrap();
+    std::fs::write(&second_pid, "unverifiable second epoch\n").unwrap();
+    assert!(matches!(
+        switching.await.unwrap(),
+        Err(Error::StopUnconfirmed(_))
+    ));
+
+    std::fs::write(&second_pid, second_record).unwrap();
+    manager
+        .recover_quarantine()
+        .await
+        .expect_err("first epoch must remain uncertain");
+    assert!(
+        !derived_dir.join("config-2.yaml").exists(),
+        "a later independent quarantine was not recovered"
+    );
+    assert!(!second_pid.exists());
+    assert!(derived_dir.join("config-1.yaml").exists());
+
+    std::fs::write(&first_pid, first_record).unwrap();
+    manager.recover_quarantine().await.unwrap();
+    assert!(!derived_dir.join("config-1.yaml").exists());
 }
 
 #[tokio::test]

--- a/crates/nyanpasu-core-manager/tests/helpers/fake_core.rs
+++ b/crates/nyanpasu-core-manager/tests/helpers/fake_core.rs
@@ -12,6 +12,7 @@ use std::{
     time::Duration,
 };
 
+use parking_lot::Mutex;
 use serde_yaml_ng::{Mapping, Value};
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
@@ -24,6 +25,7 @@ struct Behavior {
     external_controller_unix: Option<String>,
     secret: Option<String>,
     mixed_port: u16,
+    allow_lan: bool,
     ready_delay_ms: u64,
     never_ready: bool,
     exit_code: Option<i32>,
@@ -31,8 +33,15 @@ struct Behavior {
     crash_after_ms: u64,
     crash_times: u64,
     state_file: Option<String>,
+    launch_count_file: Option<String>,
+    fail_after_launches: u64,
+    fail_start_when_allow_lan: bool,
     patch_log: Option<String>,
     reject_patch: bool,
+    patch_delay_ms: u64,
+    patch_no_effect: bool,
+    reject_put: bool,
+    check_delay_ms: u64,
     check_fail: Option<String>,
 }
 
@@ -65,6 +74,7 @@ fn parse(config: &str) -> Behavior {
         external_controller_unix: s(&doc, "external-controller-unix"),
         secret: s(&doc, "secret"),
         mixed_port: u(&doc, "mixed-port") as u16,
+        allow_lan: b(&doc, "allow-lan"),
         ready_delay_ms: u(&x, "ready-delay-ms"),
         never_ready: b(&x, "never-ready"),
         exit_code: x
@@ -84,8 +94,15 @@ fn parse(config: &str) -> Behavior {
         crash_after_ms: u(&x, "crash-after-ms"),
         crash_times: u(&x, "crash-times"),
         state_file: s(&x, "state-file"),
+        launch_count_file: s(&x, "launch-count-file"),
+        fail_after_launches: u(&x, "fail-after-launches"),
+        fail_start_when_allow_lan: b(&x, "fail-start-when-allow-lan"),
         patch_log: s(&x, "patch-log"),
         reject_patch: b(&x, "reject-patch"),
+        patch_delay_ms: u(&x, "patch-delay-ms"),
+        patch_no_effect: b(&x, "patch-no-effect"),
+        reject_put: b(&x, "reject-put"),
+        check_delay_ms: u(&x, "check-delay-ms"),
         check_fail: s(&x, "check-fail"),
     }
 }
@@ -93,6 +110,7 @@ fn parse(config: &str) -> Behavior {
 struct Ctx {
     ready: AtomicBool,
     behavior: Behavior,
+    runtime: Mutex<Mapping>,
 }
 
 #[tokio::main(flavor = "current_thread")]
@@ -108,6 +126,7 @@ async fn main() {
     let behavior = parse(&config);
 
     if check_mode {
+        std::thread::sleep(Duration::from_millis(behavior.check_delay_ms));
         match &behavior.check_fail {
             Some(msg) => {
                 println!("time=\"t\" level=error msg=\"{msg}\"");
@@ -119,6 +138,20 @@ async fn main() {
 
     for line in &behavior.stderr_lines {
         eprintln!("{line}");
+    }
+    if behavior.fail_start_when_allow_lan && behavior.allow_lan {
+        exit(23);
+    }
+    if let Some(counter_path) = &behavior.launch_count_file {
+        let count: u64 = std::fs::read_to_string(counter_path)
+            .ok()
+            .and_then(|value| value.trim().parse().ok())
+            .unwrap_or(0)
+            + 1;
+        std::fs::write(counter_path, count.to_string()).expect("write launch counter");
+        if count > behavior.fail_after_launches {
+            exit(77);
+        }
     }
     if let Some(code) = behavior.exit_code {
         exit(code);
@@ -151,6 +184,7 @@ async fn main() {
     let ctx = Arc::new(Ctx {
         ready: AtomicBool::new(false),
         behavior,
+        runtime: Mutex::new(serde_yaml_ng::from_str(&config).expect("runtime mapping")),
     });
     if !ctx.behavior.never_ready {
         let ctx = ctx.clone();
@@ -265,7 +299,13 @@ where
     let request_line = lines.next().unwrap_or_default();
     let mut parts = request_line.split(' ');
     let method = parts.next().unwrap_or_default().to_owned();
-    let path = parts.next().unwrap_or_default().to_owned();
+    let path = parts
+        .next()
+        .unwrap_or_default()
+        .split('?')
+        .next()
+        .unwrap_or_default()
+        .to_owned();
 
     let mut content_length = 0usize;
     let mut authorization = None;
@@ -308,6 +348,24 @@ where
                 respond(&mut stream, 503, r#"{"message":"starting"}"#).await;
             }
         }
+        ("GET", "/configs") => {
+            let body = runtime_config_json(&ctx.runtime.lock());
+            respond(&mut stream, 200, &body).await;
+        }
+        ("PUT", "/configs") => {
+            if ctx.behavior.reject_put {
+                respond(&mut stream, 500, r#"{"message":"reload rejected"}"#).await;
+                return;
+            }
+            let request: Mapping = serde_yaml_ng::from_str(&body).expect("PUT JSON mapping");
+            let path = request
+                .get(Value::String("path".into()))
+                .and_then(Value::as_str)
+                .expect("PUT path");
+            let desired = std::fs::read_to_string(path).expect("read PUT path");
+            *ctx.runtime.lock() = serde_yaml_ng::from_str(&desired).expect("PUT runtime mapping");
+            respond(&mut stream, 204, "").await;
+        }
         ("PATCH", "/configs") => {
             if ctx.behavior.reject_patch {
                 respond(&mut stream, 500, r#"{"message":"patch rejected"}"#).await;
@@ -328,10 +386,142 @@ where
                     }
                 }
             }
+            if !ctx.behavior.patch_no_effect {
+                let patch: Mapping = serde_yaml_ng::from_str(&body).expect("PATCH JSON mapping");
+                merge_mapping(&mut ctx.runtime.lock(), &patch);
+            }
+            if ctx.behavior.patch_delay_ms > 0 {
+                tokio::time::sleep(Duration::from_millis(ctx.behavior.patch_delay_ms)).await;
+            }
             respond(&mut stream, 204, "").await;
         }
         _ => respond(&mut stream, 404, r#"{"message":"not found"}"#).await,
     }
+}
+
+fn merge_mapping(target: &mut Mapping, patch: &Mapping) {
+    for (key, value) in patch {
+        if let (Some(target), Some(patch)) = (
+            target.get_mut(key).and_then(Value::as_mapping_mut),
+            value.as_mapping(),
+        ) {
+            merge_mapping(target, patch);
+        } else {
+            target.insert(key.clone(), value.clone());
+        }
+    }
+}
+
+fn runtime_config_json(document: &Mapping) -> String {
+    let integer = |key: &str| {
+        document
+            .get(Value::String(key.into()))
+            .and_then(Value::as_i64)
+            .unwrap_or(0)
+    };
+    let boolean = |key: &str| {
+        document
+            .get(Value::String(key.into()))
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+    };
+    let string = |key: &str, default: &str| {
+        document
+            .get(Value::String(key.into()))
+            .and_then(Value::as_str)
+            .unwrap_or(default)
+            .to_owned()
+    };
+    let nested = |key: &str| {
+        document
+            .get(Value::String(key.into()))
+            .map(value_to_json)
+            .unwrap_or_else(|| "{}".into())
+    };
+    let optional_string = |key: &str| {
+        document
+            .get(Value::String(key.into()))
+            .and_then(Value::as_str)
+            .map(json_string)
+            .unwrap_or_else(|| "null".into())
+    };
+    let optional_value = |key: &str| {
+        document
+            .get(Value::String(key.into()))
+            .map(value_to_json)
+            .unwrap_or_else(|| "null".into())
+    };
+    format!(
+        concat!(
+            "{{\"port\":{},\"socks-port\":{},\"redir-port\":{},\"tproxy-port\":{},",
+            "\"mixed-port\":{},\"tun\":{},\"tuic-server\":{},\"ss-config\":{},",
+            "\"vmess-config\":{},\"tcptun-config\":{},\"udptun-config\":{},",
+            "\"authentication\":null,\"skip-auth-prefixes\":{},\"lan-allowed-ips\":{},",
+            "\"lan-disallowed-ips\":{},\"allow-lan\":{},\"bind-address\":{},",
+            "\"inbound-tfo\":false,\"inbound-mptcp\":false,\"mode\":{},",
+            "\"unified-delay\":false,\"log-level\":{},\"ipv6\":{},\"interface-name\":{},",
+            "\"routing-mark\":0,\"geox-url\":{{}},\"geo-auto-update\":false,",
+            "\"geo-update-interval\":0,\"geodata-mode\":false,\"geodata-loader\":\"\",",
+            "\"geosite-matcher\":\"\",\"tcp-concurrent\":{},\"find-process-mode\":{},",
+            "\"sniffing\":{},\"global-ua\":\"\",\"etag-support\":false,",
+            "\"keep-alive-idle\":0,\"keep-alive-interval\":0,\"disable-keep-alive\":false}}"
+        ),
+        integer("port"),
+        integer("socks-port"),
+        integer("redir-port"),
+        integer("tproxy-port"),
+        integer("mixed-port"),
+        nested("tun"),
+        nested("tuic-server"),
+        json_string(&string("ss-config", "")),
+        json_string(&string("vmess-config", "")),
+        optional_string("tcptun-config"),
+        optional_string("udptun-config"),
+        optional_value("skip-auth-prefixes"),
+        optional_value("lan-allowed-ips"),
+        optional_value("lan-disallowed-ips"),
+        boolean("allow-lan"),
+        json_string(&string("bind-address", "*")),
+        json_string(&string("mode", "rule")),
+        json_string(&string("log-level", "info")),
+        boolean("ipv6"),
+        json_string(&string("interface-name", "")),
+        boolean("tcp-concurrent"),
+        json_string(&string("find-process-mode", "off")),
+        boolean("sniffing"),
+    )
+}
+
+fn value_to_json(value: &Value) -> String {
+    match value {
+        Value::Null => "null".into(),
+        Value::Bool(value) => value.to_string(),
+        Value::Number(value) => value.to_string(),
+        Value::String(value) => json_string(value),
+        Value::Sequence(values) => format!(
+            "[{}]",
+            values
+                .iter()
+                .map(value_to_json)
+                .collect::<Vec<_>>()
+                .join(",")
+        ),
+        Value::Mapping(mapping) => format!(
+            "{{{}}}",
+            mapping
+                .iter()
+                .filter_map(|(key, value)| key
+                    .as_str()
+                    .map(|key| { format!("{}:{}", json_string(key), value_to_json(value)) }))
+                .collect::<Vec<_>>()
+                .join(",")
+        ),
+        Value::Tagged(tagged) => value_to_json(&tagged.value),
+    }
+}
+
+fn json_string(value: &str) -> String {
+    format!("{value:?}")
 }
 
 fn extract_mixed_port(body: &str) -> Option<u16> {

--- a/crates/nyanpasu-core-manager/tests/helpers/manager_host.rs
+++ b/crates/nyanpasu-core-manager/tests/helpers/manager_host.rs
@@ -1,0 +1,56 @@
+//! External test host used to simulate a manager process disappearing without
+//! running Rust destructors.
+
+use std::future::pending;
+
+use camino::Utf8PathBuf;
+use nyanpasu_core_manager::{
+    CoreKind, CoreManager, CoreSpec, CoreState, InstanceOptions, InstanceSpec, ManagerOptions,
+};
+
+#[tokio::main]
+async fn main() {
+    let mut args = std::env::args().skip(1);
+    let runtime_dir = Utf8PathBuf::from(args.next().expect("runtime dir"));
+    let source_config = Utf8PathBuf::from(args.next().expect("source config"));
+    let core_binary = Utf8PathBuf::from(args.next().expect("core binary"));
+    let ready_file = Utf8PathBuf::from(args.next().expect("ready file"));
+    let working_dir = source_config.parent().expect("config parent").to_owned();
+
+    let manager = CoreManager::new(ManagerOptions {
+        runtime_dir: Some(runtime_dir.clone()),
+        ..ManagerOptions::default()
+    })
+    .await
+    .expect("construct hosted manager");
+    manager
+        .start(InstanceSpec {
+            core: CoreSpec {
+                kind: CoreKind::Mihomo,
+                binary_path: core_binary,
+                version: None,
+                features: Vec::new(),
+            },
+            config_path: source_config,
+            working_dir,
+            pid_file: None,
+            options: InstanceOptions::default(),
+        })
+        .await
+        .expect("start hosted core");
+    let status = manager.status();
+    let CoreState::Running { epoch, pid } = status.state else {
+        panic!("hosted core is not running")
+    };
+    let revision = status.revision.expect("hosted revision");
+    let record = format!(
+        "host_pid={}\nepoch={epoch}\ncore_pid={pid}\nruntime_path={}\npid_path={}\n",
+        std::process::id(),
+        revision.runtime_path,
+        runtime_dir.join(format!("core-{epoch}.pid")),
+    );
+    std::fs::write(ready_file, record).expect("publish host readiness");
+
+    let _manager = manager;
+    pending::<()>().await;
+}

--- a/crates/nyanpasu-core-manager/tests/manager_orchestration.rs
+++ b/crates/nyanpasu-core-manager/tests/manager_orchestration.rs
@@ -29,6 +29,25 @@ async fn managed_controller_template_without_epoch_is_rejected_at_construction()
     assert!(CoreManager::new(options).await.is_err());
 }
 
+#[cfg(unix)]
+#[tokio::test]
+async fn managed_unix_controller_template_cannot_escape_runtime_directory() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let runtime = dir.join("runtime");
+    let escaped = dir.join("escaped-{epoch}.sock").to_string();
+    let result = CoreManager::new(ManagerOptions {
+        runtime_dir: Some(runtime.clone()),
+        controller_mode: ControllerMode::Managed {
+            derived_dir: runtime,
+            controller_template: Some(escaped),
+        },
+        ..ManagerOptions::default()
+    })
+    .await;
+    let error = result.err().expect("escaped template was accepted");
+    assert!(error.to_string().contains("escapes runtime directory"));
+}
+
 async fn wait_core_state(
     rx: &mut tokio::sync::watch::Receiver<nyanpasu_core_manager::CoreStatus>,
     pred: impl Fn(&CoreState) -> bool,
@@ -333,7 +352,7 @@ async fn source_mutation_after_snapshot_does_not_affect_respawn() {
     let config = common::write_config(
         &dir,
         &format!(
-            "external-controller: 127.0.0.1:{port}\nx-fake-core:\n  crash-after-ms: 500\n  crash-times: 1\n  state-file: {state_file}\n"
+            "external-controller: 127.0.0.1:{port}\nx-fake-core:\n  crash-after-ms: 1500\n  crash-times: 1\n  state-file: {state_file}\n"
         ),
     );
     let manager = manager(&dir).await;
@@ -383,6 +402,11 @@ async fn manager_sweeps_stale_artifacts_and_advances_epoch() {
     std::fs::create_dir_all(&runtime_dir).unwrap();
     std::fs::write(runtime_dir.join("config-7.yaml"), "stale: true\n").unwrap();
     std::fs::write(runtime_dir.join("config-7.yaml.backup-3"), "stale backup\n").unwrap();
+    std::fs::write(
+        runtime_dir.join("core-9.pid.tmp-123-0"),
+        "stale pid staging\n",
+    )
+    .unwrap();
 
     let manager = CoreManager::new(ManagerOptions {
         runtime_dir: Some(runtime_dir.clone()),
@@ -392,6 +416,7 @@ async fn manager_sweeps_stale_artifacts_and_advances_epoch() {
     .expect("sweeping manager");
     assert!(!runtime_dir.join("config-7.yaml").exists());
     assert!(!runtime_dir.join("config-7.yaml.backup-3").exists());
+    assert!(!runtime_dir.join("core-9.pid.tmp-123-0").exists());
 
     manager
         .start(common::mihomo_spec(&dir, config))
@@ -399,9 +424,101 @@ async fn manager_sweeps_stale_artifacts_and_advances_epoch() {
         .expect("start after sweep");
     assert!(matches!(
         manager.status().state,
-        CoreState::Running { epoch: 8, .. }
+        CoreState::Running { epoch: 10, .. }
     ));
     manager.shutdown().await.expect("shutdown");
+}
+
+#[tokio::test]
+async fn dropping_live_manager_releases_runtime_ownership() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let runtime_dir = dir.join("runtime");
+    let port = common::free_port();
+    let config = common::write_config(&dir, &format!("external-controller: 127.0.0.1:{port}\n"));
+    let options = || ManagerOptions {
+        runtime_dir: Some(runtime_dir.clone()),
+        ..ManagerOptions::default()
+    };
+    let manager = CoreManager::new(options()).await.expect("first manager");
+    manager
+        .start(common::mihomo_spec(&dir, config))
+        .await
+        .expect("start live core");
+    drop(manager);
+
+    let replacement = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            match CoreManager::new(options()).await {
+                Ok(manager) => break manager,
+                Err(Error::RuntimeDirectoryOwned(_)) => {
+                    tokio::time::sleep(Duration::from_millis(20)).await;
+                }
+                Err(error) => panic!("unexpected construction error: {error}"),
+            }
+        }
+    })
+    .await
+    .expect("dropping the manager retained its runtime lock");
+    replacement.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn initial_start_stop_uncertainty_quarantines_until_recovery() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let runtime_dir = dir.join("runtime");
+    let port = common::free_port();
+    let config = common::write_config(
+        &dir,
+        &format!("external-controller: 127.0.0.1:{port}\nx-fake-core:\n  never-ready: true\n"),
+    );
+    let manager = std::sync::Arc::new(
+        CoreManager::new(ManagerOptions {
+            runtime_dir: Some(runtime_dir.clone()),
+            stop_timeout: Duration::from_secs(1),
+            ..ManagerOptions::default()
+        })
+        .await
+        .unwrap(),
+    );
+    let start = {
+        let manager = manager.clone();
+        let mut spec = common::mihomo_spec(&dir, config.clone());
+        spec.options.startup_timeout = Duration::from_millis(300);
+        tokio::spawn(async move { manager.start(spec).await })
+    };
+    let pid_path = runtime_dir.join("core-1.pid");
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while !pid_path.exists() {
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+    })
+    .await
+    .expect("initial pid record never appeared");
+    let record = std::fs::read_to_string(&pid_path).unwrap();
+    std::fs::write(&pid_path, "corrupt record\n").unwrap();
+
+    assert!(matches!(
+        start.await.unwrap(),
+        Err(Error::StopUnconfirmed(_))
+    ));
+    let start_error = manager
+        .start(common::mihomo_spec(&dir, config.clone()))
+        .await
+        .expect_err("quarantine must reject another initial start");
+    assert!(matches!(
+        start_error,
+        Error::ManagerQuarantined { epoch: 1, .. }
+    ));
+
+    std::fs::write(&pid_path, record).unwrap();
+    common::wait_port_refused(port).await;
+    manager.recover_quarantine().await.unwrap();
+    let healthy = common::write_config(&dir, &format!("external-controller: 127.0.0.1:{port}\n"));
+    manager
+        .start(common::mihomo_spec(&dir, healthy))
+        .await
+        .expect("start after initial quarantine recovery");
+    manager.shutdown().await.unwrap();
 }
 
 #[tokio::test]

--- a/crates/nyanpasu-core-manager/tests/manager_orchestration.rs
+++ b/crates/nyanpasu-core-manager/tests/manager_orchestration.rs
@@ -375,7 +375,37 @@ async fn source_mutation_after_snapshot_does_not_affect_respawn() {
 }
 
 #[tokio::test]
-async fn next_manager_reaps_orphan_and_advances_epoch() {
+async fn manager_sweeps_stale_artifacts_and_advances_epoch() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let runtime_dir = dir.join("runtime");
+    let port = common::free_port();
+    let config = common::write_config(&dir, &format!("external-controller: 127.0.0.1:{port}\n"));
+    std::fs::create_dir_all(&runtime_dir).unwrap();
+    std::fs::write(runtime_dir.join("config-7.yaml"), "stale: true\n").unwrap();
+    std::fs::write(runtime_dir.join("config-7.yaml.backup-3"), "stale backup\n").unwrap();
+
+    let manager = CoreManager::new(ManagerOptions {
+        runtime_dir: Some(runtime_dir.clone()),
+        ..ManagerOptions::default()
+    })
+    .await
+    .expect("sweeping manager");
+    assert!(!runtime_dir.join("config-7.yaml").exists());
+    assert!(!runtime_dir.join("config-7.yaml.backup-3").exists());
+
+    manager
+        .start(common::mihomo_spec(&dir, config))
+        .await
+        .expect("start after sweep");
+    assert!(matches!(
+        manager.status().state,
+        CoreState::Running { epoch: 8, .. }
+    ));
+    manager.shutdown().await.expect("shutdown");
+}
+
+#[tokio::test]
+async fn second_manager_cannot_take_over_an_owned_runtime_directory() {
     let (_guard, dir) = common::utf8_tempdir();
     let runtime_dir = dir.join("runtime");
     let port = common::free_port();
@@ -387,25 +417,27 @@ async fn next_manager_reaps_orphan_and_advances_epoch() {
 
     let first = CoreManager::new(options()).await.expect("first manager");
     first
-        .start(common::mihomo_spec(&dir, config.clone()))
-        .await
-        .expect("start orphan candidate");
-    assert!(runtime_dir.join("config-1.yaml").exists());
-    assert!(runtime_dir.join("core-1.pid").exists());
-    drop(first); // Simulates losing the manager without graceful teardown.
-
-    let second = CoreManager::new(options()).await.expect("reaping manager");
-    common::wait_port_refused(port).await;
-    assert!(!runtime_dir.join("config-1.yaml").exists());
-    assert!(!runtime_dir.join("core-1.pid").exists());
-
-    second
         .start(common::mihomo_spec(&dir, config))
         .await
-        .expect("start after reap");
+        .expect("start first manager's core");
+    let CoreState::Running { pid, .. } = first.status().state else {
+        panic!("first manager is not running")
+    };
+
+    let second = CoreManager::new(options()).await;
+    assert!(
+        second.is_err(),
+        "second manager acquired an owned directory"
+    );
+    let error = second.err().unwrap().to_string();
+    assert!(error.contains("already owned"), "unexpected error: {error}");
     assert!(matches!(
-        second.status().state,
-        CoreState::Running { epoch: 2, .. }
+        first.status().state,
+        CoreState::Running { pid: live_pid, .. } if live_pid == pid
     ));
-    second.shutdown().await.expect("shutdown");
+    tokio::net::TcpStream::connect(("127.0.0.1", port))
+        .await
+        .expect("second construction must not kill the owned core");
+
+    first.shutdown().await.expect("shutdown first manager");
 }

--- a/crates/nyanpasu-core-manager/tests/manager_orchestration.rs
+++ b/crates/nyanpasu-core-manager/tests/manager_orchestration.rs
@@ -512,6 +512,13 @@ async fn initial_start_stop_uncertainty_quarantines_until_recovery() {
 
     std::fs::write(&pid_path, record).unwrap();
     common::wait_port_refused(port).await;
+    let blocked_cleanup = runtime_dir.join("config-1.yaml.backup-blocked");
+    std::fs::create_dir(&blocked_cleanup).unwrap();
+    manager
+        .recover_quarantine()
+        .await
+        .expect_err("unsafe artifact must fail the first cleanup attempt");
+    std::fs::remove_dir(&blocked_cleanup).unwrap();
     manager.recover_quarantine().await.unwrap();
     let healthy = common::write_config(&dir, &format!("external-controller: 127.0.0.1:{port}\n"));
     manager

--- a/crates/nyanpasu-core-manager/tests/manager_orchestration.rs
+++ b/crates/nyanpasu-core-manager/tests/manager_orchestration.rs
@@ -514,10 +514,12 @@ async fn initial_start_stop_uncertainty_quarantines_until_recovery() {
     common::wait_port_refused(port).await;
     let blocked_cleanup = runtime_dir.join("config-1.yaml.backup-blocked");
     std::fs::create_dir(&blocked_cleanup).unwrap();
+    let quarantine_status = manager.status();
     manager
         .recover_quarantine()
         .await
         .expect_err("unsafe artifact must fail the first cleanup attempt");
+    assert_eq!(manager.status().state, quarantine_status.state);
     std::fs::remove_dir(&blocked_cleanup).unwrap();
     manager.recover_quarantine().await.unwrap();
     let healthy = common::write_config(&dir, &format!("external-controller: 127.0.0.1:{port}\n"));

--- a/crates/nyanpasu-core-manager/tests/manager_orchestration.rs
+++ b/crates/nyanpasu-core-manager/tests/manager_orchestration.rs
@@ -2,10 +2,31 @@ mod common;
 
 use std::time::Duration;
 
-use nyanpasu_core_manager::{CoreState, Error, ManagerOptions, StopReason, manager::CoreManager};
+use nyanpasu_core_manager::{
+    ControllerMode, CoreState, Error, ManagerOptions, StopReason, manager::CoreManager,
+};
 
-fn manager() -> CoreManager {
-    CoreManager::new(ManagerOptions::default())
+async fn manager(runtime_dir: &camino::Utf8Path) -> CoreManager {
+    CoreManager::new(ManagerOptions {
+        runtime_dir: Some(runtime_dir.join("runtime")),
+        ..ManagerOptions::default()
+    })
+    .await
+    .expect("construct manager")
+}
+
+#[tokio::test]
+async fn managed_controller_template_without_epoch_is_rejected_at_construction() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let options = ManagerOptions {
+        controller_mode: ControllerMode::Managed {
+            derived_dir: dir,
+            controller_template: Some(r"\\.\pipe\nyanpasu\fixed".to_owned()),
+        },
+        ..ManagerOptions::default()
+    };
+
+    assert!(CoreManager::new(options).await.is_err());
 }
 
 async fn wait_core_state(
@@ -33,7 +54,7 @@ async fn start_publishes_running_and_rejects_double_start() {
     let config = common::write_config(&dir, &format!("external-controller: 127.0.0.1:{port}\n"));
     let spec = common::mihomo_spec(&dir, config);
 
-    let manager = manager();
+    let manager = manager(&dir).await;
     let mut rx = manager.subscribe();
     assert!(matches!(
         manager.status().state,
@@ -66,7 +87,8 @@ async fn start_publishes_running_and_rejects_double_start() {
 
 #[tokio::test]
 async fn stop_requires_a_running_core() {
-    let manager = manager();
+    let (_guard, dir) = common::utf8_tempdir();
+    let manager = manager(&dir).await;
     assert!(matches!(manager.stop().await, Err(Error::NotStarted)));
 }
 
@@ -81,7 +103,7 @@ async fn failed_start_reports_error_and_publishes_stopped() {
     let mut spec = common::mihomo_spec(&dir, config);
     spec.options.startup_timeout = Duration::from_secs(1);
 
-    let manager = manager();
+    let manager = manager(&dir).await;
     let err = manager.start(spec).await.expect_err("must fail");
     assert!(matches!(err, Error::StartupTimeout { .. }), "got {err}");
     assert!(matches!(
@@ -95,7 +117,7 @@ async fn missing_controller_is_rejected_strictly() {
     let (_guard, dir) = common::utf8_tempdir();
     let config = common::write_config(&dir, "mixed-port: 7890\n");
     let spec = common::mihomo_spec(&dir, config);
-    let manager = manager();
+    let manager = manager(&dir).await;
     assert!(matches!(
         manager.start(spec).await,
         Err(Error::ControllerMissing)
@@ -116,7 +138,7 @@ async fn hard_switch_replaces_the_core_and_bumps_the_epoch() {
     )
     .unwrap();
 
-    let manager = manager();
+    let manager = manager(&dir).await;
     let mut rx = manager.subscribe();
     let mut spec_a = common::mihomo_spec(&dir, config_a);
     spec_a.options.startup_timeout = Duration::from_secs(15);
@@ -146,12 +168,37 @@ async fn hard_switch_replaces_the_core_and_bumps_the_epoch() {
 }
 
 #[tokio::test]
+async fn passthrough_prepare_failure_never_leaves_switching() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let port = common::free_port();
+    let config_a = common::write_config(&dir, &format!("external-controller: 127.0.0.1:{port}\n"));
+    let config_b = dir.join("config-b.yaml");
+    std::fs::write(&config_b, "mixed-port: 7890\n").unwrap();
+
+    let manager = manager(&dir).await;
+    manager
+        .start(common::mihomo_spec(&dir, config_a))
+        .await
+        .expect("start");
+
+    let error = manager
+        .switch(common::mihomo_spec(&dir, config_b))
+        .await
+        .expect_err("missing controller must fail");
+    assert!(matches!(error, Error::ControllerMissing), "got {error}");
+    assert!(
+        !matches!(manager.status().state, CoreState::Switching { .. }),
+        "prepare failure must publish a terminal or retained state"
+    );
+}
+
+#[tokio::test]
 async fn restart_uses_the_last_spec_and_survives_stop() {
     let (_guard, dir) = common::utf8_tempdir();
     let port = common::free_port();
     let config = common::write_config(&dir, &format!("external-controller: 127.0.0.1:{port}\n"));
 
-    let manager = manager();
+    let manager = manager(&dir).await;
     assert!(matches!(manager.restart().await, Err(Error::NotStarted)));
 
     let mut spec = common::mihomo_spec(&dir, config);
@@ -172,7 +219,7 @@ async fn switch_publishes_a_switching_window() {
     let mut spec = common::mihomo_spec(&dir, config);
     spec.options.startup_timeout = Duration::from_secs(15);
 
-    let manager = manager();
+    let manager = manager(&dir).await;
     manager.start(spec.clone()).await.expect("start");
 
     let mut rx = manager.subscribe();
@@ -211,7 +258,7 @@ async fn lifecycle_sequence_matches_legacy_contract() {
         ),
     );
 
-    let manager = manager();
+    let manager = manager(&dir).await;
     let mut rx = manager.subscribe();
     let seen = std::sync::Arc::new(parking_lot::Mutex::new(vec![rx.borrow().state.clone()]));
     let seen_ = seen.clone();
@@ -275,4 +322,90 @@ async fn lifecycle_sequence_matches_legacy_contract() {
         running_after_restart,
         "recovery must re-confirm Running: {states:?}"
     );
+}
+
+#[tokio::test]
+async fn source_mutation_after_snapshot_does_not_affect_respawn() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let runtime_dir = dir.join("runtime");
+    let port = common::free_port();
+    let state_file = dir.join("crash-state");
+    let config = common::write_config(
+        &dir,
+        &format!(
+            "external-controller: 127.0.0.1:{port}\nx-fake-core:\n  crash-after-ms: 500\n  crash-times: 1\n  state-file: {state_file}\n"
+        ),
+    );
+    let manager = manager(&dir).await;
+    manager
+        .start(common::mihomo_spec(&dir, config.clone()))
+        .await
+        .expect("start");
+
+    let revision = manager.status().revision.expect("active revision");
+    assert_eq!(revision.runtime_path.file_name(), Some("config-1.yaml"));
+    assert_ne!(revision.runtime_path, config);
+    assert!(runtime_dir.join("core-1.pid").exists());
+
+    std::fs::write(
+        &config,
+        "external-controller: 127.0.0.1:1\nx-fake-core:\n  never-ready: true\n",
+    )
+    .unwrap();
+    let mut rx = manager.subscribe();
+    wait_core_state(
+        &mut rx,
+        |state| matches!(state, CoreState::Restarting { .. }),
+        Duration::from_secs(5),
+    )
+    .await;
+    wait_core_state(
+        &mut rx,
+        |state| matches!(state, CoreState::Running { .. }),
+        Duration::from_secs(10),
+    )
+    .await;
+
+    let runtime = std::fs::read_to_string(&revision.runtime_path).unwrap();
+    assert!(runtime.contains(&format!("127.0.0.1:{port}")));
+    assert!(!runtime.contains("never-ready"));
+    manager.shutdown().await.expect("shutdown");
+    assert!(!revision.runtime_path.exists());
+    assert!(!runtime_dir.join("core-1.pid").exists());
+}
+
+#[tokio::test]
+async fn next_manager_reaps_orphan_and_advances_epoch() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let runtime_dir = dir.join("runtime");
+    let port = common::free_port();
+    let config = common::write_config(&dir, &format!("external-controller: 127.0.0.1:{port}\n"));
+    let options = || ManagerOptions {
+        runtime_dir: Some(runtime_dir.clone()),
+        ..ManagerOptions::default()
+    };
+
+    let first = CoreManager::new(options()).await.expect("first manager");
+    first
+        .start(common::mihomo_spec(&dir, config.clone()))
+        .await
+        .expect("start orphan candidate");
+    assert!(runtime_dir.join("config-1.yaml").exists());
+    assert!(runtime_dir.join("core-1.pid").exists());
+    drop(first); // Simulates losing the manager without graceful teardown.
+
+    let second = CoreManager::new(options()).await.expect("reaping manager");
+    common::wait_port_refused(port).await;
+    assert!(!runtime_dir.join("config-1.yaml").exists());
+    assert!(!runtime_dir.join("core-1.pid").exists());
+
+    second
+        .start(common::mihomo_spec(&dir, config))
+        .await
+        .expect("start after reap");
+    assert!(matches!(
+        second.status().state,
+        CoreState::Running { epoch: 2, .. }
+    ));
+    second.shutdown().await.expect("shutdown");
 }

--- a/crates/nyanpasu-core-manager/tests/orphan_recovery.rs
+++ b/crates/nyanpasu-core-manager/tests/orphan_recovery.rs
@@ -93,11 +93,20 @@ async fn hard_killed_manager_is_reaped_and_all_epoch_artifacts_are_swept() {
         "temporary",
     )
     .unwrap();
+    #[cfg(windows)]
     std::fs::write(
         runtime_dir.join(format!("core-{swept_epoch}.sock")),
         "socket-placeholder",
     )
     .unwrap();
+    #[cfg(unix)]
+    {
+        let socket = std::os::unix::net::UnixListener::bind(
+            runtime_dir.join(format!("core-{swept_epoch}.sock")),
+        )
+        .unwrap();
+        drop(socket);
+    }
 
     host.hard_kill();
     // A Windows Job Object may eagerly kill the core when the host's final job
@@ -120,7 +129,7 @@ async fn hard_killed_manager_is_reaped_and_all_epoch_artifacts_are_swept() {
     while let Some(entry) = entries.next_entry().await.unwrap() {
         leftovers.push(entry.file_name().to_string_lossy().into_owned());
     }
-    assert!(leftovers.is_empty(), "unswept artifacts: {leftovers:?}");
+    assert_eq!(leftovers, [".manager.lock"], "unswept artifacts");
 
     manager
         .start(common::mihomo_spec(&dir, config))

--- a/crates/nyanpasu-core-manager/tests/orphan_recovery.rs
+++ b/crates/nyanpasu-core-manager/tests/orphan_recovery.rs
@@ -1,0 +1,137 @@
+mod common;
+
+use std::{collections::HashMap, process::Stdio, time::Duration};
+
+use nyanpasu_core_manager::{CoreManager, CoreState, ManagerOptions};
+
+struct HostProcess(std::process::Child);
+
+impl HostProcess {
+    fn hard_kill(&mut self) {
+        self.0.kill().expect("hard-kill manager host");
+        self.0.wait().expect("wait for killed manager host");
+    }
+}
+
+impl Drop for HostProcess {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+fn parse_ready(contents: &str) -> HashMap<&str, &str> {
+    contents
+        .lines()
+        .filter_map(|line| line.split_once('='))
+        .collect()
+}
+
+#[tokio::test]
+async fn hard_killed_manager_is_reaped_and_all_epoch_artifacts_are_swept() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let runtime_dir = dir.join("runtime");
+    let ready_file = dir.join("manager-ready.txt");
+    let port = common::free_port();
+    let config = common::write_config(&dir, &format!("external-controller: 127.0.0.1:{port}\n"));
+    let mut host = HostProcess(
+        std::process::Command::new(env!("CARGO_BIN_EXE_nyanpasu-manager-host"))
+            .arg(&runtime_dir)
+            .arg(&config)
+            .arg(common::fake_core_bin())
+            .arg(&ready_file)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn manager host"),
+    );
+
+    let ready = tokio::time::timeout(Duration::from_secs(15), async {
+        loop {
+            if let Ok(contents) = tokio::fs::read_to_string(&ready_file).await {
+                let values = parse_ready(&contents);
+                if values.contains_key("epoch") && values.contains_key("core_pid") {
+                    break contents;
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    })
+    .await
+    .expect("manager host never became ready");
+    let values = parse_ready(&ready);
+    let swept_epoch: u64 = values["epoch"].parse().unwrap();
+    let core_pid: u32 = values["core_pid"].parse().unwrap();
+    let runtime_path = camino::Utf8Path::new(values["runtime_path"]);
+    let pid_path = camino::Utf8Path::new(values["pid_path"]);
+    assert_eq!(swept_epoch, 1);
+    assert!(core_pid > 0);
+    assert_eq!(runtime_path.file_name(), Some("config-1.yaml"));
+    assert_eq!(pid_path.file_name(), Some("core-1.pid"));
+    assert_eq!(
+        std::fs::canonicalize(runtime_path.parent().unwrap()).unwrap(),
+        std::fs::canonicalize(&runtime_dir).unwrap()
+    );
+    assert_eq!(
+        std::fs::canonicalize(pid_path.parent().unwrap()).unwrap(),
+        std::fs::canonicalize(&runtime_dir).unwrap()
+    );
+    assert!(runtime_path.is_file());
+    assert!(pid_path.is_file());
+    tokio::net::TcpStream::connect(("127.0.0.1", port))
+        .await
+        .expect("hosted core serves before manager kill");
+
+    std::fs::write(
+        runtime_dir.join(format!("config-{swept_epoch}.yaml.backup-99")),
+        "backup",
+    )
+    .unwrap();
+    std::fs::write(
+        runtime_dir.join(format!(".config-{swept_epoch}.yaml.tmp-orphan")),
+        "temporary",
+    )
+    .unwrap();
+    std::fs::write(
+        runtime_dir.join(format!("core-{swept_epoch}.sock")),
+        "socket-placeholder",
+    )
+    .unwrap();
+
+    host.hard_kill();
+    // A Windows Job Object may eagerly kill the core when the host's final job
+    // handle closes. Unix process groups leave it alive. Recovery must handle
+    // both states and still sweep the durable epoch artifacts.
+    let _orphan_was_alive = tokio::net::TcpStream::connect(("127.0.0.1", port))
+        .await
+        .is_ok();
+
+    let manager = CoreManager::new(ManagerOptions {
+        runtime_dir: Some(runtime_dir.clone()),
+        ..ManagerOptions::default()
+    })
+    .await
+    .expect("construct recovery manager");
+    common::wait_port_refused(port).await;
+
+    let mut entries = tokio::fs::read_dir(&runtime_dir).await.unwrap();
+    let mut leftovers = Vec::new();
+    while let Some(entry) = entries.next_entry().await.unwrap() {
+        leftovers.push(entry.file_name().to_string_lossy().into_owned());
+    }
+    assert!(leftovers.is_empty(), "unswept artifacts: {leftovers:?}");
+
+    manager
+        .start(common::mihomo_spec(&dir, config))
+        .await
+        .expect("start after orphan sweep");
+    let CoreState::Running { epoch, .. } = manager.status().state else {
+        panic!("recovery core is not running")
+    };
+    assert!(
+        epoch > swept_epoch,
+        "epoch {epoch} must exceed {swept_epoch}"
+    );
+    manager.shutdown().await.expect("shutdown recovery core");
+}


### PR DESCRIPTION
## Summary

Implements the core-manager dynamic config lifecycle design (follow-up to #379): manager-owned runtime artifacts, a compensating `apply_config` saga, a write-ahead graceful switch, and construction-time orphan recovery. Fixes all 12 defects identified in the design review of the initial crate.

✅ LibNyanpasu/nyanpasu-utils#170 has been merged; the `crates/nyanpasu-utils` submodule is now pinned to upstream `main` (`9346381`), so this PR has **no cross-PR dependency**. (A small follow-up hardening that missed the squash merge is re-submitted independently as LibNyanpasu/nyanpasu-utils#171.)

## Core invariants

1. **epoch/revision separation** — epoch = process/controller lineage; revision = desired config version within an epoch (CAS token exposed via `ConfigRevision::id()`).
2. **Manager-owned snapshots** — both Managed and Passthrough modes spawn from `config-{epoch}.yaml`; user-mutable files are read exactly once per lifecycle operation into an immutable `ConfigSnapshot`/`PreparedConfig` (canonical form, semantic hashing) — eliminating the config TOCTOU.
3. **Write-ahead desired state** — `RuntimeConfigStore` atomically commits the checked config (Unix rename+fsync; Windows `ReplaceFileW`/`MoveFileExW` with bounded sharing-violation retry) *before* PATCH/PUT; a crash at any point means respawn loads the desired config. Commits distinguish `Durable` from `Uncertain` (installed but parent-fsync failed), surfaced as `ApplyOutcome::DurabilityUncertain` / `SwitchOutcome::DurabilityUncertain` / structured `Error::DurabilityUncertain`.
4. **Deny-by-default change classification** — `config_diff` classifies Noop / Patch (whitelist expressible by `ConfigPatch` AND verifiable via `GET /configs`) / Reload (PUT whitelist) / Switch (controller, secret, `dns.listen` incl. root-node shape changes, process spec, any unknown key). Uncertain → Switch.
5. **Verified reconciliation** — PATCH errors/timeouts resolve through GET projection verification instead of blind hard restarts; failure converges to the committed desired file (same-epoch restart), and only a failed desired restart rolls back to the backed-up revision. Double failure reports both errors in one terminal state.
6. **Write-ahead graceful switch** — zero-inbound bootstrap and full desired config prepared from one snapshot (both check_config-validated); `config-{new}.yaml` is atomically replaced with the FULL config before the restore PATCH, so a Supervisor respawn at any moment restores all listeners.
7. **Proof-of-death lifecycle** — `stop_and_confirm_dead()` gates epoch/endpoint reuse and artifact deletion. Unconfirmed deaths latch a **quarantine** (`Error::ManagerQuarantined`) that rejects start/apply/switch/restart until `recover_quarantine()` clears it via identity-verified process-tree reaping (retry-safe, all epochs, aggregated failures). `stop`/`shutdown` intentionally bypass the gate (documented).
8. **Exclusive runtime-dir ownership** — a process-lifetime `.manager.lock` is acquired before the construction-time orphan sweep; a second manager over an owned directory fails closed. Forwarder tasks hold `Weak<Inner>`, so dropping the last handle releases the instance and the lock.

## Review process

4 implementation batches + a 5-round dual-model review loop (every Critical/Warning across all rounds fixed; final round: zero findings, 96/100, mergeable). Every deterministic defect was fixed TDD red-first — failure evidence is recorded in each commit message. Race-class defects are covered by property-style tests (atomic readers, post-snapshot source mutation, stale-epoch event injection, hard-killed-host orphan recovery).

## Testing

- `cargo test -p nyanpasu-core-manager` — 80+ tests green (2 real-mihomo tests ignored without the platform binary); race-sensitive binaries (orchestration / graceful switch / orphan recovery / config apply) stable across repeated runs
- `cargo test -p nyanpasu-utils --features process`, `cargo test -p clash-api` — green
- `cargo clippy` `-D warnings` on both crates — clean, including a no-default-feature production build (fault-injection hooks are gated behind the non-default `test-hooks` feature via a self-referencing dev-dependency)

## Not in scope

`nyanpasu_service` wiring (async fallible `CoreManager::new`, `apply_config` + revision persistence, `ApplyOutcome`→IPC mapping) is the next phase; the integration surface is documented in the crate README.
