### PR TITLE
feat(nyanpasu-core-manager): customizable health probes with runtime liveness

### DIFF
--- a/crates/nyanpasu-core-manager/README.md
+++ b/crates/nyanpasu-core-manager/README.md
@@ -43,11 +43,13 @@ Every instance starts in `Starting` and ends in exactly one `Stopped` state.
 `InstanceStatus` publishes that lifecycle together with an orthogonal health
 dimension in one watch snapshot, so a PID can never be paired with health from
 another process run. `InstanceState` and `HealthState` are defined in
-[`src/state.rs`](src/state.rs).
+[`src/state.rs`](src/state.rs). `Instance::state()` therefore yields
+`watch::Receiver<InstanceStatus>`, not the bare `InstanceState` it returned
+before.
 
 ```mermaid
 stateDiagram-v2
-    [*] --> Starting: Instance::spawn
+    [*] --> Starting: Instance:\:spawn
     Starting --> Running: readiness success threshold
     Starting --> Stopped: startup timeout / spawn failed / budget exhausted
     Running --> Restarting: process exited, restart budget left
@@ -70,6 +72,10 @@ Readiness acknowledgement occurs exactly once for each child-process run.
 Runtime recovery never acknowledges again, so health flapping cannot reset the
 supervisor restart budget. `HealthStatus.changed_at` records only health
 transitions; `CoreStatus.changed_at` remains the lifecycle transition time.
+
+`HealthStatus` also carries `consecutive_failures`, `last_success_at`, and
+`last_error`. Its `Debug` renders `last_error` as `<redacted>`; read the field
+directly when the text is needed.
 
 `Stopped` carries a `StopReason`:
 
@@ -118,7 +124,7 @@ sequenceDiagram
     M->>I: spawn(spec, N, controller)
     I->>S: spawn(-m -d dir -f cfg, SAFE_PATHS=…)
     S->>C: exec
-    loop immediate first attempt, then health.interval; within startup_timeout
+    loop immediate first attempt, then health.interval, all within startup_timeout
         I->>C: GET /version
     end
     C-->>I: 200 OK
@@ -134,7 +140,7 @@ sequenceDiagram
     participant D as Probe driver
     participant P as Custom liveness probe
     participant T as Health tracker
-    participant W as watch&lt;InstanceStatus&gt;
+    participant W as watch#lt;InstanceStatus#gt;
 
     loop completion + health.interval
         D->>P: check(epoch, run_id/PID, Liveness)
@@ -142,8 +148,8 @@ sequenceDiagram
         D->>T: serialized observation
         T-->>W: Running + health transition/counters
     end
-    Note over D,W: Reconcile checks share this queue;<br/>at most one probe is in flight per instance
-    Note over T,W: Sustained Unhealthy is observe-only;<br/>the process is not restarted automatically
+    Note over D,W: Reconcile checks share this queue,<br/>at most one probe is in flight per instance
+    Note over T,W: Sustained Unhealthy is observe-only,<br/>the process is not restarted automatically
 ```
 
 If a future release adds a restart reaction, it must be manager-owned and pass
@@ -176,7 +182,7 @@ sequenceDiagram
     alt patch verified
         M-->>App: SwitchOutcome::Graceful
     else patch failed or uncertain
-        M->>B: stop_and_confirm_dead(); restart from committed full B (same epoch)
+        M->>B: stop_and_confirm_dead(), then restart from committed full B (same epoch)
         M-->>App: SwitchOutcome::Hard { PatchFailed }
     end
 ```
@@ -269,6 +275,29 @@ separate probes during graceful switching: the bootstrap intentionally zeroes
 proxy listener ports, so a proxy-port TCP check is unsuitable for readiness
 even though it is useful after `Running`.
 
+Each attempt receives a `ProbeContext` carrying `epoch`, `pid`, `phase`, the
+resolved `controller`, and a `cancel` token. It deliberately does not implement
+`Debug`, because the controller may hold an authentication secret.
+
+| `ProbePhase` | When it runs | Probe used |
+| --- | --- | --- |
+| `Readiness` | until the start is acknowledged | readiness |
+| `Liveness` | after `Running`, only when configured | liveness |
+| `Reconcile` | on demand after PATCH/reload and switch verification | liveness if configured, else readiness |
+
+`Instance::probe_now()` accepts `Reconcile` only; the periodic phases are driven
+by the instance itself, and requesting one directly returns `Unhealthy`.
+
+Implementing `HealthProbe` instead of using `ProbeHandle::from_fn` carries one
+contract: the returned future must be cancellation-safe, so dropping it must
+not leave a detached task behind. A probe that shells out must pass arguments
+to `tokio::process::Command` directly rather than concatenate a shell command,
+and must set `kill_on_drop(true)` so the child dies with the future.
+
+`CoreManager` installs both probes into every epoch it spawns. To drive a bare
+instance instead, `Instance::builder(spec, epoch, controller, parent)` exposes
+the same three methods before `.spawn()`.
+
 ### Managed mode + graceful switch
 
 ```rust
@@ -331,14 +360,19 @@ runtime file is atomically restored and restarted.
 ### Watch status
 
 ```rust
-use nyanpasu_core_manager::CoreState;
+use nyanpasu_core_manager::{CoreState, HealthState};
 
 let mut rx = manager.subscribe();
 tokio::spawn(async move {
     while rx.changed().await.is_ok() {
         let status = rx.borrow().clone();
         match status.state {
-            CoreState::Running { epoch, pid } => { /* … */ }
+            CoreState::Running { epoch, pid } => {
+                // Observe-only: nothing restarts the core on Unhealthy.
+                if let Some(HealthState::Unhealthy) = status.health.map(|h| h.state) {
+                    /* surface a warning */
+                }
+            }
             CoreState::Stopped { .. } => break,
             _ => { /* Starting / Restarting / Switching / Stopping */ }
         }

--- a/crates/nyanpasu-core-manager/README.md
+++ b/crates/nyanpasu-core-manager/README.md
@@ -17,9 +17,11 @@ Key concepts:
 - **Manager-owned snapshots** — both controller modes run from a private,
   stable `config-{epoch}.yaml`, never directly from the caller's mutable file.
   Supervisor respawns therefore reload the committed desired revision.
-- **Health-probed startup** — a start is only confirmed once
-  `GET /version` on the core's external controller answers. `startup_timeout`
-  is a *total* budget covering spawn, crash retries, and probing.
+- **Health-probed startup and runtime status** — a start is only confirmed once
+  its readiness probe passes. The default is `GET /version`; custom readiness
+  and optional runtime liveness probes are installed through builders.
+  `startup_timeout` is a *total* budget covering spawn, crash retries, grace,
+  and threshold evaluation.
 - **Supervision** — crash → backoff → respawn → re-probe, bounded by
   `RestartPolicy`/`Backoff` from `nyanpasu-utils`. Dropping an `Instance`
   without `stop()` kills the whole process tree.
@@ -38,12 +40,15 @@ sets `SAFE_PATHS` to the working dir plus the config dir.
 ## Instance state machine
 
 Every instance starts in `Starting` and ends in exactly one `Stopped` state.
-`InstanceState` is defined in [`src/state.rs`](src/state.rs).
+`InstanceStatus` publishes that lifecycle together with an orthogonal health
+dimension in one watch snapshot, so a PID can never be paired with health from
+another process run. `InstanceState` and `HealthState` are defined in
+[`src/state.rs`](src/state.rs).
 
 ```mermaid
 stateDiagram-v2
     [*] --> Starting: Instance::spawn
-    Starting --> Running: GET /version OK
+    Starting --> Running: readiness success threshold
     Starting --> Stopped: startup timeout / spawn failed / budget exhausted
     Running --> Restarting: process exited, restart budget left
     Restarting --> Running: respawn probe OK
@@ -54,6 +59,17 @@ stateDiagram-v2
     Stopping --> Stopped: process tree dead
     Stopped --> [*]
 ```
+
+While the lifecycle is `Starting` or `Restarting`, health is `Starting`.
+Acknowledged `Running` begins as `Healthy`. If liveness is configured,
+consecutive failures can change health to `Unhealthy` while lifecycle remains
+`Running`; consecutive successes recover it to `Healthy`. A lone failure does
+not flap the state. `Stopping` and `Stopped` carry no health value.
+
+Readiness acknowledgement occurs exactly once for each child-process run.
+Runtime recovery never acknowledges again, so health flapping cannot reset the
+supervisor restart budget. `HealthStatus.changed_at` records only health
+transitions; `CoreStatus.changed_at` remains the lifecycle transition time.
 
 `Stopped` carries a `StopReason`:
 
@@ -102,7 +118,7 @@ sequenceDiagram
     M->>I: spawn(spec, N, controller)
     I->>S: spawn(-m -d dir -f cfg, SAFE_PATHS=…)
     S->>C: exec
-    loop every probe_interval, within startup_timeout
+    loop immediate first attempt, then health.interval; within startup_timeout
         I->>C: GET /version
     end
     C-->>I: 200 OK
@@ -110,6 +126,30 @@ sequenceDiagram
     M-->>App: Ok(())
     Note over M: forwarder mirrors instance transitions<br/>into the CoreStatus watch channel
 ```
+
+### Runtime liveness (when configured)
+
+```mermaid
+sequenceDiagram
+    participant D as Probe driver
+    participant P as Custom liveness probe
+    participant T as Health tracker
+    participant W as watch&lt;InstanceStatus&gt;
+
+    loop completion + health.interval
+        D->>P: check(epoch, run_id/PID, Liveness)
+        P-->>D: Healthy / Unhealthy
+        D->>T: serialized observation
+        T-->>W: Running + health transition/counters
+    end
+    Note over D,W: Reconcile checks share this queue;<br/>at most one probe is in flight per instance
+    Note over T,W: Sustained Unhealthy is observe-only;<br/>the process is not restarted automatically
+```
+
+If a future release adds a restart reaction, it must be manager-owned and pass
+through the existing stop confirmation, quarantine, and proof-of-death paths.
+It must not call supervisor readiness acknowledgement on runtime recovery or
+kill/restart an epoch directly from the probe driver.
 
 ### Graceful switch
 
@@ -194,6 +234,41 @@ manager.start(spec).await?; // resolves once the version probe passes
 manager.stop().await?;
 ```
 
+### Custom readiness and liveness
+
+```rust
+use std::{num::NonZeroU32, time::Duration};
+use nyanpasu_core_manager::{
+    CoreManager, HealthPolicy, ProbeHandle, ProbeResult,
+};
+
+spec.options.health = HealthPolicy::new(
+    Duration::from_millis(250),
+    Duration::from_secs(1),
+    NonZeroU32::new(3).unwrap(), // failures before Unhealthy
+    NonZeroU32::new(2).unwrap(), // successes before Healthy/ready
+    Duration::from_secs(2),      // initial failure grace per process run
+)?;
+
+let tcp_liveness = ProbeHandle::from_fn("proxy-tcp", |context| async move {
+    match tokio::net::TcpStream::connect(("127.0.0.1", 7890)).await {
+        Ok(_) => ProbeResult::Healthy,
+        Err(error) => ProbeResult::Unhealthy { detail: Some(error.to_string()) },
+    }
+});
+
+let manager = CoreManager::builder(manager_options)
+    // Omit readiness_probe() to retain ControllerVersionProbe.
+    .liveness_probe(tcp_liveness)
+    .build()
+    .await?;
+```
+
+`.liveness_with_readiness_probe()` reuses one probe for both phases. Prefer
+separate probes during graceful switching: the bootstrap intentionally zeroes
+proxy listener ports, so a proxy-port TCP check is unsuitable for readiness
+even though it is useful after `Running`.
+
 ### Managed mode + graceful switch
 
 ```rust
@@ -271,10 +346,10 @@ tokio::spawn(async move {
 });
 ```
 
-`CoreStatus` also carries `changed_at` (unix ms of the last transition),
-`spec`, `controller`, and the active `ConfigRevision`. These fields are
-published together, so a new epoch is never paired with the previous epoch's
-controller.
+`CoreStatus` also carries `changed_at` (unix ms of the last lifecycle
+transition), `health`, `spec`, `controller`, and the active `ConfigRevision`.
+These fields are published together, so a new epoch is never paired with the
+previous epoch's controller or health.
 
 ## Runtime directory security and recovery
 
@@ -336,19 +411,32 @@ nyanpasu_core_manager::kind::check_config(spec).await?;
 
 ```rust
 use std::time::Duration;
-use nyanpasu_core_manager::InstanceOptions;
+use std::num::NonZeroU32;
+use nyanpasu_core_manager::{HealthPolicy, InstanceOptions};
 use nyanpasu_utils::process::{Backoff, RestartPolicy};
 
 let options = InstanceOptions {
     // Total budget for the initial start, crash retries included.
     startup_timeout: Duration::from_secs(30),
-    // GET /version cadence; each probe has a 1s request timeout.
-    probe_interval: Duration::from_millis(250),
+    health: HealthPolicy::new(
+        Duration::from_millis(250), // delay after each completed probe
+        Duration::from_secs(1),     // per-attempt timeout
+        NonZeroU32::new(3).unwrap(),// failures before Unhealthy
+        NonZeroU32::MIN,            // successes before Healthy/ready
+        Duration::ZERO,             // failure grace per child run
+    )?,
     restart_policy: RestartPolicy::OnFailure { max_restarts: 5 },
     backoff: Backoff::exponential(Duration::from_secs(1), Duration::from_secs(30))
         .with_jitter(),
 };
 ```
+
+The default readiness probe is `ControllerVersionProbe` with its fixed one
+second HTTP timeout. Runtime liveness is off unless configured, preserving the
+previous post-start behavior and overhead. `start_period` ignores initial
+failures only; its first success ends the grace immediately. Threshold streaks
+reset on the opposite result and on each new child-process run. None of these
+settings extend the one absolute initial `startup_timeout` deadline.
 
 ## Testing
 

--- a/crates/nyanpasu-core-manager/src/error.rs
+++ b/crates/nyanpasu-core-manager/src/error.rs
@@ -23,6 +23,8 @@ pub enum Error {
     InvalidConfig(String),
     #[error("invalid manager options: {0}")]
     InvalidManagerOptions(String),
+    #[error("invalid health policy: {0}")]
+    InvalidHealthPolicy(String),
     #[error("unsafe runtime artifact: {0}")]
     UnsafeRuntimeArtifact(Utf8PathBuf),
     #[error("runtime directory is already owned by another manager: {0}")]

--- a/crates/nyanpasu-core-manager/src/health.rs
+++ b/crates/nyanpasu-core-manager/src/health.rs
@@ -1,19 +1,172 @@
-//! Version-probe health checking against the core's external controller.
+//! Health-check policy and transition tracking.
 
-use std::time::Duration;
+use std::{num::NonZeroU32, time::Duration};
 
-use crate::{error::Error, spec::ResolvedController};
+use crate::{error::Error, probe::ProbeResult, spec::ResolvedController};
 
-/// Builds a probe client with the fixed one-second health timeout.
-pub(crate) fn build_health_client(
-    controller: &ResolvedController,
-) -> Result<clash_api::Client, Error> {
-    let mut builder = clash_api::Client::builder(controller.host.clone())
-        .configure_reqwest(|b| b.timeout(Duration::from_secs(1)));
-    if let Some(secret) = &controller.secret {
-        builder = builder.secret(secret.as_str());
+pub(crate) const MAX_LAST_ERROR_BYTES: usize = 512;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HealthPolicy {
+    interval: Duration,
+    timeout: Duration,
+    failure_threshold: NonZeroU32,
+    success_threshold: NonZeroU32,
+    start_period: Duration,
+}
+
+impl HealthPolicy {
+    pub fn new(
+        interval: Duration,
+        timeout: Duration,
+        failure_threshold: NonZeroU32,
+        success_threshold: NonZeroU32,
+        start_period: Duration,
+    ) -> Result<Self, Error> {
+        if interval.is_zero() {
+            return Err(Error::InvalidHealthPolicy(
+                "interval must be greater than zero".into(),
+            ));
+        }
+        if timeout.is_zero() {
+            return Err(Error::InvalidHealthPolicy(
+                "timeout must be greater than zero".into(),
+            ));
+        }
+        Ok(Self {
+            interval,
+            timeout,
+            failure_threshold,
+            success_threshold,
+            start_period,
+        })
     }
-    Ok(builder.build()?)
+
+    pub fn interval(&self) -> Duration {
+        self.interval
+    }
+
+    pub fn timeout(&self) -> Duration {
+        self.timeout
+    }
+
+    pub fn failure_threshold(&self) -> NonZeroU32 {
+        self.failure_threshold
+    }
+
+    pub fn success_threshold(&self) -> NonZeroU32 {
+        self.success_threshold
+    }
+
+    pub fn start_period(&self) -> Duration {
+        self.start_period
+    }
+}
+
+impl Default for HealthPolicy {
+    fn default() -> Self {
+        Self {
+            interval: Duration::from_millis(250),
+            timeout: Duration::from_secs(1),
+            failure_threshold: NonZeroU32::new(3).expect("non-zero"),
+            success_threshold: NonZeroU32::MIN,
+            start_period: Duration::ZERO,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TrackerState {
+    Starting,
+    Healthy,
+    Unhealthy,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TrackerUpdate {
+    pub(crate) state: TrackerState,
+    pub(crate) transitioned: bool,
+    pub(crate) consecutive_failures: u32,
+    pub(crate) last_error: Option<String>,
+}
+
+pub(crate) struct HealthTracker {
+    policy: HealthPolicy,
+    started_at: std::time::Instant,
+    grace_ended: bool,
+    state: TrackerState,
+    consecutive_failures: u32,
+    consecutive_successes: u32,
+    last_error: Option<String>,
+}
+
+impl HealthTracker {
+    pub(crate) fn new(policy: HealthPolicy, started_at: std::time::Instant) -> Self {
+        Self {
+            policy,
+            started_at,
+            grace_ended: false,
+            state: TrackerState::Starting,
+            consecutive_failures: 0,
+            consecutive_successes: 0,
+            last_error: None,
+        }
+    }
+
+    pub(crate) fn observe(
+        &mut self,
+        now: std::time::Instant,
+        result: &ProbeResult,
+    ) -> TrackerUpdate {
+        let previous = self.state;
+        match result {
+            ProbeResult::Healthy => {
+                self.grace_ended = true;
+                self.consecutive_failures = 0;
+                self.last_error = None;
+                if self.state == TrackerState::Healthy {
+                    self.consecutive_successes = 0;
+                } else {
+                    self.consecutive_successes = self.consecutive_successes.saturating_add(1);
+                    if self.consecutive_successes >= self.policy.success_threshold.get() {
+                        self.state = TrackerState::Healthy;
+                        self.consecutive_successes = 0;
+                    }
+                }
+            }
+            ProbeResult::Unhealthy { detail } => {
+                self.consecutive_successes = 0;
+                self.last_error = detail.as_deref().map(cap_detail);
+                let grace_active =
+                    !self.grace_ended && now < self.started_at + self.policy.start_period;
+                if !grace_active {
+                    self.consecutive_failures = self.consecutive_failures.saturating_add(1);
+                    if self.state != TrackerState::Unhealthy
+                        && self.consecutive_failures >= self.policy.failure_threshold.get()
+                    {
+                        self.state = TrackerState::Unhealthy;
+                    }
+                }
+            }
+        }
+        TrackerUpdate {
+            state: self.state,
+            transitioned: previous != self.state,
+            consecutive_failures: self.consecutive_failures,
+            last_error: self.last_error.clone(),
+        }
+    }
+}
+
+fn cap_detail(detail: &str) -> String {
+    if detail.len() <= MAX_LAST_ERROR_BYTES {
+        return detail.to_owned();
+    }
+    let mut end = MAX_LAST_ERROR_BYTES;
+    while !detail.is_char_boundary(end) {
+        end -= 1;
+    }
+    detail[..end].to_owned()
 }
 
 pub(crate) fn build_control_client(
@@ -28,66 +181,170 @@ pub(crate) fn build_control_client(
     Ok(builder.build()?)
 }
 
-pub(crate) struct HealthCheck {
-    client: clash_api::Client,
-}
-
-impl HealthCheck {
-    pub(crate) fn new(controller: &ResolvedController) -> Result<Self, Error> {
-        Ok(Self {
-            client: build_health_client(controller)?,
-        })
-    }
-
-    /// One probe attempt: healthy iff `GET /version` succeeds.
-    pub(crate) async fn probe_once(&self) -> bool {
-        self.client.version().await.is_ok()
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::num::NonZeroU32;
 
-    fn controller(port: u16) -> ResolvedController {
-        ResolvedController {
-            host: clash_api::Host::http(format!("127.0.0.1:{port}")).unwrap(),
-            secret: None,
-        }
+    fn policy(failures: u32, successes: u32, start_period: Duration) -> HealthPolicy {
+        HealthPolicy::new(
+            Duration::from_millis(10),
+            Duration::from_millis(20),
+            NonZeroU32::new(failures).unwrap(),
+            NonZeroU32::new(successes).unwrap(),
+            start_period,
+        )
+        .unwrap()
     }
 
-    #[tokio::test]
-    async fn probe_fails_against_closed_port_and_succeeds_against_version_server() {
-        // Closed port → probe false.
-        let port = {
-            let l = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
-            l.local_addr().unwrap().port()
-        };
-        let probe = HealthCheck::new(&controller(port)).unwrap();
-        assert!(!probe.probe_once().await);
+    #[test]
+    fn policy_rejects_zero_interval_and_timeout() {
+        assert!(
+            HealthPolicy::new(
+                Duration::ZERO,
+                Duration::from_secs(1),
+                NonZeroU32::MIN,
+                NonZeroU32::MIN,
+                Duration::ZERO,
+            )
+            .is_err()
+        );
+        assert!(
+            HealthPolicy::new(
+                Duration::from_secs(1),
+                Duration::ZERO,
+                NonZeroU32::MIN,
+                NonZeroU32::MIN,
+                Duration::ZERO,
+            )
+            .is_err()
+        );
+    }
 
-        // Minimal /version responder → probe true.
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let port = listener.local_addr().unwrap().port();
-        tokio::spawn(async move {
-            loop {
-                let Ok((mut stream, _)) = listener.accept().await else {
-                    continue;
-                };
-                tokio::spawn(async move {
-                    use tokio::io::{AsyncReadExt, AsyncWriteExt};
-                    let mut buf = [0u8; 1024];
-                    let _ = stream.read(&mut buf).await;
-                    let body = r#"{"meta":true,"version":"t"}"#;
-                    let resp = format!(
-                        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
-                        body.len()
-                    );
-                    let _ = stream.write_all(resp.as_bytes()).await;
-                });
-            }
-        });
-        let probe = HealthCheck::new(&controller(port)).unwrap();
-        assert!(probe.probe_once().await);
+    #[test]
+    fn starting_success_threshold_and_interrupted_streak() {
+        let start = std::time::Instant::now();
+        let mut tracker = HealthTracker::new(policy(3, 2, Duration::ZERO), start);
+
+        let first = tracker.observe(start, &ProbeResult::Healthy);
+        assert_eq!(first.state, TrackerState::Starting);
+        assert!(!first.transitioned);
+
+        tracker.observe(
+            start,
+            &ProbeResult::Unhealthy {
+                detail: Some("not yet".into()),
+            },
+        );
+        let restarted = tracker.observe(start, &ProbeResult::Healthy);
+        assert_eq!(restarted.state, TrackerState::Starting);
+
+        let ready = tracker.observe(start, &ProbeResult::Healthy);
+        assert_eq!(ready.state, TrackerState::Healthy);
+        assert!(ready.transitioned);
+    }
+
+    #[test]
+    fn failures_cross_threshold_without_flapping_early() {
+        let start = std::time::Instant::now();
+        let mut tracker = HealthTracker::new(policy(3, 1, Duration::ZERO), start);
+        tracker.observe(start, &ProbeResult::Healthy);
+
+        for count in 1..3 {
+            let update = tracker.observe(
+                start,
+                &ProbeResult::Unhealthy {
+                    detail: Some(format!("failure {count}")),
+                },
+            );
+            assert_eq!(update.state, TrackerState::Healthy);
+            assert!(!update.transitioned);
+        }
+        let unhealthy = tracker.observe(
+            start,
+            &ProbeResult::Unhealthy {
+                detail: Some("threshold".into()),
+            },
+        );
+        assert_eq!(unhealthy.state, TrackerState::Unhealthy);
+        assert!(unhealthy.transitioned);
+
+        let repeated = tracker.observe(
+            start,
+            &ProbeResult::Unhealthy {
+                detail: Some("still failing".into()),
+            },
+        );
+        assert_eq!(repeated.state, TrackerState::Unhealthy);
+        assert!(!repeated.transitioned);
+    }
+
+    #[test]
+    fn unhealthy_recovery_requires_consecutive_successes() {
+        let start = std::time::Instant::now();
+        let mut tracker = HealthTracker::new(policy(1, 2, Duration::ZERO), start);
+        tracker.observe(start, &ProbeResult::Healthy);
+        tracker.observe(
+            start,
+            &ProbeResult::Unhealthy {
+                detail: Some("down".into()),
+            },
+        );
+
+        let first = tracker.observe(start, &ProbeResult::Healthy);
+        assert_eq!(first.state, TrackerState::Unhealthy);
+        tracker.observe(
+            start,
+            &ProbeResult::Unhealthy {
+                detail: Some("again".into()),
+            },
+        );
+        assert_eq!(
+            tracker.observe(start, &ProbeResult::Healthy).state,
+            TrackerState::Unhealthy
+        );
+        let recovered = tracker.observe(start, &ProbeResult::Healthy);
+        assert_eq!(recovered.state, TrackerState::Healthy);
+        assert!(recovered.transitioned);
+    }
+
+    #[test]
+    fn start_period_ignores_failures_and_first_success_ends_it() {
+        let start = std::time::Instant::now();
+        let mut tracker = HealthTracker::new(policy(1, 2, Duration::from_secs(10)), start);
+        let within_grace = start + Duration::from_secs(1);
+        let ignored = tracker.observe(
+            within_grace,
+            &ProbeResult::Unhealthy {
+                detail: Some("ignored".into()),
+            },
+        );
+        assert_eq!(ignored.state, TrackerState::Starting);
+        assert_eq!(ignored.consecutive_failures, 0);
+
+        tracker.observe(within_grace, &ProbeResult::Healthy);
+        let counted = tracker.observe(
+            within_grace,
+            &ProbeResult::Unhealthy {
+                detail: Some("counted".into()),
+            },
+        );
+        assert_eq!(counted.state, TrackerState::Unhealthy);
+        assert_eq!(counted.consecutive_failures, 1);
+    }
+
+    #[test]
+    fn failure_counter_saturates_and_error_is_capped() {
+        let start = std::time::Instant::now();
+        let mut tracker = HealthTracker::new(policy(1, 1, Duration::ZERO), start);
+        tracker.consecutive_failures = u32::MAX;
+        let update = tracker.observe(
+            start,
+            &ProbeResult::Unhealthy {
+                detail: Some("x".repeat(MAX_LAST_ERROR_BYTES * 2)),
+            },
+        );
+        assert_eq!(update.consecutive_failures, u32::MAX);
+        assert!(update.last_error.as_ref().unwrap().len() <= MAX_LAST_ERROR_BYTES);
     }
 }

--- a/crates/nyanpasu-core-manager/src/instance.rs
+++ b/crates/nyanpasu-core-manager/src/instance.rs
@@ -13,17 +13,19 @@ use nyanpasu_utils::process::{
     Supervisor, SupervisorEvent, TerminatedPayload, reap_epoch_pid_file,
 };
 use tokio::{
-    sync::{mpsc, watch},
+    sync::{mpsc, oneshot, watch},
     time::Instant,
 };
 use tokio_util::sync::CancellationToken;
 
 use crate::{
     error::Error,
-    health::HealthCheck,
+    health::{HealthTracker, TrackerState},
     kind::{self, MIHOMO_SAFE_PATHS_ENV_NAME},
+    probe::{ControllerVersionProbe, ProbeHandle, ProbePhase, ProbeResult},
+    probe_driver::{ProbeDriver, ProbeObservation},
     spec::{InstanceOptions, InstanceSpec, ResolvedController},
-    state::{InstanceState, StopReason},
+    state::{HealthState, HealthStatus, InstanceState, InstanceStatus, StopReason, now_ms},
 };
 
 const STDERR_TAIL_LINES: usize = 32;
@@ -33,24 +35,35 @@ const STDERR_TAIL_LINES: usize = 32;
 pub struct Instance {
     epoch: u64,
     spec: Arc<InstanceSpec>,
-    controller: ResolvedController,
-    state_rx: watch::Receiver<InstanceState>,
+    controller: Arc<ResolvedController>,
+    state_rx: watch::Receiver<InstanceStatus>,
     shared: Arc<Shared>,
 }
 
 struct Shared {
-    state_tx: watch::Sender<InstanceState>,
+    state_tx: watch::Sender<InstanceStatus>,
     user_stop: AtomicBool,
     probe_timeout: AtomicBool,
     stderr_tail: parking_lot::Mutex<VecDeque<String>>,
     cancel: CancellationToken,
+    probe_cancel: CancellationToken,
+    probe_request_tx: mpsc::UnboundedSender<ProbeNowRequest>,
     supervisor: tokio::sync::Mutex<Option<Supervisor>>,
     monitor: tokio::sync::Mutex<Option<tokio::task::JoinHandle<()>>>,
 }
 
 impl Shared {
     fn publish(&self, state: InstanceState) {
-        let _ = self.state_tx.send(state);
+        self.state_tx.send_modify(|status| {
+            status.state = state.clone();
+            if matches!(state, InstanceState::Stopping | InstanceState::Stopped(_)) {
+                status.health = None;
+            }
+        });
+    }
+
+    fn publish_status(&self, status: InstanceStatus) {
+        let _ = self.state_tx.send(status);
     }
 
     fn tail(&self) -> String {
@@ -59,13 +72,57 @@ impl Shared {
     }
 }
 
+struct ProbeNowRequest {
+    response: oneshot::Sender<ProbeResult>,
+}
+
+pub struct InstanceBuilder {
+    spec: InstanceSpec,
+    epoch: u64,
+    controller: ResolvedController,
+    parent: CancellationToken,
+    readiness_probe: Option<ProbeHandle>,
+    liveness_probe: Option<ProbeHandle>,
+    liveness_with_readiness: bool,
+}
+
 impl Instance {
+    pub fn builder(
+        spec: InstanceSpec,
+        epoch: u64,
+        controller: ResolvedController,
+        parent: CancellationToken,
+    ) -> InstanceBuilder {
+        InstanceBuilder {
+            spec,
+            epoch,
+            controller,
+            parent,
+            readiness_probe: None,
+            liveness_probe: None,
+            liveness_with_readiness: false,
+        }
+    }
+
     pub async fn spawn(
         spec: InstanceSpec,
         epoch: u64,
         controller: ResolvedController,
         parent: CancellationToken,
     ) -> Result<Instance, Error> {
+        Self::builder(spec, epoch, controller, parent).spawn().await
+    }
+
+    async fn spawn_configured(builder: InstanceBuilder) -> Result<Instance, Error> {
+        let InstanceBuilder {
+            spec,
+            epoch,
+            controller,
+            parent,
+            readiness_probe,
+            liveness_probe,
+            liveness_with_readiness,
+        } = builder;
         if tokio::fs::metadata(&spec.config_path).await.is_err() {
             return Err(Error::ConfigNotFound(spec.config_path.clone()));
         }
@@ -77,15 +134,33 @@ impl Instance {
             .kind
             .run_args(&spec.working_dir, &spec.config_path)?;
 
+        let readiness_probe = match readiness_probe {
+            Some(probe) => probe,
+            None => ProbeHandle::new(
+                "controller-version",
+                ControllerVersionProbe::new(&controller)?,
+            ),
+        };
+        let liveness_probe = if liveness_with_readiness {
+            Some(readiness_probe.clone())
+        } else {
+            liveness_probe
+        };
+        let initial_deadline = Instant::now() + spec.options.startup_timeout;
         let spec = Arc::new(spec);
-        let (state_tx, state_rx) = watch::channel(InstanceState::Starting);
+        let controller = Arc::new(controller);
+        let (state_tx, state_rx) = watch::channel(InstanceStatus::initial());
         let cancel = parent.child_token();
+        let probe_cancel = CancellationToken::new();
+        let (probe_request_tx, probe_request_rx) = mpsc::unbounded_channel();
         let shared = Arc::new(Shared {
             state_tx,
             user_stop: AtomicBool::new(false),
             probe_timeout: AtomicBool::new(false),
             stderr_tail: parking_lot::Mutex::new(VecDeque::with_capacity(STDERR_TAIL_LINES)),
             cancel: cancel.clone(),
+            probe_cancel,
+            probe_request_tx,
             supervisor: tokio::sync::Mutex::new(None),
             monitor: tokio::sync::Mutex::new(None),
         });
@@ -127,8 +202,13 @@ impl Instance {
         let monitor = tokio::spawn(monitor_loop(
             event_rx,
             shared.clone(),
+            epoch,
             spec.options.clone(),
             controller.clone(),
+            readiness_probe,
+            liveness_probe,
+            initial_deadline,
+            probe_request_rx,
         ));
         *shared.monitor.lock().await = Some(monitor);
 
@@ -141,7 +221,7 @@ impl Instance {
         })
     }
 
-    pub fn state(&self) -> watch::Receiver<InstanceState> {
+    pub fn state(&self) -> watch::Receiver<InstanceStatus> {
         self.state_rx.clone()
     }
 
@@ -158,7 +238,7 @@ impl Instance {
     }
 
     pub fn pid(&self) -> Option<u32> {
-        match &*self.state_rx.borrow() {
+        match &self.state_rx.borrow().state {
             InstanceState::Running { pid } => Some(*pid),
             _ => None,
         }
@@ -169,7 +249,7 @@ impl Instance {
     pub async fn wait_ready(&self) -> Result<(), Error> {
         let mut rx = self.state_rx.clone();
         loop {
-            let state = rx.borrow_and_update().clone();
+            let state = rx.borrow_and_update().state.clone();
             match state {
                 InstanceState::Running { .. } => return Ok(()),
                 InstanceState::Stopped(reason) => {
@@ -194,6 +274,29 @@ impl Instance {
         }
     }
 
+    /// Runs one serialized health check using the instance's configured probe.
+    pub async fn probe_now(&self, phase: ProbePhase) -> ProbeResult {
+        if !matches!(phase, ProbePhase::Reconcile) {
+            return ProbeResult::Unhealthy {
+                detail: Some("only reconciliation probes can be requested directly".into()),
+            };
+        }
+        let (response, result) = oneshot::channel();
+        if self
+            .shared
+            .probe_request_tx
+            .send(ProbeNowRequest { response })
+            .is_err()
+        {
+            return ProbeResult::Unhealthy {
+                detail: Some("instance probe monitor is not running".into()),
+            };
+        }
+        result.await.unwrap_or_else(|_| ProbeResult::Unhealthy {
+            detail: Some("instance probe driver stopped".into()),
+        })
+    }
+
     /// Compatibility wrapper for callers that do not provide a manager stop
     /// deadline.
     pub async fn stop(self) -> Result<(), Error> {
@@ -205,7 +308,7 @@ impl Instance {
     /// If normal supervisor termination is uncertain, the structured epoch pid
     /// record is the only authority used for the fallback kill.
     pub async fn stop_and_confirm_dead(self, timeout: std::time::Duration) -> Result<(), Error> {
-        if self.state_rx.borrow().is_terminal() {
+        if self.state_rx.borrow().state.is_terminal() {
             self.reap_epoch_record_if_present().await.map_err(|error| {
                 Error::StopUnconfirmed(format!(
                     "terminal instance identity verification failed: {error}"
@@ -214,6 +317,7 @@ impl Instance {
             return Ok(());
         }
         self.shared.user_stop.store(true, Ordering::SeqCst);
+        self.shared.probe_cancel.cancel();
         self.shared.publish(InstanceState::Stopping);
         let supervisor = self.shared.supervisor.lock().await.take();
         let stop_result = match supervisor {
@@ -235,7 +339,7 @@ impl Instance {
                 }
             }
         }
-        let terminal = self.state_rx.borrow().is_terminal();
+        let terminal = self.state_rx.borrow().state.is_terminal();
         if stop_result.is_ok() && (monitor_confirmed || terminal) {
             self.reap_epoch_record_if_present().await.map_err(|error| {
                 Error::StopUnconfirmed(format!(
@@ -290,11 +394,35 @@ impl Instance {
     }
 }
 
+impl InstanceBuilder {
+    pub fn readiness_probe(mut self, probe: ProbeHandle) -> Self {
+        self.readiness_probe = Some(probe);
+        self
+    }
+
+    pub fn liveness_probe(mut self, probe: ProbeHandle) -> Self {
+        self.liveness_probe = Some(probe);
+        self.liveness_with_readiness = false;
+        self
+    }
+
+    pub fn liveness_with_readiness_probe(mut self) -> Self {
+        self.liveness_probe = None;
+        self.liveness_with_readiness = true;
+        self
+    }
+
+    pub async fn spawn(self) -> Result<Instance, Error> {
+        Instance::spawn_configured(self).await
+    }
+}
+
 /// Dropping an `Instance` without `stop()` cancels supervision so the core
 /// process tree is killed instead of orphaned (the monitor and supervisor
 /// tasks hold `Arc<Shared>`, so drop alone would never reach them).
 impl Drop for Instance {
     fn drop(&mut self) {
+        self.shared.probe_cancel.cancel();
         self.shared.cancel.cancel();
     }
 }
@@ -340,56 +468,108 @@ fn epoch_pid_path(spec: &InstanceSpec, epoch: u64) -> Option<&camino::Utf8Path> 
     .then_some(pid_file)
 }
 
-struct Probe {
+struct RunState {
+    run_id: u64,
     pid: u32,
-    deadline: Instant,
+    ack_attempted: bool,
+    ready: bool,
+    tracker: HealthTracker,
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn monitor_loop(
     mut events: mpsc::UnboundedReceiver<SupervisorEvent>,
     shared: Arc<Shared>,
+    epoch: u64,
     options: InstanceOptions,
-    controller: ResolvedController,
+    controller: Arc<ResolvedController>,
+    readiness_probe: ProbeHandle,
+    liveness_probe: Option<ProbeHandle>,
+    initial_deadline: Instant,
+    mut probe_requests: mpsc::UnboundedReceiver<ProbeNowRequest>,
 ) {
-    let health = match HealthCheck::new(&controller) {
-        Ok(health) => health,
-        Err(error) => {
-            shared.cancel.cancel();
-            shared.publish(InstanceState::Stopped(StopReason::Error(format!(
-                "failed to build the health-probe client: {error}"
-            ))));
-            return;
-        }
-    };
-
-    let initial_deadline = Instant::now() + options.startup_timeout;
+    let (observation_tx, mut observations) = mpsc::unbounded_channel();
     let mut ever_ready = false;
     let mut timeout_fired = false;
-    let mut probe: Option<Probe> = None;
+    let mut probes_cancelled = false;
+    let mut next_run_id = 0_u64;
+    let mut current: Option<RunState> = None;
+    let mut driver: Option<ProbeDriver> = None;
+    let mut respawn_deadline: Option<Instant> = None;
     let mut last_exit: Option<TerminatedPayload> = None;
 
     loop {
+        let respawn_deadline_for_select = respawn_deadline.unwrap_or(initial_deadline);
         tokio::select! {
+            biased;
+            _ = shared.probe_cancel.cancelled(), if !probes_cancelled => {
+                probes_cancelled = true;
+                stop_probe_driver(&mut driver).await;
+                current = None;
+                respawn_deadline = None;
+            }
             maybe = events.recv() => match maybe {
                 Some(SupervisorEvent::Started { pid }) => {
-                    probe = Some(Probe {
-                        pid,
-                        deadline: Instant::now() + options.startup_timeout,
+                    stop_probe_driver(&mut driver).await;
+                    next_run_id = next_run_id.saturating_add(1);
+                    let started_at = std::time::Instant::now();
+                    let previous_health = shared.state_tx.borrow().health.clone();
+                    let lifecycle = shared.state_tx.borrow().state.clone();
+                    shared.publish_status(InstanceStatus {
+                        state: lifecycle,
+                        health: Some(reset_starting_health(previous_health.as_ref())),
                     });
+                    current = Some(RunState {
+                        run_id: next_run_id,
+                        pid,
+                        ack_attempted: false,
+                        ready: false,
+                        tracker: HealthTracker::new(options.health.clone(), started_at),
+                    });
+                    respawn_deadline = ever_ready
+                        .then(|| Instant::now() + options.startup_timeout);
+                    if !probes_cancelled {
+                        driver = Some(ProbeDriver::start(
+                            epoch,
+                            next_run_id,
+                            pid,
+                            controller.clone(),
+                            readiness_probe.clone(),
+                            liveness_probe.clone(),
+                            options.health.clone(),
+                            observation_tx.clone(),
+                        ));
+                    }
                 }
                 Some(SupervisorEvent::Restarting { attempt, .. }) => {
-                    probe = None;
-                    shared.publish(InstanceState::Restarting { attempt });
+                    stop_probe_driver(&mut driver).await;
+                    current = None;
+                    respawn_deadline = None;
+                    let previous_health = shared.state_tx.borrow().health.clone();
+                    shared.publish_status(InstanceStatus {
+                        state: InstanceState::Restarting { attempt },
+                        health: Some(reset_starting_health(previous_health.as_ref())),
+                    });
                 }
-                Some(SupervisorEvent::Exited(payload)) => last_exit = Some(payload),
+                Some(SupervisorEvent::Exited(payload)) => {
+                    stop_probe_driver(&mut driver).await;
+                    current = None;
+                    respawn_deadline = None;
+                    last_exit = Some(payload);
+                }
                 Some(SupervisorEvent::GaveUp) => {
-                    shared.publish(InstanceState::Stopped(StopReason::Error(format!(
+                    stop_probe_driver(&mut driver).await;
+                    shared.publish_status(InstanceStatus {
+                        state: InstanceState::Stopped(StopReason::Error(format!(
                         "core kept crashing; restart budget exhausted\n{}",
                         shared.tail()
-                    ))));
+                        ))),
+                        health: None,
+                    });
                     return;
                 }
                 Some(SupervisorEvent::Stopped) => {
+                    stop_probe_driver(&mut driver).await;
                     publish_terminal(&shared, last_exit.as_ref());
                     return;
                 }
@@ -401,33 +581,228 @@ async fn monitor_loop(
             },
             _ = tokio::time::sleep_until(initial_deadline), if !ever_ready && !timeout_fired => {
                 // Total limit for the initial start, crash-retries included.
-                timeout_fired = true;
-                probe = None;
-                shared.probe_timeout.store(true, Ordering::SeqCst);
-                shared.cancel.cancel(); // the supervisor kills the tree, then emits Stopped
-            }
-            _ = tokio::time::sleep(options.probe_interval), if probe.is_some() => {
-                let deadline = probe.as_ref().expect("guarded").deadline;
-                if health.probe_once().await {
-                    let pid = probe.take().expect("guarded").pid;
-                    let supervisor = shared.supervisor.lock().await;
-                    let acknowledged = match supervisor.as_ref() {
-                        Some(supervisor) => supervisor.acknowledge_ready(pid).await,
-                        None => false,
-                    };
-                    drop(supervisor);
-                    if acknowledged {
-                        ever_ready = true;
-                        shared.publish(InstanceState::Running { pid });
-                    }
-                } else if ever_ready && Instant::now() >= deadline {
-                    // A post-crash respawn never became healthy again.
-                    probe = None;
+                let became_ready = drain_probe_observations(
+                    &mut observations,
+                    &mut current,
+                    &mut ever_ready,
+                    &mut respawn_deadline,
+                    initial_deadline,
+                    &shared,
+                    driver.as_ref(),
+                    epoch,
+                ).await;
+                if !became_ready && !ever_ready {
+                    timeout_fired = true;
+                    current = None;
+                    respawn_deadline = None;
+                    stop_probe_driver(&mut driver).await;
                     shared.probe_timeout.store(true, Ordering::SeqCst);
+                    shared.probe_cancel.cancel();
+                    shared.cancel.cancel(); // the supervisor kills the tree, then emits Stopped
+                }
+            }
+            _ = tokio::time::sleep_until(respawn_deadline_for_select), if respawn_deadline.is_some() => {
+                let became_ready = drain_probe_observations(
+                    &mut observations,
+                    &mut current,
+                    &mut ever_ready,
+                    &mut respawn_deadline,
+                    initial_deadline,
+                    &shared,
+                    driver.as_ref(),
+                    epoch,
+                ).await;
+                if !became_ready && respawn_deadline.is_some() {
+                    current = None;
+                    respawn_deadline = None;
+                    stop_probe_driver(&mut driver).await;
+                    shared.probe_timeout.store(true, Ordering::SeqCst);
+                    shared.probe_cancel.cancel();
                     shared.cancel.cancel();
                 }
             }
+            request = probe_requests.recv() => match request {
+                Some(request) if current.as_ref().is_some_and(|run| run.ready) => {
+                    if let Some(driver) = &driver {
+                        driver.reconcile(request.response);
+                    } else {
+                        let _ = request.response.send(ProbeResult::Unhealthy {
+                            detail: Some("instance probe driver is not running".into()),
+                        });
+                    }
+                }
+                Some(request) => {
+                    let _ = request.response.send(ProbeResult::Unhealthy {
+                        detail: Some("instance is not running".into()),
+                    });
+                }
+                None => {}
+            },
+            observation = observations.recv() => {
+                let Some(observation) = observation else { continue };
+                apply_probe_observation(
+                    observation,
+                    &mut current,
+                    &mut ever_ready,
+                    &mut respawn_deadline,
+                    initial_deadline,
+                    &shared,
+                    driver.as_ref(),
+                    epoch,
+                ).await;
+            }
         }
+    }
+}
+
+fn observation_applies(observation: &ProbeObservation, run: &RunState) -> bool {
+    observation.run_id == run.run_id && observation.pid == run.pid
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn apply_probe_observation(
+    observation: ProbeObservation,
+    current: &mut Option<RunState>,
+    ever_ready: &mut bool,
+    respawn_deadline: &mut Option<Instant>,
+    initial_deadline: Instant,
+    shared: &Shared,
+    driver: Option<&ProbeDriver>,
+    epoch: u64,
+) -> bool {
+    let Some(run) = current.as_mut() else {
+        return false;
+    };
+    if !observation_applies(&observation, run) {
+        return false;
+    }
+    let beyond_initial_deadline =
+        !*ever_ready && observation.completed_at > initial_deadline.into_std();
+    let beyond_respawn_deadline =
+        respawn_deadline.is_some_and(|deadline| observation.completed_at > deadline.into_std());
+    if beyond_initial_deadline || beyond_respawn_deadline {
+        return false;
+    }
+
+    tracing::trace!(
+        epoch,
+        run_id = observation.run_id,
+        pid = observation.pid,
+        phase = ?observation.phase,
+        "applying health probe observation"
+    );
+    let update = run
+        .tracker
+        .observe(observation.completed_at, &observation.result);
+    let should_ack = !run.ack_attempted && update.state == TrackerState::Healthy;
+    if should_ack {
+        run.ack_attempted = true;
+        let pid = run.pid;
+        let supervisor = shared.supervisor.lock().await;
+        let acknowledged = match supervisor.as_ref() {
+            Some(supervisor) => supervisor.acknowledge_ready(pid).await,
+            None => false,
+        };
+        drop(supervisor);
+        if acknowledged {
+            *ever_ready = true;
+            *respawn_deadline = None;
+            if let Some(run) = current.as_mut() {
+                run.ready = true;
+            }
+            if let Some(driver) = driver {
+                driver.use_liveness();
+            }
+            let previous = shared.state_tx.borrow().health.clone();
+            shared.publish_status(InstanceStatus {
+                state: InstanceState::Running { pid },
+                health: Some(health_status(previous.as_ref(), &update, &observation)),
+            });
+        }
+        return acknowledged;
+    }
+
+    let previous = shared.state_tx.borrow().health.clone();
+    let lifecycle = shared.state_tx.borrow().state.clone();
+    shared.publish_status(InstanceStatus {
+        state: lifecycle,
+        health: Some(health_status(previous.as_ref(), &update, &observation)),
+    });
+    false
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn drain_probe_observations(
+    observations: &mut mpsc::UnboundedReceiver<ProbeObservation>,
+    current: &mut Option<RunState>,
+    ever_ready: &mut bool,
+    respawn_deadline: &mut Option<Instant>,
+    initial_deadline: Instant,
+    shared: &Shared,
+    driver: Option<&ProbeDriver>,
+    epoch: u64,
+) -> bool {
+    while let Ok(observation) = observations.try_recv() {
+        let became_ready = apply_probe_observation(
+            observation,
+            current,
+            ever_ready,
+            respawn_deadline,
+            initial_deadline,
+            shared,
+            driver,
+            epoch,
+        )
+        .await;
+        if became_ready {
+            return true;
+        }
+    }
+    false
+}
+
+async fn stop_probe_driver(driver: &mut Option<ProbeDriver>) {
+    if let Some(driver) = driver.take() {
+        driver.stop().await;
+    }
+}
+
+fn reset_starting_health(previous: Option<&HealthStatus>) -> HealthStatus {
+    HealthStatus {
+        state: HealthState::Starting,
+        changed_at: previous
+            .filter(|status| status.state == HealthState::Starting)
+            .map_or_else(now_ms, |status| status.changed_at),
+        consecutive_failures: 0,
+        last_error: None,
+        last_success_at: None,
+    }
+}
+
+fn health_status(
+    previous: Option<&HealthStatus>,
+    update: &crate::health::TrackerUpdate,
+    observation: &ProbeObservation,
+) -> HealthStatus {
+    let state = match update.state {
+        TrackerState::Starting => HealthState::Starting,
+        TrackerState::Healthy => HealthState::Healthy,
+        TrackerState::Unhealthy => HealthState::Unhealthy,
+    };
+    let changed_at = previous
+        .filter(|status| status.state == state)
+        .map_or(observation.completed_at_ms, |status| status.changed_at);
+    let last_success_at = if observation.result.is_healthy() {
+        Some(observation.completed_at_ms)
+    } else {
+        previous.and_then(|status| status.last_success_at)
+    };
+    HealthStatus {
+        state,
+        changed_at,
+        consecutive_failures: update.consecutive_failures,
+        last_error: update.last_error.clone(),
+        last_success_at,
     }
 }
 
@@ -444,5 +819,150 @@ fn publish_terminal(shared: &Shared, last_exit: Option<&TerminatedPayload>) {
             shared.tail()
         ))
     };
-    let _ = shared.state_tx.send(InstanceState::Stopped(reason));
+    let _ = shared.state_tx.send(InstanceStatus {
+        state: InstanceState::Stopped(reason),
+        health: None,
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+
+    fn run_state(run_id: u64, pid: u32, started_at: std::time::Instant) -> RunState {
+        RunState {
+            run_id,
+            pid,
+            ack_attempted: false,
+            ready: false,
+            tracker: HealthTracker::new(crate::health::HealthPolicy::default(), started_at),
+        }
+    }
+
+    fn healthy_observation(
+        run_id: u64,
+        pid: u32,
+        completed_at: std::time::Instant,
+    ) -> ProbeObservation {
+        ProbeObservation {
+            run_id,
+            pid,
+            phase: ProbePhase::Readiness,
+            completed_at,
+            completed_at_ms: now_ms(),
+            result: ProbeResult::Healthy,
+        }
+    }
+
+    #[test]
+    fn observation_requires_matching_run_id_and_pid() {
+        let now = std::time::Instant::now();
+        let run = run_state(7, 42, now);
+
+        assert!(observation_applies(&healthy_observation(7, 42, now), &run));
+        assert!(!observation_applies(&healthy_observation(6, 42, now), &run));
+        assert!(!observation_applies(&healthy_observation(7, 41, now), &run));
+        assert!(!observation_applies(&healthy_observation(6, 41, now), &run));
+    }
+
+    #[test]
+    #[ignore = "spawned as the managed child by the deadline-drain test"]
+    fn deadline_drain_test_child() {
+        std::thread::sleep(Duration::from_secs(60));
+    }
+
+    #[tokio::test]
+    async fn deadline_drain_applies_queued_boundary_observation_before_timeout() {
+        let test_binary = std::env::current_exe().expect("test executable");
+        let (event_tx, mut event_rx) = mpsc::unbounded_channel();
+        let supervisor = Supervisor::builder(move || {
+            Command::new(&test_binary)
+                .args([
+                    "--exact",
+                    "instance::tests::deadline_drain_test_child",
+                    "--ignored",
+                ])
+                .kill_grace(Duration::from_millis(20))
+        })
+        .readiness(ReadinessProbe::Acknowledged)
+        .on_event(move |event| {
+            let _ = event_tx.send(event);
+        })
+        .spawn()
+        .await
+        .expect("spawn test child");
+        let pid = tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                if let Some(SupervisorEvent::Started { pid }) = event_rx.recv().await {
+                    break pid;
+                }
+            }
+        })
+        .await
+        .expect("test child did not start");
+
+        let (state_tx, state_rx) = watch::channel(InstanceStatus::initial());
+        let (probe_request_tx, _probe_request_rx) = mpsc::unbounded_channel();
+        let shared = Shared {
+            state_tx,
+            user_stop: AtomicBool::new(false),
+            probe_timeout: AtomicBool::new(false),
+            stderr_tail: parking_lot::Mutex::new(VecDeque::new()),
+            cancel: CancellationToken::new(),
+            probe_cancel: CancellationToken::new(),
+            probe_request_tx,
+            supervisor: tokio::sync::Mutex::new(Some(supervisor)),
+            monitor: tokio::sync::Mutex::new(None),
+        };
+        let initial_deadline = Instant::now() + Duration::from_millis(10);
+        let deadline = initial_deadline.into_std();
+        let mut current = Some(run_state(1, pid, std::time::Instant::now()));
+        let mut ever_ready = false;
+        let mut respawn_deadline = None;
+        let (observation_tx, mut observations) = mpsc::unbounded_channel();
+        observation_tx
+            .send(healthy_observation(
+                1,
+                pid,
+                deadline + Duration::from_nanos(1),
+            ))
+            .unwrap();
+        observation_tx
+            .send(healthy_observation(1, pid, deadline))
+            .unwrap();
+        tokio::time::sleep_until(initial_deadline + Duration::from_millis(1)).await;
+
+        assert!(
+            drain_probe_observations(
+                &mut observations,
+                &mut current,
+                &mut ever_ready,
+                &mut respawn_deadline,
+                initial_deadline,
+                &shared,
+                None,
+                1,
+            )
+            .await
+        );
+        assert!(ever_ready);
+        assert!(current.as_ref().is_some_and(|run| run.ready));
+        assert!(matches!(
+            state_rx.borrow().state,
+            InstanceState::Running { pid: running_pid } if running_pid == pid
+        ));
+
+        let supervisor = shared
+            .supervisor
+            .lock()
+            .await
+            .take()
+            .expect("supervisor retained");
+        tokio::time::timeout(Duration::from_secs(5), supervisor.stop())
+            .await
+            .expect("stop test child")
+            .expect("supervisor stop");
+    }
 }

--- a/crates/nyanpasu-core-manager/src/lib.rs
+++ b/crates/nyanpasu-core-manager/src/lib.rs
@@ -10,15 +10,22 @@ mod health;
 pub mod instance;
 pub mod kind;
 pub mod manager;
+pub mod probe;
+mod probe_driver;
 pub mod runtime_store;
 pub mod spec;
 pub mod state;
 
 pub use clash_api::Host;
 pub use error::Error;
-pub use instance::Instance;
+pub use health::HealthPolicy;
+pub use instance::{Instance, InstanceBuilder};
 pub use kind::CoreKind;
-pub use manager::{ApplyOutcome, CoreManager, DegradeReason, SwitchOutcome};
+pub use manager::{ApplyOutcome, CoreManager, CoreManagerBuilder, DegradeReason, SwitchOutcome};
+pub use probe::{
+    ControllerVersionProbe, HealthProbe, ProbeContext, ProbeFuture, ProbeHandle, ProbePhase,
+    ProbeResult,
+};
 pub use runtime_store::{
     RuntimeCommitDurability, RuntimeConfigBackup, RuntimeConfigCommit, RuntimeConfigStore,
     StagedRuntimeConfig,
@@ -27,5 +34,6 @@ pub use spec::{
     ControllerMode, CoreSpec, InstanceOptions, InstanceSpec, ManagerOptions, ResolvedController,
 };
 pub use state::{
-    ConfigRevision, CoreState, CoreStatus, InstanceState, RevisionId, SpecSummary, StopReason,
+    ConfigRevision, CoreState, CoreStatus, HealthState, HealthStatus, InstanceState,
+    InstanceStatus, RevisionId, SpecSummary, StopReason,
 };

--- a/crates/nyanpasu-core-manager/src/manager.rs
+++ b/crates/nyanpasu-core-manager/src/manager.rs
@@ -16,11 +16,12 @@ use crate::{
     error::Error,
     instance::Instance,
     kind::CoreKind,
+    probe::{ProbeHandle, ProbePhase},
     runtime_store::{RuntimeConfigStore, RuntimeDirectoryLock, StagedRuntimeConfig},
     spec::{ControllerMode, InstanceSpec, ManagerOptions, ResolvedController},
     state::{
-        ConfigRevision, CoreState, CoreStatus, InstanceState, RevisionId, SpecSummary, StopReason,
-        now_ms,
+        ConfigRevision, CoreState, CoreStatus, HealthStatus, InstanceState, InstanceStatus,
+        RevisionId, SpecSummary, StopReason, now_ms,
     },
 };
 
@@ -94,8 +95,21 @@ pub struct CoreManager {
     inner: Arc<Inner>,
 }
 
+pub struct CoreManagerBuilder {
+    options: ManagerOptions,
+    probes: ProbePlan,
+}
+
+#[derive(Clone, Default)]
+struct ProbePlan {
+    readiness: Option<ProbeHandle>,
+    liveness: Option<ProbeHandle>,
+    liveness_with_readiness: bool,
+}
+
 struct Inner {
     options: ManagerOptions,
+    probes: ProbePlan,
     store: RuntimeConfigStore,
     ctrl: tokio::sync::Mutex<Ctrl>,
     status_tx: watch::Sender<CoreStatus>,
@@ -162,37 +176,92 @@ impl Inner {
         revision: Option<ConfigRevision>,
     ) {
         self.status_tx.send_modify(|status| {
+            let lifecycle_changed = status.state != state;
+            let health = default_health_for_state(status.health.as_ref(), &state);
             status.state = state;
+            status.health = health;
             status.spec = spec;
             status.controller = controller;
             status.revision = revision;
-            status.changed_at = now_ms();
-        });
-    }
-
-    fn publish_active(&self, active: &Active, state: CoreState) {
-        self.publish(
-            state,
-            Some(spec_summary(&active.source_spec)),
-            Some(active.instance.controller().host.clone()),
-            Some(active.revision.clone()),
-        );
-    }
-
-    fn publish_epoch_state(&self, epoch: u64, state: CoreState) {
-        self.status_tx.send_modify(|status| {
-            if apply_epoch_state(status, epoch, state.clone()) {
+            if lifecycle_changed {
                 status.changed_at = now_ms();
             }
         });
     }
+
+    fn publish_active(&self, active: &Active, state: CoreState) {
+        self.publish_instance(
+            &active.instance,
+            state,
+            &active.source_spec,
+            &active.revision,
+        );
+    }
+
+    fn publish_instance(
+        &self,
+        instance: &Instance,
+        state: CoreState,
+        source_spec: &InstanceSpec,
+        revision: &ConfigRevision,
+    ) {
+        let health = instance.state().borrow().health.clone();
+        self.status_tx.send_modify(|status| {
+            let lifecycle_changed = status.state != state;
+            status.state = state;
+            status.health = health;
+            status.spec = Some(spec_summary(source_spec));
+            status.controller = Some(instance.controller().host.clone());
+            status.revision = Some(revision.clone());
+            if lifecycle_changed {
+                status.changed_at = now_ms();
+            }
+        });
+    }
+
+    fn publish_epoch_status(&self, epoch: u64, instance: InstanceStatus) {
+        self.status_tx
+            .send_if_modified(|status| apply_epoch_status(status, epoch, &instance));
+    }
 }
 
-fn apply_epoch_state(status: &mut CoreStatus, epoch: u64, state: CoreState) -> bool {
+fn default_health_for_state(
+    previous: Option<&HealthStatus>,
+    state: &CoreState,
+) -> Option<HealthStatus> {
+    let target = match state {
+        CoreState::Starting { .. } | CoreState::Restarting { .. } | CoreState::Switching { .. } => {
+            crate::state::HealthState::Starting
+        }
+        CoreState::Running { .. } => crate::state::HealthState::Healthy,
+        CoreState::Stopping { .. } | CoreState::Stopped { .. } => return None,
+    };
+    let mut health = HealthStatus::starting();
+    health.state = target;
+    if let Some(previous) = previous.filter(|status| status.state == target) {
+        health.changed_at = previous.changed_at;
+        health.consecutive_failures = previous.consecutive_failures;
+        health.last_error.clone_from(&previous.last_error);
+        health.last_success_at = previous.last_success_at;
+    }
+    Some(health)
+}
+
+fn apply_epoch_status(status: &mut CoreStatus, epoch: u64, instance: &InstanceStatus) -> bool {
     if status.revision.as_ref().map(|revision| revision.epoch) != Some(epoch) {
         return false;
     }
+    let state = instance_core_state(epoch, &instance.state);
+    let lifecycle_changed = status.state != state;
+    let health_changed = status.health != instance.health;
+    if !lifecycle_changed && !health_changed {
+        return false;
+    }
     status.state = state;
+    status.health = instance.health.clone();
+    if lifecycle_changed {
+        status.changed_at = now_ms();
+    }
     true
 }
 
@@ -203,8 +272,43 @@ fn spec_summary(spec: &InstanceSpec) -> SpecSummary {
     }
 }
 
+impl CoreManagerBuilder {
+    pub fn readiness_probe(mut self, probe: ProbeHandle) -> Self {
+        self.probes.readiness = Some(probe);
+        self
+    }
+
+    pub fn liveness_probe(mut self, probe: ProbeHandle) -> Self {
+        self.probes.liveness = Some(probe);
+        self.probes.liveness_with_readiness = false;
+        self
+    }
+
+    pub fn liveness_with_readiness_probe(mut self) -> Self {
+        self.probes.liveness = None;
+        self.probes.liveness_with_readiness = true;
+        self
+    }
+
+    pub async fn build(self) -> Result<CoreManager, Error> {
+        CoreManager::build_configured(self).await
+    }
+}
+
 impl CoreManager {
+    pub fn builder(options: ManagerOptions) -> CoreManagerBuilder {
+        CoreManagerBuilder {
+            options,
+            probes: ProbePlan::default(),
+        }
+    }
+
     pub async fn new(options: ManagerOptions) -> Result<Self, Error> {
+        Self::builder(options).build().await
+    }
+
+    async fn build_configured(builder: CoreManagerBuilder) -> Result<Self, Error> {
+        let CoreManagerBuilder { options, probes } = builder;
         let runtime_dir = match (&options.runtime_dir, &options.controller_mode) {
             (Some(runtime_dir), _) => runtime_dir.clone(),
             (None, ControllerMode::Managed { derived_dir, .. }) => derived_dir.clone(),
@@ -240,6 +344,7 @@ impl CoreManager {
         Ok(Self {
             inner: Arc::new(Inner {
                 options,
+                probes,
                 store,
                 ctrl: tokio::sync::Mutex::default(),
                 status_tx,
@@ -272,7 +377,7 @@ impl CoreManager {
         let mut ctrl = self.inner.ctrl.lock().await;
         reject_quarantine(&ctrl)?;
         let current = ctrl.current.as_ref().ok_or(Error::NotStarted)?;
-        if current.instance.state().borrow().is_terminal() {
+        if current.instance.state().borrow().state.is_terminal() {
             return Err(Error::NotStarted);
         }
         let actual_revision = current.revision.id();
@@ -443,7 +548,7 @@ impl CoreManager {
     ) -> bool {
         if let ConfigChange::Patch { patch, projection } = change {
             return self
-                .patch_and_verify(current.instance.controller(), patch, projection)
+                .patch_and_verify(&current.instance, patch, projection)
                 .await;
         }
         if matches!(change, ConfigChange::Switch) {
@@ -479,17 +584,21 @@ impl CoreManager {
                 unreachable!()
             }
         }
-        self.probe_health(current.instance.controller()).await
+        current
+            .instance
+            .probe_now(ProbePhase::Reconcile)
+            .await
+            .is_healthy()
     }
 
     async fn patch_and_verify(
         &self,
-        controller: &ResolvedController,
+        instance: &Instance,
         patch: &clash_api::ConfigPatch,
         projection: &config_diff::RuntimeProjection,
     ) -> bool {
         let client = match crate::health::build_control_client(
-            controller,
+            instance.controller(),
             self.inner.options.control_timeout,
         ) {
             Ok(client) => client,
@@ -515,17 +624,7 @@ impl CoreManager {
                 return false;
             }
         }
-        self.probe_health(controller).await
-    }
-
-    async fn probe_health(&self, controller: &ResolvedController) -> bool {
-        match crate::health::HealthCheck::new(controller) {
-            Ok(health) => health.probe_once().await,
-            Err(error) => {
-                tracing::warn!("failed to build post-apply health probe: {error}");
-                false
-            }
-        }
+        instance.probe_now(ProbePhase::Reconcile).await.is_healthy()
     }
 
     async fn restart_with_compensation(
@@ -825,13 +924,9 @@ impl CoreManager {
         epoch: u64,
         controller: ResolvedController,
     ) -> Result<Instance, Error> {
-        let instance = Instance::spawn(
-            effective_spec,
-            epoch,
-            controller,
-            self.inner.options.cancel_token.clone(),
-        )
-        .await?;
+        let instance = self
+            .spawn_instance(effective_spec, epoch, controller)
+            .await?;
         if let Err(error) = instance.wait_ready().await {
             return match instance
                 .stop_and_confirm_dead(self.inner.options.stop_timeout)
@@ -844,6 +939,30 @@ impl CoreManager {
             };
         }
         Ok(instance)
+    }
+
+    async fn spawn_instance(
+        &self,
+        effective_spec: InstanceSpec,
+        epoch: u64,
+        controller: ResolvedController,
+    ) -> Result<Instance, Error> {
+        let mut builder = Instance::builder(
+            effective_spec,
+            epoch,
+            controller,
+            self.inner.options.cancel_token.clone(),
+        );
+        if let Some(probe) = self.inner.probes.readiness.clone() {
+            builder = builder.readiness_probe(probe);
+        }
+        if let Some(probe) = self.inner.probes.liveness.clone() {
+            builder = builder.liveness_probe(probe);
+        }
+        if self.inner.probes.liveness_with_readiness {
+            builder = builder.liveness_with_readiness_probe();
+        }
+        builder.spawn().await
     }
 
     fn next_epoch(&self) -> u64 {
@@ -965,7 +1084,7 @@ impl CoreManager {
         let running = ctrl
             .current
             .as_ref()
-            .is_some_and(|active| !active.instance.state().borrow().is_terminal());
+            .is_some_and(|active| !active.instance.state().borrow().state.is_terminal());
         if running {
             return Err(Error::AlreadyRunning);
         }
@@ -1015,13 +1134,9 @@ impl CoreManager {
             Some(prepared.controller.host.clone()),
             Some(prepared.revision.clone()),
         );
-        let instance = match Instance::spawn(
-            prepared.effective_spec,
-            epoch,
-            prepared.controller,
-            self.inner.options.cancel_token.clone(),
-        )
-        .await
+        let instance = match self
+            .spawn_instance(prepared.effective_spec, epoch, prepared.controller)
+            .await
         {
             Ok(instance) => instance,
             Err(error) => {
@@ -1051,11 +1166,11 @@ impl CoreManager {
         }
 
         let pid = instance.pid().unwrap_or_default();
-        self.inner.publish(
+        self.inner.publish_instance(
+            &instance,
             CoreState::Running { epoch, pid },
-            Some(spec_summary(&prepared.source_spec)),
-            Some(instance.controller().host.clone()),
-            Some(prepared.revision.clone()),
+            &prepared.source_spec,
+            &prepared.revision,
         );
         let forwarder = spawn_forwarder(&self.inner, instance.state(), epoch);
         ctrl.last_spec = Some(prepared.source_spec.clone());
@@ -1181,7 +1296,7 @@ impl CoreManager {
         let running = ctrl
             .current
             .as_ref()
-            .is_some_and(|active| !active.instance.state().borrow().is_terminal());
+            .is_some_and(|active| !active.instance.state().borrow().state.is_terminal());
         if !running {
             if let Some(stale) = ctrl.current.take() {
                 abort_and_await(stale.forwarder).await;
@@ -1274,18 +1389,21 @@ impl CoreManager {
         let Some(active) = ctrl.current.as_ref() else {
             return;
         };
-        let state = instance_core_state(active.instance.epoch(), &active.instance.state().borrow());
+        let state = instance_core_state(
+            active.instance.epoch(),
+            &active.instance.state().borrow().state,
+        );
         self.inner.publish_active(active, state);
     }
 
     fn install_switched(&self, ctrl: &mut Ctrl, instance: Instance, prepared: PreparedLaunch) {
         let epoch = prepared.revision.epoch;
         let pid = instance.pid().unwrap_or_default();
-        self.inner.publish(
+        self.inner.publish_instance(
+            &instance,
             CoreState::Running { epoch, pid },
-            Some(spec_summary(&prepared.source_spec)),
-            Some(instance.controller().host.clone()),
-            Some(prepared.revision.clone()),
+            &prepared.source_spec,
+            &prepared.revision,
         );
         let forwarder = spawn_forwarder(&self.inner, instance.state(), epoch);
         ctrl.last_spec = Some(prepared.source_spec.clone());
@@ -1330,13 +1448,13 @@ impl CoreManager {
             Some(launch.revision.clone()),
         );
 
-        let instance = match Instance::spawn(
-            launch.effective_spec.clone(),
-            epoch,
-            launch.controller.clone(),
-            self.inner.options.cancel_token.clone(),
-        )
-        .await
+        let instance = match self
+            .spawn_instance(
+                launch.effective_spec.clone(),
+                epoch,
+                launch.controller.clone(),
+            )
+            .await
         {
             Ok(instance) => instance,
             Err(error) => {
@@ -1431,10 +1549,9 @@ impl CoreManager {
         let reconciled = tokio::time::timeout(self.inner.options.reconcile_timeout, async {
             match restoration.as_ref() {
                 Some((patch, projection)) => {
-                    self.patch_and_verify(instance.controller(), patch, projection)
-                        .await
+                    self.patch_and_verify(&instance, patch, projection).await
                 }
-                None => self.probe_health(instance.controller()).await,
+                None => instance.probe_now(ProbePhase::Reconcile).await.is_healthy(),
             }
         })
         .await
@@ -1507,12 +1624,12 @@ impl CoreManager {
             revision,
             ..
         } = active;
-        let captured_state = instance.state().borrow().clone();
+        let captured_status = instance.state().borrow().clone();
         abort_and_await(forwarder).await;
-        if captured_state.is_terminal() {
+        if captured_status.state.is_terminal() {
             let epoch = instance.epoch();
             self.inner.publish(
-                instance_core_state(epoch, &captured_state),
+                instance_core_state(epoch, &captured_status.state),
                 Some(spec_summary(&source_spec)),
                 Some(instance.controller().host.clone()),
                 Some(revision),
@@ -1694,18 +1811,18 @@ fn instance_core_state(epoch: u64, state: &InstanceState) -> CoreState {
 
 fn spawn_forwarder(
     inner: &Arc<Inner>,
-    mut state_rx: watch::Receiver<InstanceState>,
+    mut state_rx: watch::Receiver<InstanceStatus>,
     epoch: u64,
 ) -> tokio::task::JoinHandle<()> {
     let inner = Arc::downgrade(inner);
     tokio::spawn(async move {
         while state_rx.changed().await.is_ok() {
-            let state = state_rx.borrow_and_update().clone();
-            let terminal = state.is_terminal();
+            let status = state_rx.borrow_and_update().clone();
+            let terminal = status.state.is_terminal();
             let Some(inner) = inner.upgrade() else {
                 break;
             };
-            inner.publish_epoch_state(epoch, instance_core_state(epoch, &state));
+            inner.publish_epoch_status(epoch, status);
             if terminal {
                 break;
             }
@@ -1806,12 +1923,74 @@ mod tests {
                 reason: Some(StopReason::Finished),
             },
         ] {
-            assert!(!apply_epoch_state(&mut status, 8, stale));
+            let stale_status = InstanceStatus {
+                state: match stale {
+                    CoreState::Running { pid, .. } => InstanceState::Running { pid },
+                    CoreState::Restarting { attempt, .. } => InstanceState::Restarting { attempt },
+                    CoreState::Stopped { reason } => {
+                        InstanceState::Stopped(reason.unwrap_or(StopReason::Finished))
+                    }
+                    _ => unreachable!(),
+                },
+                health: None,
+            };
+            assert!(!apply_epoch_status(&mut status, 8, &stale_status));
             assert!(matches!(
                 status.state,
                 CoreState::Running { epoch: 9, pid: 90 }
             ));
         }
+    }
+
+    #[test]
+    fn stale_epoch_status_neither_mutates_nor_wakes_watchers() {
+        let mut status = CoreStatus::initial();
+        status.revision = Some(ConfigRevision {
+            epoch: 9,
+            generation: 1,
+            source_hash: "source".into(),
+            effective_hash: "effective".into(),
+            runtime_path: "config-9.yaml".into(),
+        });
+        status.state = CoreState::Running { epoch: 9, pid: 90 };
+        let (tx, rx) = watch::channel(status);
+        let stale = InstanceStatus {
+            state: InstanceState::Running { pid: 80 },
+            health: Some(HealthStatus::starting()),
+        };
+
+        let sent = tx.send_if_modified(|status| apply_epoch_status(status, 8, &stale));
+
+        assert!(!sent);
+        assert!(!rx.has_changed().unwrap());
+        assert!(matches!(
+            rx.borrow().state,
+            CoreState::Running { epoch: 9, pid: 90 }
+        ));
+    }
+
+    #[test]
+    fn pure_health_transition_preserves_lifecycle_changed_at() {
+        let mut status = CoreStatus::initial();
+        status.revision = Some(ConfigRevision {
+            epoch: 3,
+            generation: 1,
+            source_hash: "source".into(),
+            effective_hash: "effective".into(),
+            runtime_path: "config-3.yaml".into(),
+        });
+        status.state = CoreState::Running { epoch: 3, pid: 30 };
+        status.changed_at = 7;
+        let mut health = HealthStatus::starting();
+        health.state = crate::state::HealthState::Unhealthy;
+        let instance = InstanceStatus {
+            state: InstanceState::Running { pid: 30 },
+            health: Some(health.clone()),
+        };
+
+        assert!(apply_epoch_status(&mut status, 3, &instance));
+        assert_eq!(status.changed_at, 7);
+        assert_eq!(status.health, Some(health));
     }
 
     #[test]

--- a/crates/nyanpasu-core-manager/src/probe.rs
+++ b/crates/nyanpasu-core-manager/src/probe.rs
@@ -1,0 +1,205 @@
+//! Custom readiness and liveness probes.
+
+use std::{future::Future, pin::Pin, sync::Arc, time::Duration};
+
+use tokio_util::sync::CancellationToken;
+
+use crate::{Error, ResolvedController};
+
+/// The boxed future returned by an object-safe [`HealthProbe`].
+pub type ProbeFuture<'a> = Pin<Box<dyn Future<Output = ProbeResult> + Send + 'a>>;
+
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProbeResult {
+    Healthy,
+    Unhealthy { detail: Option<String> },
+}
+
+impl ProbeResult {
+    pub fn is_healthy(&self) -> bool {
+        matches!(self, Self::Healthy)
+    }
+}
+
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProbePhase {
+    Readiness,
+    Liveness,
+    Reconcile,
+}
+
+/// Context for one probe attempt.
+///
+/// This type intentionally does not implement `Debug`: a resolved controller
+/// may carry an authentication secret.
+#[derive(Clone)]
+pub struct ProbeContext {
+    pub epoch: u64,
+    pub pid: u32,
+    pub phase: ProbePhase,
+    pub controller: Arc<ResolvedController>,
+    pub cancel: CancellationToken,
+}
+
+/// One readiness, liveness, or reconciliation check.
+///
+/// Implementations must be cancellation-safe: dropping the returned future
+/// must not leave a detached task behind. External-command probes must pass
+/// arguments directly to [`tokio::process::Command`] rather than concatenate a
+/// shell command, and must call `kill_on_drop(true)` so the child is killed
+/// when the future is dropped.
+pub trait HealthProbe: Send + Sync + 'static {
+    fn check<'a>(&'a self, context: ProbeContext) -> ProbeFuture<'a>;
+}
+
+/// Cheaply cloneable, debug-safe handle to a custom probe.
+#[derive(Clone)]
+pub struct ProbeHandle {
+    label: Arc<str>,
+    inner: Arc<dyn HealthProbe>,
+}
+
+impl ProbeHandle {
+    pub fn new(label: impl Into<Arc<str>>, probe: impl HealthProbe) -> Self {
+        Self {
+            label: label.into(),
+            inner: Arc::new(probe),
+        }
+    }
+
+    pub fn from_fn<F, Fut>(label: impl Into<Arc<str>>, function: F) -> Self
+    where
+        F: Fn(ProbeContext) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = ProbeResult> + Send + 'static,
+    {
+        Self::new(label, FnProbe(function))
+    }
+
+    pub fn label(&self) -> &str {
+        &self.label
+    }
+
+    pub fn check(&self, context: ProbeContext) -> ProbeFuture<'_> {
+        self.inner.check(context)
+    }
+}
+
+impl std::fmt::Debug for ProbeHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ProbeHandle")
+            .field("label", &self.label)
+            .finish()
+    }
+}
+
+struct FnProbe<F>(F);
+
+impl<F, Fut> HealthProbe for FnProbe<F>
+where
+    F: Fn(ProbeContext) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = ProbeResult> + Send + 'static,
+{
+    fn check<'a>(&'a self, context: ProbeContext) -> ProbeFuture<'a> {
+        Box::pin((self.0)(context))
+    }
+}
+
+/// Default readiness probe: healthy iff `GET /version` succeeds.
+pub struct ControllerVersionProbe {
+    client: clash_api::Client,
+}
+
+impl ControllerVersionProbe {
+    pub fn new(controller: &ResolvedController) -> Result<Self, Error> {
+        let mut builder = clash_api::Client::builder(controller.host.clone())
+            .configure_reqwest(|builder| builder.timeout(Duration::from_secs(1)));
+        if let Some(secret) = &controller.secret {
+            builder = builder.secret(secret.as_str());
+        }
+        Ok(Self {
+            client: builder.build()?,
+        })
+    }
+}
+
+impl HealthProbe for ControllerVersionProbe {
+    fn check<'a>(&'a self, _context: ProbeContext) -> ProbeFuture<'a> {
+        Box::pin(async move {
+            match self.client.version().await {
+                Ok(_) => ProbeResult::Healthy,
+                Err(error) => ProbeResult::Unhealthy {
+                    detail: Some(error.to_string()),
+                },
+            }
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn controller(port: u16) -> ResolvedController {
+        ResolvedController {
+            host: clash_api::Host::http(format!("127.0.0.1:{port}")).unwrap(),
+            secret: None,
+        }
+    }
+
+    fn context(controller: ResolvedController) -> ProbeContext {
+        ProbeContext {
+            epoch: 1,
+            pid: 1,
+            phase: ProbePhase::Readiness,
+            controller: Arc::new(controller),
+            cancel: CancellationToken::new(),
+        }
+    }
+
+    struct SecretProbe;
+
+    impl HealthProbe for SecretProbe {
+        fn check<'a>(&'a self, _context: ProbeContext) -> ProbeFuture<'a> {
+            Box::pin(async { ProbeResult::Healthy })
+        }
+    }
+
+    #[test]
+    fn handle_debug_prints_only_the_label() {
+        let handle = ProbeHandle::new("safe-label", SecretProbe);
+        let debug = format!("{handle:?}");
+        assert_eq!(debug, "ProbeHandle { label: \"safe-label\" }");
+        assert!(!debug.contains("SecretProbe"));
+    }
+
+    #[tokio::test]
+    async fn controller_version_probe_matches_version_endpoint_health() {
+        let closed_port = {
+            let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+            listener.local_addr().unwrap().port()
+        };
+        let closed_controller = controller(closed_port);
+        let probe = ControllerVersionProbe::new(&closed_controller).unwrap();
+        assert!(!probe.check(context(closed_controller)).await.is_healthy());
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            use tokio::io::{AsyncReadExt, AsyncWriteExt};
+            let mut buf = [0_u8; 1024];
+            let _ = stream.read(&mut buf).await;
+            let body = r#"{"meta":true,"version":"t"}"#;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            stream.write_all(response.as_bytes()).await.unwrap();
+        });
+        let controller = controller(port);
+        let probe = ControllerVersionProbe::new(&controller).unwrap();
+        assert!(probe.check(context(controller)).await.is_healthy());
+    }
+}

--- a/crates/nyanpasu-core-manager/src/probe_driver.rs
+++ b/crates/nyanpasu-core-manager/src/probe_driver.rs
@@ -1,0 +1,430 @@
+use std::{sync::Arc, time::Duration};
+
+use tokio::{sync::mpsc, task::JoinHandle};
+use tokio_util::sync::CancellationToken;
+
+use crate::{
+    health::HealthPolicy,
+    probe::{ProbeContext, ProbeHandle, ProbePhase, ProbeResult},
+    spec::ResolvedController,
+};
+
+#[derive(Debug, Clone)]
+pub(crate) struct ProbeObservation {
+    pub(crate) run_id: u64,
+    pub(crate) pid: u32,
+    pub(crate) phase: ProbePhase,
+    pub(crate) completed_at: std::time::Instant,
+    pub(crate) completed_at_ms: i64,
+    pub(crate) result: ProbeResult,
+}
+
+enum DriverCommand {
+    UseLiveness,
+    Reconcile {
+        response: tokio::sync::oneshot::Sender<ProbeResult>,
+    },
+}
+
+pub(crate) struct ProbeDriver {
+    command_tx: mpsc::UnboundedSender<DriverCommand>,
+    cancel: CancellationToken,
+    task: Option<JoinHandle<()>>,
+}
+
+impl ProbeDriver {
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn start(
+        epoch: u64,
+        run_id: u64,
+        pid: u32,
+        controller: Arc<ResolvedController>,
+        readiness: ProbeHandle,
+        liveness: Option<ProbeHandle>,
+        policy: HealthPolicy,
+        observation_tx: mpsc::UnboundedSender<ProbeObservation>,
+    ) -> Self {
+        let (command_tx, mut command_rx) = mpsc::unbounded_channel();
+        let cancel = CancellationToken::new();
+        let task_cancel = cancel.clone();
+        let task = tokio::spawn(async move {
+            let mut periodic = Some((readiness.clone(), ProbePhase::Readiness));
+            // Match the former `tokio::time::interval` behavior: the first
+            // readiness attempt is immediate, then delay after each result.
+            let mut next_probe = tokio::time::Instant::now();
+
+            loop {
+                tokio::select! {
+                    biased;
+                    _ = task_cancel.cancelled() => break,
+                    command = command_rx.recv() => match command {
+                        Some(DriverCommand::UseLiveness) => {
+                            periodic = liveness
+                                .clone()
+                                .map(|probe| (probe, ProbePhase::Liveness));
+                            next_probe = tokio::time::Instant::now() + policy.interval();
+                        }
+                        Some(DriverCommand::Reconcile { response }) => {
+                            let probe = liveness.as_ref().unwrap_or(&readiness).clone();
+                            if let Some(observation) = run_attempt(
+                                &probe,
+                                epoch,
+                                run_id,
+                                pid,
+                                ProbePhase::Reconcile,
+                                controller.clone(),
+                                policy.timeout(),
+                                &task_cancel,
+                            ).await {
+                                let _ = response.send(observation.result.clone());
+                                let _ = observation_tx.send(observation);
+                            }
+                        }
+                        None => break,
+                    },
+                    _ = tokio::time::sleep_until(next_probe), if periodic.is_some() => {
+                        let (probe, phase) = periodic.as_ref().expect("guarded");
+                        if let Some(observation) = run_attempt(
+                            probe,
+                            epoch,
+                            run_id,
+                            pid,
+                            *phase,
+                            controller.clone(),
+                            policy.timeout(),
+                            &task_cancel,
+                        ).await {
+                            let _ = observation_tx.send(observation);
+                        }
+                        next_probe = tokio::time::Instant::now() + policy.interval();
+                    }
+                }
+            }
+        });
+        Self {
+            command_tx,
+            cancel,
+            task: Some(task),
+        }
+    }
+
+    pub(crate) fn use_liveness(&self) {
+        let _ = self.command_tx.send(DriverCommand::UseLiveness);
+    }
+
+    pub(crate) fn reconcile(&self, response: tokio::sync::oneshot::Sender<ProbeResult>) {
+        let _ = self.command_tx.send(DriverCommand::Reconcile { response });
+    }
+
+    pub(crate) async fn stop(mut self) {
+        self.cancel.cancel();
+        if let Some(task) = self.task.take() {
+            let _ = task.await;
+        }
+    }
+}
+
+impl Drop for ProbeDriver {
+    fn drop(&mut self) {
+        self.cancel.cancel();
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn run_attempt(
+    probe: &ProbeHandle,
+    epoch: u64,
+    run_id: u64,
+    pid: u32,
+    phase: ProbePhase,
+    controller: Arc<ResolvedController>,
+    timeout: Duration,
+    driver_cancel: &CancellationToken,
+) -> Option<ProbeObservation> {
+    let attempt_cancel = driver_cancel.child_token();
+    let context = ProbeContext {
+        epoch,
+        pid,
+        phase,
+        controller,
+        cancel: attempt_cancel.clone(),
+    };
+    let mut future = probe.check(context);
+    let result = tokio::select! {
+        biased;
+        _ = driver_cancel.cancelled() => {
+            attempt_cancel.cancel();
+            return None;
+        }
+        timed = tokio::time::timeout(timeout, &mut future) => match timed {
+            Ok(result) => result,
+            Err(_) => {
+                attempt_cancel.cancel();
+                ProbeResult::Unhealthy {
+                    detail: Some(format!("probe timed out after {timeout:?}")),
+                }
+            }
+        },
+    };
+    drop(future);
+    Some(ProbeObservation {
+        run_id,
+        pid,
+        phase,
+        completed_at: std::time::Instant::now(),
+        completed_at_ms: crate::state::now_ms(),
+        result,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        future::Future,
+        pin::Pin,
+        sync::{
+            Arc,
+            atomic::{AtomicBool, AtomicUsize, Ordering},
+        },
+        task::{Context, Poll},
+    };
+
+    use super::*;
+    use crate::probe::{HealthProbe, ProbeFuture};
+
+    fn controller() -> Arc<ResolvedController> {
+        Arc::new(ResolvedController {
+            host: clash_api::Host::http("127.0.0.1:1").unwrap(),
+            secret: None,
+        })
+    }
+
+    fn policy(interval: Duration, timeout: Duration) -> HealthPolicy {
+        HealthPolicy::new(
+            interval,
+            timeout,
+            std::num::NonZeroU32::MIN,
+            std::num::NonZeroU32::MIN,
+            Duration::ZERO,
+        )
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn reconcile_queues_behind_periodic_and_max_concurrency_is_one() {
+        let active = Arc::new(AtomicUsize::new(0));
+        let maximum = Arc::new(AtomicUsize::new(0));
+        let started = Arc::new(tokio::sync::Notify::new());
+        let release = Arc::new(tokio::sync::Semaphore::new(0));
+        let probe = ProbeHandle::from_fn("serial", {
+            let active = active.clone();
+            let maximum = maximum.clone();
+            let started = started.clone();
+            let release = release.clone();
+            move |_| {
+                let active = active.clone();
+                let maximum = maximum.clone();
+                let started = started.clone();
+                let release = release.clone();
+                async move {
+                    let now = active.fetch_add(1, Ordering::SeqCst) + 1;
+                    maximum.fetch_max(now, Ordering::SeqCst);
+                    started.notify_one();
+                    let permit = release.acquire().await.unwrap();
+                    permit.forget();
+                    active.fetch_sub(1, Ordering::SeqCst);
+                    ProbeResult::Healthy
+                }
+            }
+        });
+        let (observation_tx, mut observation_rx) = mpsc::unbounded_channel();
+        let driver = ProbeDriver::start(
+            1,
+            1,
+            10,
+            controller(),
+            probe.clone(),
+            Some(probe),
+            policy(Duration::from_millis(1), Duration::from_secs(2)),
+            observation_tx,
+        );
+        driver.use_liveness();
+        tokio::time::timeout(Duration::from_secs(1), started.notified())
+            .await
+            .expect("periodic probe did not start");
+
+        let (response_tx, mut response_rx) = tokio::sync::oneshot::channel();
+        driver.reconcile(response_tx);
+        assert!(response_rx.try_recv().is_err());
+        release.add_permits(1);
+        let first = tokio::time::timeout(Duration::from_secs(1), observation_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(first.phase, ProbePhase::Liveness);
+        tokio::time::timeout(Duration::from_secs(1), started.notified())
+            .await
+            .expect("queued reconcile did not start");
+        assert!(response_rx.try_recv().is_err());
+        release.add_permits(1);
+        assert!(
+            tokio::time::timeout(Duration::from_secs(1), response_rx)
+                .await
+                .unwrap()
+                .unwrap()
+                .is_healthy()
+        );
+        assert_eq!(maximum.load(Ordering::SeqCst), 1);
+        driver.stop().await;
+    }
+
+    struct PendingProbe {
+        started: Arc<tokio::sync::Notify>,
+        dropped_after_cancel: Arc<AtomicBool>,
+    }
+
+    struct PendingFuture {
+        cancel: CancellationToken,
+        dropped_after_cancel: Arc<AtomicBool>,
+    }
+
+    impl Future for PendingFuture {
+        type Output = ProbeResult;
+
+        fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
+            Poll::Pending
+        }
+    }
+
+    impl Drop for PendingFuture {
+        fn drop(&mut self) {
+            self.dropped_after_cancel
+                .store(self.cancel.is_cancelled(), Ordering::SeqCst);
+        }
+    }
+
+    impl HealthProbe for PendingProbe {
+        fn check<'a>(&'a self, context: ProbeContext) -> ProbeFuture<'a> {
+            self.started.notify_one();
+            Box::pin(PendingFuture {
+                cancel: context.cancel,
+                dropped_after_cancel: self.dropped_after_cancel.clone(),
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn timeout_is_failure_and_cancels_before_dropping_future() {
+        let started = Arc::new(tokio::sync::Notify::new());
+        let dropped_after_cancel = Arc::new(AtomicBool::new(false));
+        let probe = ProbeHandle::new(
+            "pending",
+            PendingProbe {
+                started: started.clone(),
+                dropped_after_cancel: dropped_after_cancel.clone(),
+            },
+        );
+        let (observation_tx, mut observation_rx) = mpsc::unbounded_channel();
+        let driver = ProbeDriver::start(
+            1,
+            1,
+            10,
+            controller(),
+            probe,
+            None,
+            policy(Duration::from_millis(1), Duration::from_millis(20)),
+            observation_tx,
+        );
+        tokio::time::timeout(Duration::from_secs(1), started.notified())
+            .await
+            .unwrap();
+        let observation = tokio::time::timeout(Duration::from_secs(1), observation_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(!observation.result.is_healthy());
+        assert!(dropped_after_cancel.load(Ordering::SeqCst));
+        driver.stop().await;
+    }
+
+    #[tokio::test]
+    async fn cancel_stops_without_publishing_a_late_observation() {
+        let started = Arc::new(tokio::sync::Notify::new());
+        let probe = ProbeHandle::new(
+            "pending",
+            PendingProbe {
+                started: started.clone(),
+                dropped_after_cancel: Arc::new(AtomicBool::new(false)),
+            },
+        );
+        let (observation_tx, mut observation_rx) = mpsc::unbounded_channel();
+        let driver = ProbeDriver::start(
+            1,
+            1,
+            10,
+            controller(),
+            probe,
+            None,
+            policy(Duration::from_millis(1), Duration::from_secs(5)),
+            observation_tx,
+        );
+        tokio::time::timeout(Duration::from_secs(1), started.notified())
+            .await
+            .unwrap();
+        driver.stop().await;
+        assert!(observation_rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn separate_epoch_drivers_can_probe_concurrently() {
+        let active = Arc::new(AtomicUsize::new(0));
+        let both_started = Arc::new(tokio::sync::Notify::new());
+        let release = Arc::new(tokio::sync::Notify::new());
+        let probe = ProbeHandle::from_fn("parallel", {
+            let active = active.clone();
+            let both_started = both_started.clone();
+            let release = release.clone();
+            move |_| {
+                let active = active.clone();
+                let both_started = both_started.clone();
+                let release = release.clone();
+                async move {
+                    if active.fetch_add(1, Ordering::SeqCst) + 1 == 2 {
+                        both_started.notify_one();
+                    }
+                    release.notified().await;
+                    active.fetch_sub(1, Ordering::SeqCst);
+                    ProbeResult::Healthy
+                }
+            }
+        });
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let first = ProbeDriver::start(
+            1,
+            1,
+            10,
+            controller(),
+            probe.clone(),
+            None,
+            policy(Duration::from_millis(1), Duration::from_secs(2)),
+            tx.clone(),
+        );
+        let second = ProbeDriver::start(
+            2,
+            1,
+            20,
+            controller(),
+            probe,
+            None,
+            policy(Duration::from_millis(1), Duration::from_secs(2)),
+            tx,
+        );
+        tokio::time::timeout(Duration::from_secs(1), both_started.notified())
+            .await
+            .expect("epoch probes did not overlap");
+        assert_eq!(active.load(Ordering::SeqCst), 2);
+        release.notify_waiters();
+        first.stop().await;
+        second.stop().await;
+    }
+}

--- a/crates/nyanpasu-core-manager/src/spec.rs
+++ b/crates/nyanpasu-core-manager/src/spec.rs
@@ -6,7 +6,7 @@ use camino::Utf8PathBuf;
 use nyanpasu_utils::process::{Backoff, RestartPolicy};
 use tokio_util::sync::CancellationToken;
 
-use crate::kind::CoreKind;
+use crate::{health::HealthPolicy, kind::CoreKind};
 
 #[derive(Debug, Clone)]
 pub struct CoreSpec {
@@ -30,9 +30,9 @@ pub struct InstanceSpec {
 
 #[derive(Debug, Clone)]
 pub struct InstanceOptions {
-    /// Total limit for the initial start (spawn → version probe success).
+    /// Total limit for the initial start (spawn → readiness threshold).
     pub startup_timeout: Duration,
-    pub probe_interval: Duration,
+    pub health: HealthPolicy,
     pub restart_policy: RestartPolicy,
     pub backoff: Backoff,
 }
@@ -41,7 +41,7 @@ impl Default for InstanceOptions {
     fn default() -> Self {
         Self {
             startup_timeout: Duration::from_secs(30),
-            probe_interval: Duration::from_millis(250),
+            health: HealthPolicy::default(),
             restart_policy: RestartPolicy::OnFailure { max_restarts: 5 },
             backoff: Backoff::exponential(Duration::from_secs(1), Duration::from_secs(30))
                 .with_jitter(),
@@ -106,7 +106,11 @@ mod tests {
     fn instance_options_defaults_match_spec() {
         let o = InstanceOptions::default();
         assert_eq!(o.startup_timeout, Duration::from_secs(30));
-        assert_eq!(o.probe_interval, Duration::from_millis(250));
+        assert_eq!(o.health.interval(), Duration::from_millis(250));
+        assert_eq!(o.health.timeout(), Duration::from_secs(1));
+        assert_eq!(o.health.failure_threshold().get(), 3);
+        assert_eq!(o.health.success_threshold().get(), 1);
+        assert_eq!(o.health.start_period(), Duration::ZERO);
         assert_eq!(
             o.restart_policy,
             RestartPolicy::OnFailure { max_restarts: 5 }

--- a/crates/nyanpasu-core-manager/src/state.rs
+++ b/crates/nyanpasu-core-manager/src/state.rs
@@ -4,9 +4,54 @@ use camino::Utf8PathBuf;
 
 use crate::kind::CoreKind;
 
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HealthState {
+    Starting,
+    Healthy,
+    Unhealthy,
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct HealthStatus {
+    pub state: HealthState,
+    /// Unix milliseconds of the last health-state transition.
+    pub changed_at: i64,
+    pub consecutive_failures: u32,
+    pub last_error: Option<String>,
+    pub last_success_at: Option<i64>,
+}
+
+impl std::fmt::Debug for HealthStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HealthStatus")
+            .field("state", &self.state)
+            .field("changed_at", &self.changed_at)
+            .field("consecutive_failures", &self.consecutive_failures)
+            .field(
+                "last_error",
+                &self.last_error.as_ref().map(|_| "<redacted>"),
+            )
+            .field("last_success_at", &self.last_success_at)
+            .finish()
+    }
+}
+
+impl HealthStatus {
+    pub(crate) fn starting() -> Self {
+        Self {
+            state: HealthState::Starting,
+            changed_at: now_ms(),
+            consecutive_failures: 0,
+            last_error: None,
+            last_success_at: None,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum InstanceState {
-    /// Spawned; the version health probe has not passed yet.
+    /// Spawned; the readiness success threshold has not been reached yet.
     Starting,
     Running {
         pid: u32,
@@ -22,6 +67,21 @@ pub enum InstanceState {
 impl InstanceState {
     pub fn is_terminal(&self) -> bool {
         matches!(self, Self::Stopped(_))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InstanceStatus {
+    pub state: InstanceState,
+    pub health: Option<HealthStatus>,
+}
+
+impl InstanceStatus {
+    pub(crate) fn initial() -> Self {
+        Self {
+            state: InstanceState::Starting,
+            health: Some(HealthStatus::starting()),
+        }
     }
 }
 
@@ -118,6 +178,7 @@ pub struct CoreStatus {
     pub state: CoreState,
     /// Unix milliseconds of the last state transition (feeds IPC `state_changed_at`).
     pub changed_at: i64,
+    pub health: Option<HealthStatus>,
     pub spec: Option<SpecSummary>,
     /// The controller endpoint owned by the active epoch in either mode.
     pub controller: Option<clash_api::Host>,
@@ -129,6 +190,7 @@ impl CoreStatus {
         Self {
             state: CoreState::Stopped { reason: None },
             changed_at: now_ms(),
+            health: None,
             spec: None,
             controller: None,
             revision: None,

--- a/crates/nyanpasu-core-manager/tests/common/mod.rs
+++ b/crates/nyanpasu-core-manager/tests/common/mod.rs
@@ -5,7 +5,8 @@ use std::{sync::Arc, time::Duration};
 
 use camino::{Utf8Path, Utf8PathBuf};
 use nyanpasu_core_manager::{
-    CoreKind, CoreSpec, InstanceOptions, InstanceSpec, state::InstanceState,
+    CoreKind, CoreSpec, HealthPolicy, InstanceOptions, InstanceSpec,
+    state::{HealthState, InstanceState, InstanceStatus},
 };
 use nyanpasu_utils::process::{Backoff, RestartPolicy};
 use parking_lot::Mutex;
@@ -27,7 +28,14 @@ pub fn free_port() -> u16 {
 pub fn fast_options() -> InstanceOptions {
     InstanceOptions {
         startup_timeout: Duration::from_secs(5),
-        probe_interval: Duration::from_millis(50),
+        health: HealthPolicy::new(
+            Duration::from_millis(50),
+            Duration::from_secs(1),
+            std::num::NonZeroU32::new(3).unwrap(),
+            std::num::NonZeroU32::MIN,
+            Duration::ZERO,
+        )
+        .unwrap(),
         restart_policy: RestartPolicy::OnFailure { max_restarts: 2 },
         backoff: Backoff::exponential(Duration::from_millis(50), Duration::from_millis(200)),
     }
@@ -61,13 +69,13 @@ pub fn utf8_tempdir() -> (tempfile::TempDir, Utf8PathBuf) {
 }
 
 pub async fn wait_for_state(
-    rx: &mut watch::Receiver<InstanceState>,
+    rx: &mut watch::Receiver<InstanceStatus>,
     pred: impl Fn(&InstanceState) -> bool,
     timeout: Duration,
 ) -> InstanceState {
     tokio::time::timeout(timeout, async {
         loop {
-            let current = rx.borrow_and_update().clone();
+            let current = rx.borrow_and_update().state.clone();
             if pred(&current) {
                 return current;
             }
@@ -80,15 +88,39 @@ pub async fn wait_for_state(
     .expect("timed out waiting for state")
 }
 
+pub async fn wait_for_health(
+    rx: &mut watch::Receiver<InstanceStatus>,
+    target: HealthState,
+    timeout: Duration,
+) -> InstanceStatus {
+    tokio::time::timeout(timeout, async {
+        loop {
+            let current = rx.borrow_and_update().clone();
+            if current
+                .health
+                .as_ref()
+                .is_some_and(|health| health.state == target)
+            {
+                return current;
+            }
+            if rx.changed().await.is_err() {
+                panic!("state channel closed while waiting for health");
+            }
+        }
+    })
+    .await
+    .expect("timed out waiting for health")
+}
+
 /// Records every state transition for later sequence assertions.
 pub fn record_states(
-    mut rx: watch::Receiver<InstanceState>,
+    mut rx: watch::Receiver<InstanceStatus>,
 ) -> (tokio::task::JoinHandle<()>, Arc<Mutex<Vec<InstanceState>>>) {
-    let log = Arc::new(Mutex::new(vec![rx.borrow().clone()]));
+    let log = Arc::new(Mutex::new(vec![rx.borrow().state.clone()]));
     let log_ = log.clone();
     let handle = tokio::spawn(async move {
         while rx.changed().await.is_ok() {
-            log_.lock().push(rx.borrow().clone());
+            log_.lock().push(rx.borrow().state.clone());
         }
     });
     (handle, log)

--- a/crates/nyanpasu-core-manager/tests/config_apply.rs
+++ b/crates/nyanpasu-core-manager/tests/config_apply.rs
@@ -1,10 +1,19 @@
 mod common;
 
-use std::time::Duration;
+use std::{
+    collections::HashSet,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::Duration,
+};
 
 use nyanpasu_core_manager::{
-    ApplyOutcome, CoreManager, CoreState, Error, InstanceSpec, ManagerOptions, RevisionId,
+    ApplyOutcome, ControllerVersionProbe, CoreManager, CoreState, Error, HealthProbe, InstanceSpec,
+    ManagerOptions, ProbeHandle, ProbePhase, ProbeResult, RevisionId,
 };
+use parking_lot::Mutex;
 
 async fn manager(dir: &camino::Utf8Path, control_timeout: Duration) -> CoreManager {
     CoreManager::new(ManagerOptions {
@@ -36,6 +45,78 @@ fn spec(dir: &camino::Utf8Path, path: camino::Utf8PathBuf) -> InstanceSpec {
 
 fn passthrough_yaml(port: u16, extra: &str) -> String {
     format!("external-controller: 127.0.0.1:{port}\nmode: rule\n{extra}")
+}
+
+#[tokio::test]
+async fn custom_probe_plan_reaches_desired_replacement_and_rollback() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let port = common::free_port();
+    let first = write_named(
+        &dir,
+        "probe-old.yaml",
+        &passthrough_yaml(port, "x-setting: old\n"),
+    );
+    let desired = write_named(
+        &dir,
+        "probe-desired.yaml",
+        &passthrough_yaml(port, "x-setting: desired\n"),
+    );
+    let attempts = Arc::new(Mutex::new(Vec::<(u64, u32)>::new()));
+    let readiness = ProbeHandle::from_fn("recorded-readiness", {
+        let attempts = attempts.clone();
+        move |context| {
+            attempts.lock().push((context.epoch, context.pid));
+            async move {
+                if context.epoch == 2 {
+                    return ProbeResult::Unhealthy {
+                        detail: Some("reject desired epoch".into()),
+                    };
+                }
+                match ControllerVersionProbe::new(context.controller.as_ref()) {
+                    Ok(probe) => probe.check(context).await,
+                    Err(error) => ProbeResult::Unhealthy {
+                        detail: Some(error.to_string()),
+                    },
+                }
+            }
+        }
+    });
+    let manager = CoreManager::builder(ManagerOptions {
+        runtime_dir: Some(dir.join("runtime")),
+        ..ManagerOptions::default()
+    })
+    .readiness_probe(readiness)
+    .build()
+    .await
+    .unwrap();
+    manager.start(spec(&dir, first)).await.unwrap();
+    let mut desired_spec = spec(&dir, desired);
+    desired_spec.options.startup_timeout = Duration::from_secs(2);
+
+    let outcome = manager.apply_config(desired_spec, None).await.unwrap();
+    assert!(matches!(outcome, ApplyOutcome::RolledBack { .. }));
+    let (old_pids, desired_pids): (HashSet<_>, HashSet<_>) = {
+        let attempts = attempts.lock();
+        (
+            attempts
+                .iter()
+                .filter_map(|(epoch, pid)| (*epoch == 1).then_some(*pid))
+                .collect(),
+            attempts
+                .iter()
+                .filter_map(|(epoch, pid)| (*epoch == 2).then_some(*pid))
+                .collect(),
+        )
+    };
+    assert!(
+        old_pids.len() >= 2,
+        "initial and rollback did not both probe"
+    );
+    assert!(
+        !desired_pids.is_empty(),
+        "desired replacement did not probe"
+    );
+    manager.stop().await.unwrap();
 }
 
 #[tokio::test]
@@ -90,6 +171,62 @@ async fn apply_patch_updates_the_revision_without_restarting() {
     assert_eq!(running(&manager), before);
     assert_eq!(revision.generation, 2);
     manager.shutdown().await.expect("shutdown");
+}
+
+#[tokio::test]
+async fn custom_reconcile_failure_uses_the_existing_restart_path() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let port = common::free_port();
+    let first = write_named(&dir, "reconcile-first.yaml", &passthrough_yaml(port, ""));
+    let desired = write_named(
+        &dir,
+        "reconcile-desired.yaml",
+        &passthrough_yaml(port, "allow-lan: true\n"),
+    );
+    let saw_reconcile = Arc::new(AtomicBool::new(false));
+    let probe = ProbeHandle::from_fn("reconcile-aware", {
+        let saw_reconcile = saw_reconcile.clone();
+        move |context| {
+            let reconcile = context.phase == ProbePhase::Reconcile;
+            if reconcile {
+                saw_reconcile.store(true, Ordering::SeqCst);
+            }
+            async move {
+                if reconcile {
+                    ProbeResult::Unhealthy {
+                        detail: Some("force restart compensation".into()),
+                    }
+                } else {
+                    match ControllerVersionProbe::new(context.controller.as_ref()) {
+                        Ok(probe) => probe.check(context).await,
+                        Err(error) => ProbeResult::Unhealthy {
+                            detail: Some(error.to_string()),
+                        },
+                    }
+                }
+            }
+        }
+    });
+    let manager = CoreManager::builder(ManagerOptions {
+        runtime_dir: Some(dir.join("runtime")),
+        ..ManagerOptions::default()
+    })
+    .readiness_probe(probe)
+    .build()
+    .await
+    .unwrap();
+    manager.start(spec(&dir, first)).await.unwrap();
+    let before = running(&manager);
+
+    let outcome = manager
+        .apply_config(spec(&dir, desired), None)
+        .await
+        .unwrap();
+
+    assert!(saw_reconcile.load(Ordering::SeqCst));
+    assert!(matches!(outcome, ApplyOutcome::Restarted { .. }));
+    assert_ne!(running(&manager).1, before.1);
+    manager.stop().await.unwrap();
 }
 
 #[tokio::test]
@@ -368,16 +505,22 @@ fn revision_id_is_an_explicit_cas_token() {
 async fn source_mutation_during_staged_check_cannot_change_the_apply() {
     let (_guard, dir) = common::utf8_tempdir();
     let port = common::free_port();
-    let behavior = "x-fake-core:\n  check-delay-ms: 300\n";
+    let check_started = dir.join("check-started");
+    let check_started_path = check_started.as_str().replace('\\', "/");
     let first = write_named(
         &dir,
         "first.yaml",
-        &passthrough_yaml(port, &format!("x-setting: old\n{behavior}")),
+        &passthrough_yaml(port, "x-setting: old\n"),
     );
     let desired = write_named(
         &dir,
         "desired.yaml",
-        &passthrough_yaml(port, &format!("x-setting: desired\n{behavior}")),
+        &passthrough_yaml(
+            port,
+            &format!(
+                "x-setting: desired\nx-fake-core:\n  check-delay-ms: 1000\n  check-started-file: '{check_started_path}'\n"
+            ),
+        ),
     );
     let manager = std::sync::Arc::new(manager(&dir, Duration::from_secs(1)).await);
     manager
@@ -390,7 +533,13 @@ async fn source_mutation_during_staged_check_cannot_change_the_apply() {
         let apply_spec = spec(&dir, desired.clone());
         tokio::spawn(async move { manager.apply_config(apply_spec, None).await })
     };
-    tokio::time::sleep(Duration::from_millis(100)).await;
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while !tokio::fs::try_exists(&check_started).await.unwrap() {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("staged config check never started");
     std::fs::write(
         &desired,
         passthrough_yaml(port, "x-setting: mutated\nx-fake-core:\n  exit-code: 91\n"),
@@ -461,6 +610,8 @@ async fn unconfirmed_replacement_stop_never_cleans_or_reuses_its_epoch() {
     let port = common::free_port();
     let counter = dir.join("launch-count.txt");
     let counter_path = counter.as_str().replace('\\', "/");
+    let rejected_state = dir.join("rejected-crash-state");
+    let rejected_state_path = rejected_state.as_str().replace('\\', "/");
     let first = write_named(
         &dir,
         "first.yaml",
@@ -474,6 +625,136 @@ async fn unconfirmed_replacement_stop_never_cleans_or_reuses_its_epoch() {
     let desired = write_named(
         &dir,
         "desired.yaml",
+        &passthrough_yaml(
+            port,
+            &format!(
+                "x-setting: desired\nx-fake-core:\n  launch-count-file: '{counter_path}'\n  fail-after-launches: 99\n  never-ready: true\n  crash-after-ms: 3000\n  crash-times: 1\n  state-file: '{rejected_state_path}'\n"
+            ),
+        ),
+    );
+    let manager = std::sync::Arc::new(
+        CoreManager::new(ManagerOptions {
+            runtime_dir: Some(runtime_dir.clone()),
+            stop_timeout: Duration::from_secs(1),
+            reconcile_timeout: Duration::from_secs(3),
+            ..ManagerOptions::default()
+        })
+        .await
+        .expect("construct manager"),
+    );
+    manager
+        .start(spec(&dir, first.clone()))
+        .await
+        .expect("start");
+
+    let apply = {
+        let manager = manager.clone();
+        let mut desired_spec = spec(&dir, desired.clone());
+        // Leave enough time for the replacement process to execute its launch
+        // hook even when this integration binary runs many fake cores in
+        // parallel; the test is about unconfirmed death, not a short budget.
+        desired_spec.options.startup_timeout = Duration::from_secs(15);
+        desired_spec.options.restart_policy =
+            nyanpasu_utils::process::RestartPolicy::OnFailure { max_restarts: 0 };
+        tokio::spawn(async move { manager.apply_config(desired_spec, None).await })
+    };
+    let rejected_pid = runtime_dir.join("core-2.pid");
+    tokio::time::timeout(Duration::from_secs(15), async {
+        loop {
+            let pid_exists = tokio::fs::try_exists(&rejected_pid).await.unwrap();
+            let replacement_launched =
+                std::fs::read_to_string(&counter).is_ok_and(|value| value.trim() == "2");
+            if pid_exists && replacement_launched {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+    })
+    .await
+    .expect("replacement pid record never appeared");
+    let valid_pid_record = std::fs::read_to_string(&rejected_pid).unwrap();
+    std::fs::write(&rejected_pid, "identity deliberately unavailable\n").unwrap();
+
+    let result = apply.await.unwrap();
+    assert!(
+        matches!(result, Err(Error::StopUnconfirmed(_))),
+        "unexpected compensation result: {result:?}"
+    );
+    assert!(runtime_dir.join("config-2.yaml").exists());
+    assert!(rejected_pid.exists());
+    assert_eq!(std::fs::read_to_string(counter).unwrap().trim(), "2");
+    assert!(matches!(
+        manager.status().state,
+        CoreState::Stopped { reason: Some(_) }
+    ));
+
+    let CoreState::Stopped {
+        reason: Some(reason),
+    } = manager.status().state
+    else {
+        panic!("quarantine was not published")
+    };
+    let status_reason = reason.to_string();
+    assert!(status_reason.contains("quarantin"), "{status_reason}");
+    let start_error = manager
+        .start(spec(&dir, first.clone()))
+        .await
+        .expect_err("quarantine must reject start");
+    assert!(
+        start_error.to_string().contains("quarantin"),
+        "{start_error}"
+    );
+    let apply_error = manager
+        .apply_config(spec(&dir, desired), None)
+        .await
+        .expect_err("quarantine must reject apply");
+    assert!(
+        apply_error.to_string().contains("quarantin"),
+        "{apply_error}"
+    );
+    assert!(matches!(
+        manager.switch(spec(&dir, first.clone())).await,
+        Err(Error::ManagerQuarantined { .. })
+    ));
+    assert!(matches!(
+        manager.restart().await,
+        Err(Error::ManagerQuarantined { .. })
+    ));
+
+    std::fs::write(rejected_pid, valid_pid_record).unwrap();
+    common::wait_port_refused(port).await;
+    manager
+        .recover_quarantine()
+        .await
+        .expect("identity-verified recovery");
+    assert!(!runtime_dir.join("config-2.yaml").exists());
+    manager
+        .start(spec(&dir, first))
+        .await
+        .expect("start after quarantine recovery");
+    manager.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn readiness_timeout_with_unconfirmed_stop_preserves_and_quarantines_epoch() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let runtime_dir = dir.join("runtime");
+    let port = common::free_port();
+    let counter = dir.join("readiness-timeout-launch-count.txt");
+    let counter_path = counter.as_str().replace('\\', "/");
+    let first = write_named(
+        &dir,
+        "readiness-timeout-first.yaml",
+        &passthrough_yaml(
+            port,
+            &format!(
+                "x-setting: old\nx-fake-core:\n  launch-count-file: '{counter_path}'\n  fail-after-launches: 99\n"
+            ),
+        ),
+    );
+    let desired = write_named(
+        &dir,
+        "readiness-timeout-desired.yaml",
         &passthrough_yaml(
             port,
             &format!(
@@ -499,32 +780,38 @@ async fn unconfirmed_replacement_stop_never_cleans_or_reuses_its_epoch() {
     let apply = {
         let manager = manager.clone();
         let mut desired_spec = spec(&dir, desired.clone());
-        desired_spec.options.startup_timeout = Duration::from_millis(300);
+        // This remains an absolute startup budget, but is intentionally
+        // generous because this integration binary launches many fake cores
+        // concurrently. The marker below proves epoch 2 launched before its
+        // identity record is corrupted.
+        desired_spec.options.startup_timeout = Duration::from_secs(15);
         tokio::spawn(async move { manager.apply_config(desired_spec, None).await })
     };
     let rejected_pid = runtime_dir.join("core-2.pid");
-    tokio::time::timeout(Duration::from_secs(5), async {
-        while !tokio::fs::try_exists(&rejected_pid).await.unwrap() {
+    tokio::time::timeout(Duration::from_secs(15), async {
+        loop {
+            let pid_exists = tokio::fs::try_exists(&rejected_pid).await.unwrap();
+            let replacement_launched =
+                std::fs::read_to_string(&counter).is_ok_and(|value| value.trim() == "2");
+            if pid_exists && replacement_launched {
+                break;
+            }
             tokio::time::sleep(Duration::from_millis(5)).await;
         }
     })
     .await
-    .expect("replacement pid record never appeared");
+    .expect("never-ready replacement pid record never appeared");
     let valid_pid_record = std::fs::read_to_string(&rejected_pid).unwrap();
     std::fs::write(&rejected_pid, "identity deliberately unavailable\n").unwrap();
 
     let result = apply.await.unwrap();
     assert!(
         matches!(result, Err(Error::StopUnconfirmed(_))),
-        "unexpected compensation result: {result:?}"
+        "unexpected readiness-timeout compensation result: {result:?}"
     );
     assert!(runtime_dir.join("config-2.yaml").exists());
     assert!(rejected_pid.exists());
-    assert_eq!(std::fs::read_to_string(counter).unwrap().trim(), "2");
-    assert!(matches!(
-        manager.status().state,
-        CoreState::Stopped { reason: Some(_) }
-    ));
+    assert_eq!(std::fs::read_to_string(&counter).unwrap().trim(), "2");
 
     let CoreState::Stopped {
         reason: Some(reason),

--- a/crates/nyanpasu-core-manager/tests/fake_core_smoke.rs
+++ b/crates/nyanpasu-core-manager/tests/fake_core_smoke.rs
@@ -12,7 +12,7 @@ async fn fake_core_serves_version_and_records_patches() {
     let config = common::write_config(
         &dir,
         &format!(
-            "external-controller: 127.0.0.1:{port}\nx-fake-core:\n  ready-delay-ms: 200\n  patch-log: {patch_log}\n"
+            "external-controller: 127.0.0.1:{port}\nx-fake-core:\n  ready-delay-ms: 1500\n  patch-log: {patch_log}\n"
         ),
     );
 

--- a/crates/nyanpasu-core-manager/tests/graceful_switch.rs
+++ b/crates/nyanpasu-core-manager/tests/graceful_switch.rs
@@ -3,8 +3,8 @@ mod common;
 use std::time::Duration;
 
 use nyanpasu_core_manager::{
-    ControllerMode, CoreKind, CoreState, DegradeReason, Error, ManagerOptions, StopReason,
-    manager::CoreManager,
+    ControllerMode, ControllerVersionProbe, CoreKind, CoreState, DegradeReason, Error, HealthProbe,
+    ManagerOptions, ProbeHandle, ProbeResult, StopReason, manager::CoreManager,
 };
 
 fn unique_template() -> Option<String> {
@@ -479,7 +479,7 @@ async fn graceful_overlap_keeps_both_epoch_pid_records_without_miskilling_old() 
     let config_b = dir.join("config-b.yaml");
     std::fs::write(
         &config_b,
-        format!("mixed-port: {mixed}\nx-fake-core:\n  ready-delay-ms: 750\n"),
+        format!("mixed-port: {mixed}\nx-fake-core:\n  ready-delay-ms: 5000\n"),
     )
     .unwrap();
     let manager = Arc::new(managed_manager(derived_dir.clone()).await);
@@ -493,10 +493,11 @@ async fn graceful_overlap_keeps_both_epoch_pid_records_without_miskilling_old() 
 
     let switching = {
         let manager = manager.clone();
-        let spec_b = common::mihomo_spec(&dir, config_b);
+        let mut spec_b = common::mihomo_spec(&dir, config_b);
+        spec_b.options.startup_timeout = Duration::from_secs(15);
         tokio::spawn(async move { manager.switch(spec_b).await })
     };
-    let (old_record, new_record) = tokio::time::timeout(Duration::from_secs(5), async {
+    let (old_record, new_record) = tokio::time::timeout(Duration::from_secs(15), async {
         loop {
             let old = nyanpasu_utils::process::read_epoch_pid_file(
                 derived_dir.join("core-1.pid").as_std_path(),
@@ -536,7 +537,7 @@ async fn quarantine_recovery_continues_after_an_independent_epoch_failure() {
     let config_b = dir.join("config-b.yaml");
     std::fs::write(
         &config_b,
-        "mixed-port: 0\nx-fake-core:\n  ready-delay-ms: 700\n",
+        "mixed-port: 0\nx-fake-core:\n  ready-delay-ms: 5000\n",
     )
     .unwrap();
     let manager = Arc::new(
@@ -556,14 +557,15 @@ async fn quarantine_recovery_continues_after_an_independent_epoch_failure() {
         .await
         .unwrap();
 
-    let spec_b = common::mihomo_spec(&dir, config_b);
+    let mut spec_b = common::mihomo_spec(&dir, config_b);
+    spec_b.options.startup_timeout = Duration::from_secs(15);
     let switching = {
         let manager = manager.clone();
         tokio::spawn(async move { manager.switch(spec_b).await })
     };
     let first_pid = derived_dir.join("core-1.pid");
     let second_pid = derived_dir.join("core-2.pid");
-    tokio::time::timeout(Duration::from_secs(5), async {
+    tokio::time::timeout(Duration::from_secs(15), async {
         while !second_pid.exists() {
             tokio::time::sleep(Duration::from_millis(5)).await;
         }
@@ -802,7 +804,32 @@ async fn rejected_patch_falls_back_to_a_hard_restart() {
     )
     .unwrap();
 
-    let manager = managed_manager(dir.join("derived")).await;
+    let attempts = Arc::new(Mutex::new(Vec::<(u64, u32)>::new()));
+    let readiness = ProbeHandle::from_fn("graceful-recorded-readiness", {
+        let attempts = attempts.clone();
+        move |context| {
+            attempts.lock().push((context.epoch, context.pid));
+            async move {
+                match ControllerVersionProbe::new(context.controller.as_ref()) {
+                    Ok(probe) => probe.check(context).await,
+                    Err(error) => ProbeResult::Unhealthy {
+                        detail: Some(error.to_string()),
+                    },
+                }
+            }
+        }
+    });
+    let manager = CoreManager::builder(ManagerOptions {
+        controller_mode: ControllerMode::Managed {
+            derived_dir: dir.join("derived"),
+            controller_template: unique_template(),
+        },
+        ..ManagerOptions::default()
+    })
+    .readiness_probe(readiness)
+    .build()
+    .await
+    .unwrap();
     manager
         .start(common::mihomo_spec(&dir, config_a))
         .await
@@ -822,5 +849,26 @@ async fn rejected_patch_falls_back_to_a_hard_restart() {
     tokio::net::TcpStream::connect(("127.0.0.1", mixed))
         .await
         .expect("fallback core serves the mixed port");
+    let (initial_pids, candidate_pids): (
+        std::collections::HashSet<_>,
+        std::collections::HashSet<_>,
+    ) = {
+        let attempts = attempts.lock();
+        (
+            attempts
+                .iter()
+                .filter_map(|(epoch, pid)| (*epoch == 1).then_some(*pid))
+                .collect(),
+            attempts
+                .iter()
+                .filter_map(|(epoch, pid)| (*epoch == 2).then_some(*pid))
+                .collect(),
+        )
+    };
+    assert!(!initial_pids.is_empty(), "initial start missed probe plan");
+    assert!(
+        candidate_pids.len() >= 2,
+        "graceful bootstrap and fallback did not both inherit probe plan"
+    );
     manager.shutdown().await.expect("shutdown");
 }

--- a/crates/nyanpasu-core-manager/tests/helpers/fake_core.rs
+++ b/crates/nyanpasu-core-manager/tests/helpers/fake_core.rs
@@ -42,6 +42,7 @@ struct Behavior {
     patch_no_effect: bool,
     reject_put: bool,
     check_delay_ms: u64,
+    check_started_file: Option<String>,
     check_fail: Option<String>,
 }
 
@@ -103,6 +104,7 @@ fn parse(config: &str) -> Behavior {
         patch_no_effect: b(&x, "patch-no-effect"),
         reject_put: b(&x, "reject-put"),
         check_delay_ms: u(&x, "check-delay-ms"),
+        check_started_file: s(&x, "check-started-file"),
         check_fail: s(&x, "check-fail"),
     }
 }
@@ -126,6 +128,9 @@ async fn main() {
     let behavior = parse(&config);
 
     if check_mode {
+        if let Some(path) = &behavior.check_started_file {
+            std::fs::write(path, "started").expect("write check-started marker");
+        }
         std::thread::sleep(Duration::from_millis(behavior.check_delay_ms));
         match &behavior.check_fail {
             Some(msg) => {

--- a/crates/nyanpasu-core-manager/tests/instance_lifecycle.rs
+++ b/crates/nyanpasu-core-manager/tests/instance_lifecycle.rs
@@ -1,6 +1,20 @@
 mod common;
 
-use nyanpasu_core_manager::{instance::Instance, spec::ResolvedController, state::InstanceState};
+use std::{
+    num::NonZeroU32,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
+
+use nyanpasu_core_manager::{
+    HealthPolicy, ProbeHandle, ProbePhase, ProbeResult,
+    instance::Instance,
+    spec::ResolvedController,
+    state::{HealthState, InstanceState},
+};
 use tokio_util::sync::CancellationToken;
 
 fn http_controller(port: u16) -> ResolvedController {
@@ -27,7 +41,7 @@ async fn start_confirms_via_version_probe() {
 
     instance.wait_ready().await.expect("becomes healthy");
     assert!(matches!(
-        *instance.state().borrow(),
+        instance.state().borrow().state,
         InstanceState::Running { pid } if pid > 0
     ));
     assert_eq!(instance.epoch(), 1);
@@ -124,7 +138,7 @@ async fn crash_recovers_through_restart_and_reprobe() {
     let config = common::write_config(
         &dir,
         &format!(
-            "external-controller: 127.0.0.1:{port}\nx-fake-core:\n  crash-after-ms: 400\n  crash-times: 1\n  state-file: {state_file}\n"
+            "external-controller: 127.0.0.1:{port}\nx-fake-core:\n  crash-after-ms: 1200\n  crash-times: 1\n  state-file: {state_file}\n"
         ),
     );
     let spec = common::mihomo_spec(&dir, config);
@@ -135,21 +149,30 @@ async fn crash_recovers_through_restart_and_reprobe() {
     let (recorder, log) = common::record_states(instance.state());
     instance.wait_ready().await.expect("initially healthy");
 
-    // First run crashes at ~400ms; the supervisor restarts; the re-probe
+    // The first run crashes; the supervisor restarts; the re-probe
     // confirms the second (healthy) run.
-    let mut rx = instance.state();
-    common::wait_for_state(
-        &mut rx,
-        |s| matches!(s, InstanceState::Restarting { .. }),
-        std::time::Duration::from_secs(5),
-    )
-    .await;
-    common::wait_for_state(
-        &mut rx,
-        |s| matches!(s, InstanceState::Running { .. }),
-        std::time::Duration::from_secs(10),
-    )
-    .await;
+    tokio::time::timeout(Duration::from_secs(10), async {
+        loop {
+            let (restarted, running) = {
+                let states = log.lock();
+                (
+                    states
+                        .iter()
+                        .any(|state| matches!(state, InstanceState::Restarting { .. })),
+                    states
+                        .iter()
+                        .filter(|state| matches!(state, InstanceState::Running { .. }))
+                        .count(),
+                )
+            };
+            if restarted && running >= 2 {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("replacement never became ready");
 
     instance.stop().await.expect("stop");
     recorder.abort();
@@ -169,7 +192,7 @@ async fn crash_loop_exhausts_the_budget() {
     let config = common::write_config(
         &dir,
         &format!(
-            "external-controller: 127.0.0.1:{port}\nx-fake-core:\n  crash-after-ms: 300\n  crash-times: 99\n  state-file: {state_file}\n"
+            "external-controller: 127.0.0.1:{port}\nx-fake-core:\n  crash-after-ms: 1200\n  crash-times: 99\n  state-file: {state_file}\n"
         ),
     );
     let mut spec = common::mihomo_spec(&dir, config);
@@ -229,4 +252,380 @@ async fn user_stop_is_terminal_and_releases_the_port() {
         "terminal was {terminal:?}"
     );
     common::wait_port_refused(port).await;
+}
+
+#[tokio::test]
+async fn custom_readiness_and_success_threshold_gate_running() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let port = common::free_port();
+    let config = common::write_config(&dir, &format!("external-controller: 127.0.0.1:{port}\n"));
+    let mut spec = common::mihomo_spec(&dir, config);
+    spec.options.health = HealthPolicy::new(
+        Duration::from_millis(20),
+        Duration::from_secs(1),
+        NonZeroU32::new(3).unwrap(),
+        NonZeroU32::new(3).unwrap(),
+        Duration::ZERO,
+    )
+    .unwrap();
+    let calls = Arc::new(AtomicUsize::new(0));
+    let probe = ProbeHandle::from_fn("threshold-readiness", {
+        let calls = calls.clone();
+        move |_| {
+            calls.fetch_add(1, Ordering::SeqCst);
+            async { ProbeResult::Healthy }
+        }
+    });
+
+    let instance = Instance::builder(spec, 1, http_controller(port), CancellationToken::new())
+        .readiness_probe(probe)
+        .spawn()
+        .await
+        .expect("spawn");
+    instance.wait_ready().await.expect("threshold reached");
+    assert!(calls.load(Ordering::SeqCst) >= 3);
+    assert!(matches!(
+        instance.state().borrow().state,
+        InstanceState::Running { .. }
+    ));
+    instance.stop().await.expect("stop");
+}
+
+#[tokio::test]
+async fn liveness_is_off_by_default_after_custom_readiness() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let port = common::free_port();
+    let config = common::write_config(&dir, &format!("external-controller: 127.0.0.1:{port}\n"));
+    let mut spec = common::mihomo_spec(&dir, config);
+    spec.options.health = HealthPolicy::new(
+        Duration::from_millis(20),
+        Duration::from_secs(1),
+        NonZeroU32::new(3).unwrap(),
+        NonZeroU32::MIN,
+        Duration::ZERO,
+    )
+    .unwrap();
+    let calls = Arc::new(AtomicUsize::new(0));
+    let probe = ProbeHandle::from_fn("readiness-only", {
+        let calls = calls.clone();
+        move |_| {
+            calls.fetch_add(1, Ordering::SeqCst);
+            async { ProbeResult::Healthy }
+        }
+    });
+    let instance = Instance::builder(spec, 1, http_controller(port), CancellationToken::new())
+        .readiness_probe(probe)
+        .spawn()
+        .await
+        .unwrap();
+    instance.wait_ready().await.unwrap();
+    let after_ready = calls.load(Ordering::SeqCst);
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    assert_eq!(calls.load(Ordering::SeqCst), after_ready);
+    instance.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn readiness_probe_can_be_reused_for_liveness() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let port = common::free_port();
+    let config = common::write_config(&dir, &format!("external-controller: 127.0.0.1:{port}\n"));
+    let mut spec = common::mihomo_spec(&dir, config);
+    spec.options.health = HealthPolicy::new(
+        Duration::from_millis(20),
+        Duration::from_secs(1),
+        NonZeroU32::MIN,
+        NonZeroU32::MIN,
+        Duration::ZERO,
+    )
+    .unwrap();
+    let phases = Arc::new(parking_lot::Mutex::new(Vec::new()));
+    let probe = ProbeHandle::from_fn("shared-probe", {
+        let phases = phases.clone();
+        move |context| {
+            phases.lock().push(context.phase);
+            async { ProbeResult::Healthy }
+        }
+    });
+    let instance = Instance::builder(spec, 1, http_controller(port), CancellationToken::new())
+        .readiness_probe(probe)
+        .liveness_with_readiness_probe()
+        .spawn()
+        .await
+        .unwrap();
+    instance.wait_ready().await.unwrap();
+    tokio::time::timeout(Duration::from_secs(1), async {
+        while !phases.lock().contains(&ProbePhase::Liveness) {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("shared probe never entered liveness phase");
+    assert!(phases.lock().contains(&ProbePhase::Readiness));
+    instance.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn liveness_hysteresis_is_observe_only_and_recovers() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let port = common::free_port();
+    let config = common::write_config(&dir, &format!("external-controller: 127.0.0.1:{port}\n"));
+    let mut spec = common::mihomo_spec(&dir, config);
+    spec.options.health = HealthPolicy::new(
+        Duration::from_millis(20),
+        Duration::from_secs(1),
+        NonZeroU32::new(2).unwrap(),
+        NonZeroU32::new(2).unwrap(),
+        Duration::ZERO,
+    )
+    .unwrap();
+    let readiness = ProbeHandle::from_fn("ready", |_| async { ProbeResult::Healthy });
+    let failures_remaining = Arc::new(AtomicUsize::new(0));
+    let liveness_calls = Arc::new(AtomicUsize::new(0));
+    let liveness = ProbeHandle::from_fn("scripted-liveness", {
+        let failures_remaining = failures_remaining.clone();
+        let liveness_calls = liveness_calls.clone();
+        move |_| {
+            liveness_calls.fetch_add(1, Ordering::SeqCst);
+            let fail = failures_remaining
+                .try_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
+                    remaining.checked_sub(1)
+                })
+                .is_ok();
+            async move {
+                if fail {
+                    ProbeResult::Unhealthy {
+                        detail: Some("credential=must-not-appear-in-debug".repeat(64)),
+                    }
+                } else {
+                    ProbeResult::Healthy
+                }
+            }
+        }
+    });
+    let instance = Instance::builder(spec, 1, http_controller(port), CancellationToken::new())
+        .readiness_probe(readiness)
+        .liveness_probe(liveness)
+        .spawn()
+        .await
+        .unwrap();
+    instance.wait_ready().await.unwrap();
+    let pid = instance.pid().unwrap();
+
+    let before_blip = liveness_calls.load(Ordering::SeqCst);
+    failures_remaining.store(1, Ordering::SeqCst);
+    tokio::time::timeout(Duration::from_secs(2), async {
+        while liveness_calls.load(Ordering::SeqCst) < before_blip + 2 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .unwrap();
+    assert_eq!(
+        instance.state().borrow().health.as_ref().unwrap().state,
+        HealthState::Healthy,
+        "one failure must not flap health"
+    );
+
+    failures_remaining.store(4, Ordering::SeqCst);
+    let mut rx = instance.state();
+    let unhealthy =
+        common::wait_for_health(&mut rx, HealthState::Unhealthy, Duration::from_secs(2)).await;
+    assert!(matches!(unhealthy.state, InstanceState::Running { pid: current } if current == pid));
+    let health = unhealthy.health.unwrap();
+    assert!(health.consecutive_failures >= 2);
+    assert!(health.last_error.as_ref().unwrap().len() <= 512);
+    assert!(!format!("{health:?}").contains("credential="));
+    let unhealthy_changed_at = health.changed_at;
+
+    let recovered =
+        common::wait_for_health(&mut rx, HealthState::Healthy, Duration::from_secs(2)).await;
+    assert!(matches!(recovered.state, InstanceState::Running { pid: current } if current == pid));
+    assert!(recovered.health.unwrap().changed_at >= unhealthy_changed_at);
+    instance
+        .wait_ready()
+        .await
+        .expect("runtime unhealthy does not revoke readiness");
+    assert_eq!(instance.pid(), Some(pid), "observe-only must not restart");
+    instance.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn absolute_startup_deadline_rejects_late_probe_success() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let port = common::free_port();
+    let config = common::write_config(&dir, &format!("external-controller: 127.0.0.1:{port}\n"));
+    let mut spec = common::mihomo_spec(&dir, config);
+    spec.options.startup_timeout = Duration::from_millis(120);
+    spec.options.health = HealthPolicy::new(
+        Duration::from_millis(10),
+        Duration::from_secs(1),
+        NonZeroU32::MIN,
+        NonZeroU32::MIN,
+        Duration::from_secs(1),
+    )
+    .unwrap();
+    let probe = ProbeHandle::from_fn("late-success", |_| async {
+        tokio::time::sleep(Duration::from_millis(400)).await;
+        ProbeResult::Healthy
+    });
+    let instance = Instance::builder(spec, 1, http_controller(port), CancellationToken::new())
+        .readiness_probe(probe)
+        .spawn()
+        .await
+        .unwrap();
+    let error = instance.wait_ready().await.expect_err("deadline must win");
+    assert!(matches!(
+        error,
+        nyanpasu_core_manager::Error::StartupTimeout { .. }
+    ));
+    common::wait_port_refused(port).await;
+}
+
+#[tokio::test]
+async fn stop_cancels_a_hanging_liveness_probe() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let port = common::free_port();
+    let config = common::write_config(&dir, &format!("external-controller: 127.0.0.1:{port}\n"));
+    let mut spec = common::mihomo_spec(&dir, config);
+    spec.options.health = HealthPolicy::new(
+        Duration::from_millis(10),
+        Duration::from_secs(5),
+        NonZeroU32::MIN,
+        NonZeroU32::MIN,
+        Duration::ZERO,
+    )
+    .unwrap();
+    let started = Arc::new(tokio::sync::Notify::new());
+    let liveness = ProbeHandle::from_fn("hanging", {
+        let started = started.clone();
+        move |context| {
+            let started = started.clone();
+            async move {
+                started.notify_one();
+                context.cancel.cancelled().await;
+                ProbeResult::Healthy
+            }
+        }
+    });
+    let instance = Instance::builder(spec, 1, http_controller(port), CancellationToken::new())
+        .readiness_probe(ProbeHandle::from_fn("ready", |_| async {
+            ProbeResult::Healthy
+        }))
+        .liveness_probe(liveness)
+        .spawn()
+        .await
+        .unwrap();
+    instance.wait_ready().await.unwrap();
+    tokio::time::timeout(Duration::from_secs(1), started.notified())
+        .await
+        .expect("liveness did not start");
+    tokio::time::timeout(Duration::from_secs(2), instance.stop())
+        .await
+        .expect("stop blocked behind probe")
+        .unwrap();
+    common::wait_port_refused(port).await;
+}
+
+#[tokio::test]
+async fn startup_timeout_is_one_budget_across_crash_retries() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let port = common::free_port();
+    let state_file = dir.join("retry-state");
+    let launch_count = dir.join("launch-count");
+    let config = common::write_config(
+        &dir,
+        &format!(
+            "external-controller: 127.0.0.1:{port}\nx-fake-core:\n  crash-after-ms: 150\n  crash-times: 1\n  state-file: {state_file}\n  launch-count-file: {launch_count}\n  fail-after-launches: 99\n"
+        ),
+    );
+    let mut spec = common::mihomo_spec(&dir, config);
+    spec.options.startup_timeout = Duration::from_secs(10);
+    spec.options.restart_policy =
+        nyanpasu_utils::process::RestartPolicy::OnFailure { max_restarts: 20 };
+    spec.options.backoff = nyanpasu_utils::process::Backoff::exponential(
+        Duration::from_millis(10),
+        Duration::from_millis(10),
+    );
+    let instance = Instance::builder(spec, 1, http_controller(port), CancellationToken::new())
+        .readiness_probe(ProbeHandle::from_fn("never-ready", |_| async {
+            ProbeResult::Unhealthy {
+                detail: Some("not ready".into()),
+            }
+        }))
+        .spawn()
+        .await
+        .unwrap();
+    let started = std::time::Instant::now();
+    let error = instance.wait_ready().await.expect_err("must time out");
+    assert!(matches!(
+        error,
+        nyanpasu_core_manager::Error::StartupTimeout { .. }
+    ));
+    assert!(
+        started.elapsed() < Duration::from_secs(11),
+        "crash retries extended the absolute startup deadline"
+    );
+    let launches: usize = std::fs::read_to_string(launch_count)
+        .ok()
+        .and_then(|value| value.trim().parse().ok())
+        .unwrap_or(0);
+    assert!(launches > 1, "test did not exercise a retry");
+}
+
+#[tokio::test]
+async fn exited_run_cancels_its_in_flight_probe_before_replacement() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let port = common::free_port();
+    let state_file = dir.join("one-crash-state");
+    let config = common::write_config(
+        &dir,
+        &format!(
+            "external-controller: 127.0.0.1:{port}\nx-fake-core:\n  crash-after-ms: 80\n  crash-times: 1\n  state-file: {state_file}\n"
+        ),
+    );
+    let mut spec = common::mihomo_spec(&dir, config);
+    spec.options.startup_timeout = Duration::from_millis(450);
+    spec.options.health = HealthPolicy::new(
+        Duration::from_millis(5),
+        Duration::from_secs(1),
+        NonZeroU32::MIN,
+        NonZeroU32::MIN,
+        Duration::ZERO,
+    )
+    .unwrap();
+    let first_pid = Arc::new(parking_lot::Mutex::new(None));
+    let probe = ProbeHandle::from_fn("late-first-run", {
+        let first_pid = first_pid.clone();
+        move |context| {
+            let is_first = {
+                let mut first = first_pid.lock();
+                let pid = *first.get_or_insert(context.pid);
+                pid == context.pid
+            };
+            async move {
+                if is_first {
+                    tokio::time::sleep(Duration::from_millis(250)).await;
+                    ProbeResult::Healthy
+                } else {
+                    ProbeResult::Unhealthy {
+                        detail: Some("replacement remains unhealthy".into()),
+                    }
+                }
+            }
+        }
+    });
+    let instance = Instance::builder(spec, 1, http_controller(port), CancellationToken::new())
+        .readiness_probe(probe)
+        .spawn()
+        .await
+        .unwrap();
+    let error = instance
+        .wait_ready()
+        .await
+        .expect_err("cancelled first-run probe must not ready the replacement");
+    assert!(matches!(
+        error,
+        nyanpasu_core_manager::Error::StartupTimeout { .. }
+    ));
 }

--- a/crates/nyanpasu-core-manager/tests/manager_orchestration.rs
+++ b/crates/nyanpasu-core-manager/tests/manager_orchestration.rs
@@ -1,9 +1,17 @@
 mod common;
 
-use std::time::Duration;
+use std::{
+    num::NonZeroU32,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
 
 use nyanpasu_core_manager::{
-    ControllerMode, CoreState, Error, ManagerOptions, StopReason, manager::CoreManager,
+    ControllerMode, CoreState, Error, HealthPolicy, HealthState, ManagerOptions, ProbeHandle,
+    ProbeResult, StopReason, manager::CoreManager,
 };
 
 async fn manager(runtime_dir: &camino::Utf8Path) -> CoreManager {
@@ -13,6 +21,92 @@ async fn manager(runtime_dir: &camino::Utf8Path) -> CoreManager {
     })
     .await
     .expect("construct manager")
+}
+
+#[tokio::test]
+async fn manager_builder_forwards_atomic_runtime_health_without_bumping_lifecycle_time() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let port = common::free_port();
+    let config = common::write_config(&dir, &format!("external-controller: 127.0.0.1:{port}\n"));
+    let mut spec = common::mihomo_spec(&dir, config);
+    spec.options.health = HealthPolicy::new(
+        Duration::from_millis(20),
+        Duration::from_secs(1),
+        NonZeroU32::new(2).unwrap(),
+        NonZeroU32::MIN,
+        Duration::ZERO,
+    )
+    .unwrap();
+    let readiness_calls = Arc::new(AtomicUsize::new(0));
+    let readiness = ProbeHandle::from_fn("manager-readiness", {
+        let readiness_calls = readiness_calls.clone();
+        move |context| {
+            assert_eq!(context.epoch, 1);
+            readiness_calls.fetch_add(1, Ordering::SeqCst);
+            async { ProbeResult::Healthy }
+        }
+    });
+    let failing = Arc::new(AtomicBool::new(false));
+    let liveness = ProbeHandle::from_fn("manager-liveness", {
+        let failing = failing.clone();
+        move |_| {
+            let fail = failing.load(Ordering::SeqCst);
+            async move {
+                if fail {
+                    ProbeResult::Unhealthy {
+                        detail: Some("runtime API unavailable".into()),
+                    }
+                } else {
+                    ProbeResult::Healthy
+                }
+            }
+        }
+    });
+    let manager = CoreManager::builder(ManagerOptions {
+        runtime_dir: Some(dir.join("runtime")),
+        ..ManagerOptions::default()
+    })
+    .readiness_probe(readiness)
+    .liveness_probe(liveness)
+    .build()
+    .await
+    .unwrap();
+    let mut status_rx = manager.subscribe();
+    manager.start(spec).await.unwrap();
+    assert!(readiness_calls.load(Ordering::SeqCst) >= 1);
+    let running = manager.status();
+    let running_changed_at = running.changed_at;
+    let CoreState::Running { epoch, pid } = running.state else {
+        panic!("manager did not publish running")
+    };
+    assert_eq!(epoch, 1);
+    assert_eq!(running.health.unwrap().state, HealthState::Healthy);
+
+    failing.store(true, Ordering::SeqCst);
+    let unhealthy = tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            status_rx.changed().await.unwrap();
+            let status = status_rx.borrow_and_update().clone();
+            if status
+                .health
+                .as_ref()
+                .is_some_and(|health| health.state == HealthState::Unhealthy)
+            {
+                break status;
+            }
+        }
+    })
+    .await
+    .expect("manager did not forward unhealthy state");
+    assert!(matches!(
+        unhealthy.state,
+        CoreState::Running {
+            epoch: 1,
+            pid: current
+        } if current == pid
+    ));
+    assert_eq!(unhealthy.changed_at, running_changed_at);
+    manager.stop().await.unwrap();
 }
 
 #[tokio::test]
@@ -273,7 +367,7 @@ async fn lifecycle_sequence_matches_legacy_contract() {
     let config = common::write_config(
         &dir,
         &format!(
-            "external-controller: 127.0.0.1:{port}\nx-fake-core:\n  crash-after-ms: 400\n  crash-times: 1\n  state-file: {state_file}\n"
+            "external-controller: 127.0.0.1:{port}\nx-fake-core:\n  crash-after-ms: 1500\n  crash-times: 1\n  state-file: {state_file}\n"
         ),
     );
 
@@ -294,8 +388,24 @@ async fn lifecycle_sequence_matches_legacy_contract() {
         .start(common::mihomo_spec(&dir, config))
         .await
         .expect("start");
-    // Crash at ~400ms, recovery, then user stop.
-    tokio::time::sleep(Duration::from_secs(3)).await;
+    let first_pid = match manager.status().state {
+        CoreState::Running { pid, .. } => pid,
+        ref state => panic!("expected initial Running, got {state:?}"),
+    };
+    let mut recovery_rx = manager.subscribe();
+    tokio::time::timeout(Duration::from_secs(10), async {
+        loop {
+            if matches!(
+                recovery_rx.borrow_and_update().state,
+                CoreState::Running { pid, .. } if pid != first_pid
+            ) {
+                break;
+            }
+            recovery_rx.changed().await.expect("status channel open");
+        }
+    })
+    .await
+    .expect("core never recovered from scripted crash");
     manager.stop().await.expect("stop");
     // Let the recorder drain the final Stopped notification before teardown — on the current-thread runtime the woken recorder task only runs once we yield.
     tokio::time::timeout(Duration::from_secs(2), async {
@@ -453,6 +563,9 @@ async fn dropping_live_manager_releases_runtime_ownership() {
                 Err(Error::RuntimeDirectoryOwned(_)) => {
                     tokio::time::sleep(Duration::from_millis(20)).await;
                 }
+                Err(Error::Io(error)) if error.kind() == std::io::ErrorKind::PermissionDenied => {
+                    tokio::time::sleep(Duration::from_millis(20)).await;
+                }
                 Err(error) => panic!("unexpected construction error: {error}"),
             }
         }
@@ -467,9 +580,13 @@ async fn initial_start_stop_uncertainty_quarantines_until_recovery() {
     let (_guard, dir) = common::utf8_tempdir();
     let runtime_dir = dir.join("runtime");
     let port = common::free_port();
+    let crash_state = dir.join("initial-crash-state");
+    let launch_count = dir.join("initial-launch-count");
     let config = common::write_config(
         &dir,
-        &format!("external-controller: 127.0.0.1:{port}\nx-fake-core:\n  never-ready: true\n"),
+        &format!(
+            "external-controller: 127.0.0.1:{port}\nx-fake-core:\n  never-ready: true\n  crash-after-ms: 3000\n  crash-times: 1\n  state-file: '{crash_state}'\n  launch-count-file: '{launch_count}'\n  fail-after-launches: 99\n"
+        ),
     );
     let manager = std::sync::Arc::new(
         CoreManager::new(ManagerOptions {
@@ -483,12 +600,19 @@ async fn initial_start_stop_uncertainty_quarantines_until_recovery() {
     let start = {
         let manager = manager.clone();
         let mut spec = common::mihomo_spec(&dir, config.clone());
-        spec.options.startup_timeout = Duration::from_millis(300);
+        spec.options.startup_timeout = Duration::from_secs(15);
+        spec.options.restart_policy =
+            nyanpasu_utils::process::RestartPolicy::OnFailure { max_restarts: 0 };
         tokio::spawn(async move { manager.start(spec).await })
     };
     let pid_path = runtime_dir.join("core-1.pid");
-    tokio::time::timeout(Duration::from_secs(5), async {
-        while !pid_path.exists() {
+    tokio::time::timeout(Duration::from_secs(15), async {
+        loop {
+            let launched =
+                std::fs::read_to_string(&launch_count).is_ok_and(|value| value.trim() == "1");
+            if pid_path.exists() && launched {
+                break;
+            }
             tokio::time::sleep(Duration::from_millis(5)).await;
         }
     })

--- a/crates/nyanpasu-core-manager/tests/real_mihomo_smoke.rs
+++ b/crates/nyanpasu-core-manager/tests/real_mihomo_smoke.rs
@@ -83,7 +83,7 @@ async fn real_core_starts_probes_and_stops() {
         .await
         .expect("real mihomo passes the version probe");
     assert!(matches!(
-        *instance.state().borrow(),
+        instance.state().borrow().state,
         InstanceState::Running { pid } if pid > 0
     ));
 


### PR DESCRIPTION
cc @4o3f

Replaces the hardcoded `GET /version` readiness gate in `nyanpasu-core-manager` with a pluggable probe abstraction, adds optional runtime liveness probing, and publishes health as an atomic composite snapshot alongside the lifecycle state.

Scope is this crate only — no `nyanpasu-utils` changes, no `nyanpasu_service` changes, submodule untouched, and no dependency or lockfile changes.

## Compatibility

Defaults reproduce current behavior byte-for-byte. Readiness stays `ControllerVersionProbe` (`GET /version`, 1s timeout) at a 250ms interval, and **liveness is off unless explicitly configured** — an unconfigured instance still performs zero probes after reaching `Running`.

The one breaking API change is `InstanceOptions::probe_interval` → `health: HealthPolicy`. `core-manager` currently has no in-repo downstream consumer, so the break surface is zero.

## What's in it

- **`src/probe.rs`** — object-safe `HealthProbe` trait + `ProbeHandle`. The handle's `Debug` prints only its label and `ProbeContext` deliberately has no `Debug`, so probe internals and controller secrets cannot leak into logs.
- **`src/probe_driver.rs`** — single-in-flight driver with per-attempt timeouts and cancel-before-drop. Probes no longer `await` inside the monitor `select!`, so a slow probe can no longer stall supervisor event drain. Periodic liveness and saga `Reconcile` requests serialize through one queue.
- **`src/health.rs`** — validated value-typed `HealthPolicy` (interval / timeout / failure & success thresholds / start period) plus a purely synchronous `HealthTracker` with injected timestamps.
- **Configuration split** — behavior objects stay out of `InstanceSpec`/`InstanceOptions` and live on the builder instead; only the value type `HealthPolicy` goes into options. This keeps `config_diff`'s `Debug`-based change classification accurate, which an opaque probe would have corrupted.
- **`CoreManagerBuilder`** — `readiness_probe` / `liveness_probe` / `liveness_with_readiness_probe`. All five instance-creation paths (initial start, replacement, rollback, graceful bootstrap, graceful fallback) share one builder helper so none can silently miss the probe plan.
- **manager** — composite epoch forwarding via `send_if_modified`; the three `probe_health()` call sites now route through `Instance::probe_now(Reconcile)`, so a custom probe also governs saga verification.

## Invariants worth reviewing

These are the properties the design hinges on, each mechanically enforced rather than left to convention:

1. **`acknowledge_ready` at most once per child run.** Recovering from `Unhealthy` never re-acknowledges — otherwise health flapping would silently reset the supervisor restart budget and defeat the storm breaker.
2. **One composite `watch<InstanceStatus>`, not a second channel.** A new PID can never be paired with the previous process's health.
3. **`HealthStatus.changed_at` is separate** from the lifecycle timestamp that feeds IPC `state_changed_at`; a pure health change never bumps it.
4. **Observations carry `run_id` + `pid`** and are invalidated on `Exited` as well as restart/stop/cancel.
5. **The initial startup deadline is absolute** — crash retries, the start period, and thresholds never extend it.

On (5): the monitor `select!` is `biased;` with the deadline arms ahead of the observation arm, so a probe that succeeded at `deadline - ε` could lose to the timeout and kill a core that had in fact become ready. Both deadline arms now drain already-queued observations and apply any still within budget before committing to the kill. `completed_at == deadline` remains accepted; strictly after remains rejected.

## Design boundary: observe-only

A failing liveness probe reports `Unhealthy` while the lifecycle stays `Running`. **Nothing is restarted automatically.**

Safe automatic recycling needs a PID-guarded `Supervisor::restart_current` in `nyanpasu-utils` (confirm death + consume restart budget + count toward the storm window) and a serialization protocol with the apply/switch saga, quarantine, and proof-of-death machinery. That is a separate and larger change. The upgrade path is documented in the README rather than stubbed as a single-variant enum in code.

## Verification

- `cargo fmt --all -- --check` — pass
- `cargo clippy -p nyanpasu-core-manager --all-targets -- -D warnings` — pass
- `cargo test -p nyanpasu-core-manager` — **111 passed, 0 failed, 3 ignored** (2 real-mihomo tests need the platform binary; 1 is a helper spawned as a managed child by the deadline-drain test)

Reviewed by two independent models against the implementation plan: zero Critical findings from both. Three accepted warnings were fixed in the process — a mis-named test, the deadline race above, and a lost coverage path (see below).

## Known gaps — please weigh these

1. **Stale-observation rejection has predicate-level coverage only.** The reachable path is: run N's driver enqueues an observation, the monitor is still handling `Exited`/`Started`, and the observation is dequeued once run N+1 is current. That ordering could not be reproduced deterministically without sleep-tuning, so the decision was extracted into `observation_applies` and unit-tested exhaustively (matching, stale run_id with reused PID, matching run_id with different PID, both stale). The production path does call that predicate, but the queue-ordering scenario itself has no end-to-end test. Flagging explicitly rather than claiming coverage that does not exist.

2. **A test's failure trigger changed.** `unconfirmed_replacement_stop_never_cleans_or_reuses_its_epoch` previously drove failure through a 300ms `startup_timeout` against a never-ready core, which became flaky under parallel load. It is now crash-driven, and the readiness-timeout path was restored as a **separate** test rather than dropped.

3. **Deferred warnings, not fixed here:** `HealthPolicy` accepts absurd durations such as `Duration::MAX`, which can panic `Instant` arithmetic (`startup_timeout` has the same pre-existing hazard); the probe-request queue is unbounded, though in-repo callers are serialized by the `ctrl` lock; and `Instance::probe_now(phase)` rejects two of three `ProbePhase` variants at runtime, which is a mild API smell inherited from the plan's wording.

4. **`Reconcile` is a deliberate behavior change.** It now returns `Unhealthy` when the run is not `ready`, where the previous direct HTTP probe could have succeeded in the post-crash rebuild window. The stricter reading was chosen intentionally — claiming health before readiness is a lie — but it does make an `apply` in that window fail more readily than before.

5. **Local build note:** a full-parallel test build OOMs the nightly LLVM backend on at least one dev machine; `CARGO_BUILD_JOBS=1` works around it. No dependency or feature was added to paper over this.
