### PR TITLE
test(core-manager): real-core integration suite + clash-rs ipc flag, meow profile, noop classify

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,12 +16,12 @@ permissions:
   contents: read
 
 jobs:
-  real-mihomo:
+  real-cores:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
       fail-fast: false
-    name: Real mihomo tests (${{ matrix.os }})
+    name: Real core tests (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -46,12 +46,14 @@ jobs:
       - uses: denoland/setup-deno@v2
         with:
           deno-version: v2.x
-      - name: Download mihomo core
-        run: deno run -A scripts/prepare-mihomo.ts
+      - name: Download cores
+        run: deno run -A scripts/prepare-cores.ts
       - name: Run integration tests
         run: cargo test -p clash-api --test mihomo -- --ignored --nocapture
       - name: Run core-manager smoke tests
         run: cargo test -p nyanpasu-core-manager --test real_mihomo_smoke -- --ignored --nocapture
+      - name: Run core-manager real-core tests
+        run: cargo test -p nyanpasu-core-manager --test real_cores -- --ignored --nocapture
 
   nyanpasu-ipc:
     strategy:

--- a/crates/clash-api/src/api/version.rs
+++ b/crates/clash-api/src/api/version.rs
@@ -2,9 +2,11 @@ use reqwest::Method;
 
 use crate::{Client, Result, retry::RequestMetadata};
 
-/// Mihomo core version information.
+/// Core version information. Clash Premium omits `meta`, so it defaults to
+/// `false` for non-mihomo cores.
 #[derive(Clone, Debug, PartialEq, Eq, serde::Deserialize, serde::Serialize, specta::Type)]
 pub struct Version {
+    #[serde(default)]
     pub meta: bool,
     pub version: String,
 }

--- a/crates/nyanpasu-core-manager/README.md
+++ b/crates/nyanpasu-core-manager/README.md
@@ -365,6 +365,12 @@ directory. Managed mode may use `derived_dir` as the compatibility runtime-dir
 alias; Passthrough requires `runtime_dir` explicitly. The advertised endpoint
 is available as `CoreStatus.controller` in both modes.
 
+Managed endpoints are per-kind: mihomo and clash-rs (new enough versions) take
+a named pipe / unix socket, clash premium and meow are HTTP-only. clash-rs is
+a special case — its CLI unconditionally overrides the config's IPC key, so
+the manager passes the endpoint as `--controller-ipc` instead of
+`external-controller-pipe` in YAML.
+
 ### Apply config with revision CAS
 
 ```rust
@@ -530,6 +536,19 @@ it first, or point `MIHOMO_BIN` at one):
 deno run -A scripts/prepare-mihomo.ts
 cargo test -p nyanpasu-core-manager --test real_mihomo_smoke -- --ignored --nocapture
 ```
+
+A broader suite covers all four real cores — mihomo, clash-rs, clash premium
+and meow: start/stop, proxied traffic through a test socks5 outbound, config
+updates (noop/patch/reload/restart per kind), and the Force/Prefer/Disable
+local IPC policies:
+
+```sh
+deno run -A scripts/prepare-cores.ts
+cargo test -p nyanpasu-core-manager --test real_cores -- --ignored --nocapture
+```
+
+Each binary can be overridden with `<NAME>_BIN` (`MIHOMO_BIN`, `CLASH_RS_BIN`,
+`CLASH_BIN`, `MEOW_BIN`).
 
 ## Design
 

--- a/crates/nyanpasu-core-manager/src/config/mihomo.rs
+++ b/crates/nyanpasu-core-manager/src/config/mihomo.rs
@@ -217,9 +217,14 @@ pub(crate) fn classify(
 
     let source_diff = diff(current_source, desired_source);
     if desired_spec.core.kind != CoreKind::Mihomo {
-        // Non-mihomo kinds degrade to Switch — but an identical config is
-        // still a Noop; there is nothing to deny.
-        return Ok(if source_diff.is_empty() {
+        // Non-mihomo kinds degrade to Switch. An identical config is still a
+        // Noop — but only when the *effective* documents also match: a
+        // capability change (e.g. the binary was replaced in place and now
+        // resolves a different version) can alter the derived config and the
+        // resolved controller without any source edit, and that must restart.
+        let unchanged =
+            source_diff.is_empty() && diff(current_effective, desired_effective).is_empty();
+        return Ok(if unchanged {
             ConfigChange::Noop
         } else {
             ConfigChange::Switch
@@ -550,6 +555,25 @@ mod tests {
                 "{kind:?} should noop on an identical config"
             );
         }
+    }
+
+    #[test]
+    fn non_mihomo_noop_requires_unchanged_effective_config() {
+        // Same source, but capability resolution rewrote the controller:
+        // the derived config changed, so this must restart, not noop.
+        let spec = spec(CoreKind::ClashRust, "clash-rs");
+        assert!(matches!(
+            classify(
+                &mapping("mixed-port: 7890"),
+                &mapping("external-controller: 127.0.0.1:9090"),
+                &spec,
+                &mapping("mixed-port: 7890"),
+                &mapping("external-controller-pipe: /tmp/core-1.sock"),
+                &spec,
+            )
+            .unwrap(),
+            ConfigChange::Switch
+        ));
     }
 
     #[test]

--- a/crates/nyanpasu-core-manager/src/config/mihomo.rs
+++ b/crates/nyanpasu-core-manager/src/config/mihomo.rs
@@ -3,7 +3,8 @@
 //!
 //! Every field table here mirrors Mihomo's own config schema and its Clash
 //! RESTful API surface, so nothing in this module generalizes to another core:
-//! [`classify`] degrades every non-Mihomo kind to [`ConfigChange::Switch`].
+//! [`classify`] degrades every non-Mihomo kind to [`ConfigChange::Switch`]
+//! (an identical config is still [`ConfigChange::Noop`]).
 //! Other cores get their own sibling module on top of [`super::diff`].
 
 use std::collections::BTreeSet;
@@ -210,13 +211,21 @@ pub(crate) fn classify(
     desired_effective: &Mapping,
     desired_spec: &InstanceSpec,
 ) -> Result<ConfigChange, Error> {
-    if desired_spec.core.kind != CoreKind::Mihomo
-        || process_spec_changed(current_spec, desired_spec)
-    {
+    if process_spec_changed(current_spec, desired_spec) {
         return Ok(ConfigChange::Switch);
     }
 
     let source_diff = diff(current_source, desired_source);
+    if desired_spec.core.kind != CoreKind::Mihomo {
+        // Non-mihomo kinds degrade to Switch — but an identical config is
+        // still a Noop; there is nothing to deny.
+        return Ok(if source_diff.is_empty() {
+            ConfigChange::Noop
+        } else {
+            ConfigChange::Switch
+        });
+    }
+
     if source_diff.iter().any(|entry| {
         entry
             .path
@@ -515,6 +524,32 @@ mod tests {
             classify_documents(&mapping("dns: {ipv6: false}"), &mapping("dns: null")).unwrap(),
             ConfigChange::Switch
         ));
+    }
+
+    #[test]
+    fn identical_config_is_noop_for_every_kind() {
+        for kind in [
+            CoreKind::Mihomo,
+            CoreKind::ClashRust,
+            CoreKind::ClashPremium,
+        ] {
+            let spec = spec(kind, "core");
+            assert!(
+                matches!(
+                    classify(
+                        &mapping("mixed-port: 7890"),
+                        &Mapping::new(),
+                        &spec,
+                        &mapping("mixed-port: 7890"),
+                        &Mapping::new(),
+                        &spec,
+                    )
+                    .unwrap(),
+                    ConfigChange::Noop
+                ),
+                "{kind:?} should noop on an identical config"
+            );
+        }
     }
 
     #[test]

--- a/crates/nyanpasu-core-manager/src/error.rs
+++ b/crates/nyanpasu-core-manager/src/error.rs
@@ -20,8 +20,6 @@ pub enum Error {
     },
     #[error("no external controller configured; the version health probe needs one")]
     ControllerMissing,
-    #[error("core kind `{0}` has no launch profile yet")]
-    UnsupportedCore(CoreKind),
     #[error(
         "core `{kind}` version `{version}` does not support the required local IPC transport; use LocalIpcPolicy::Prefer or LocalIpcPolicy::Disable"
     )]

--- a/crates/nyanpasu-core-manager/src/instance.rs
+++ b/crates/nyanpasu-core-manager/src/instance.rs
@@ -131,7 +131,6 @@ impl Instance {
         if tokio::fs::metadata(&spec.core.binary_path).await.is_err() {
             return Err(Error::BinaryNotFound(spec.core.binary_path.clone()));
         }
-        // Rejects kinds without a launch profile (`Meow`) before spawning.
         kind::run_args(spec.core.kind, &spec.working_dir, &spec.config_path)?;
 
         let readiness_probe = match readiness_probe {
@@ -168,7 +167,8 @@ impl Instance {
         let (event_tx, event_rx) = mpsc::unbounded_channel();
         let supervisor = Supervisor::builder({
             let spec = spec.clone();
-            move || build_command(&spec, epoch)
+            let controller = controller.clone();
+            move || build_command(&spec, epoch, &controller)
         })
         .restart_policy(spec.options.restart_policy)
         .backoff(spec.options.backoff)
@@ -427,9 +427,10 @@ impl Drop for Instance {
     }
 }
 
-fn build_command(spec: &InstanceSpec, epoch: u64) -> Command {
-    let args = kind::run_args(spec.core.kind, &spec.working_dir, &spec.config_path)
+fn build_command(spec: &InstanceSpec, epoch: u64, controller: &ResolvedController) -> Command {
+    let mut args = kind::run_args(spec.core.kind, &spec.working_dir, &spec.config_path)
         .expect("kind validated in Instance::spawn");
+    args.extend(kind::controller_args(spec.core.kind, &controller.host));
     let config_dir = spec
         .config_path
         .parent()

--- a/crates/nyanpasu-core-manager/src/kind.rs
+++ b/crates/nyanpasu-core-manager/src/kind.rs
@@ -16,7 +16,7 @@ const SAFE_PATHS_SEPARATOR: &str = ";";
 #[cfg(not(windows))]
 const SAFE_PATHS_SEPARATOR: &str = ":";
 
-/// Launch arguments for this kind. `Meow` has no launch profile yet.
+/// Launch arguments for this kind.
 pub(crate) fn run_args(
     kind: CoreKind,
     working_dir: &Utf8Path,
@@ -25,11 +25,31 @@ pub(crate) fn run_args(
     let dir = OsString::from(working_dir.as_str());
     let cfg = OsString::from(config_path.as_str());
     Ok(match kind {
-        CoreKind::Mihomo => vec!["-m".into(), "-d".into(), dir, "-f".into(), cfg],
+        // Meow accepts the mihomo CLI for compatibility.
+        CoreKind::Mihomo | CoreKind::Meow => {
+            vec!["-m".into(), "-d".into(), dir, "-f".into(), cfg]
+        }
         CoreKind::ClashRust => vec!["-d".into(), dir, "-c".into(), cfg],
         CoreKind::ClashPremium => vec!["-d".into(), dir, "-f".into(), cfg],
-        CoreKind::Meow => return Err(Error::UnsupportedCore(kind)),
     })
+}
+
+/// Extra launch flags to enable the controller for kinds that cannot take it
+/// from the config file.
+///
+/// clash-bin unconditionally overwrites the config's `external_controller_ipc`
+/// with its CLI flag value (clash-bin/src/main.rs), so for clash-rs a system
+/// IPC endpoint only takes effect when passed as `--controller-ipc`.
+pub(crate) fn controller_args(kind: CoreKind, host: &clash_api::Host) -> Vec<OsString> {
+    if !matches!(kind, CoreKind::ClashRust) {
+        return Vec::new();
+    }
+    match host {
+        clash_api::Host::NamedPipe(path) | clash_api::Host::UnixSocket(path) => {
+            vec!["--controller-ipc".into(), path.as_os_str().to_owned()]
+        }
+        _ => Vec::new(),
+    }
 }
 
 /// Arguments for a one-shot `-t` config validation run (same for all kinds,
@@ -52,9 +72,6 @@ pub fn mihomo_safe_paths(working_dir: &Utf8Path, config_dir: &Utf8Path) -> Strin
 /// One-shot `-t` config validation, replacing the legacy `check_config_`.
 /// A non-zero exit becomes [`Error::ConfigCheckFailed`] with a condensed message.
 pub async fn check_config(spec: &crate::spec::InstanceSpec) -> Result<(), Error> {
-    if matches!(spec.core.kind, CoreKind::Meow) {
-        return Err(Error::UnsupportedCore(spec.core.kind));
-    }
     let config_dir = spec
         .config_path
         .parent()
@@ -149,12 +166,13 @@ mod tests {
     }
 
     #[test]
-    fn meow_has_no_launch_profile() {
+    fn meow_shares_the_mihomo_launch_profile() {
         let dir = Utf8PathBuf::from("/d");
-        assert!(matches!(
-            run_args(CoreKind::Meow, &dir, &dir),
-            Err(Error::UnsupportedCore(CoreKind::Meow))
-        ));
+        let cfg = Utf8PathBuf::from("/d/config.yaml");
+        assert_eq!(
+            run_args(CoreKind::Meow, &dir, &cfg).unwrap(),
+            run_args(CoreKind::Mihomo, &dir, &cfg).unwrap()
+        );
     }
 
     #[test]

--- a/crates/nyanpasu-core-manager/tests/common/mod.rs
+++ b/crates/nyanpasu-core-manager/tests/common/mod.rs
@@ -1,6 +1,9 @@
 //! Shared utilities for nyanpasu-core-manager integration tests.
 #![allow(dead_code)]
 
+pub mod real;
+pub mod socks5;
+
 use std::{sync::Arc, time::Duration};
 
 use camino::{Utf8Path, Utf8PathBuf};

--- a/crates/nyanpasu-core-manager/tests/common/real.rs
+++ b/crates/nyanpasu-core-manager/tests/common/real.rs
@@ -51,6 +51,16 @@ pub fn workspace_root() -> Utf8PathBuf {
         .to_owned()
 }
 
+/// Serializes the real-core tests: parallel runs contend on CPU and on
+/// ephemeral ports (a free port can be grabbed by another test's core before
+/// this one binds it), which made startup and proxy-chain checks flaky.
+pub async fn serial_lock() -> tokio::sync::MutexGuard<'static, ()> {
+    static LOCK: std::sync::OnceLock<tokio::sync::Mutex<()>> = std::sync::OnceLock::new();
+    LOCK.get_or_init(|| tokio::sync::Mutex::new(()))
+        .lock()
+        .await
+}
+
 /// Locates the core binary in `tests/bin`; `<NAME>_BIN` (e.g. `MIHOMO_BIN`,
 /// `CLASH_RS_BIN`) overrides the path.
 pub fn real_core_bin(core: &RealCore) -> Utf8PathBuf {

--- a/crates/nyanpasu-core-manager/tests/common/real.rs
+++ b/crates/nyanpasu-core-manager/tests/common/real.rs
@@ -1,0 +1,142 @@
+//! Helpers for integration tests against the real core binaries in
+//! `tests/bin/` (downloaded by `deno run -A scripts/prepare-cores.ts`).
+
+use std::time::Duration;
+
+use camino::{Utf8Path, Utf8PathBuf};
+use nyanpasu_core_manager::{
+    ControllerMode, CoreKind, CoreManager, CoreSpec, InstanceOptions, InstanceSpec, LocalIpcPolicy,
+    ManagerOptions,
+};
+
+/// A real core under test: its manager kind and the binary name in tests/bin.
+#[derive(Debug, Clone, Copy)]
+pub struct RealCore {
+    pub kind: CoreKind,
+    pub name: &'static str,
+    /// Whether the core can serve its controller over system IPC
+    /// (named pipe / unix socket) at the downloaded version.
+    pub system_ipc: bool,
+}
+
+pub const MIHOMO: RealCore = RealCore {
+    kind: CoreKind::Mihomo,
+    name: "mihomo",
+    system_ipc: true,
+};
+pub const CLASH_RS: RealCore = RealCore {
+    kind: CoreKind::ClashRust,
+    name: "clash-rs",
+    system_ipc: true,
+};
+pub const CLASH_PREMIUM: RealCore = RealCore {
+    kind: CoreKind::ClashPremium,
+    name: "clash",
+    system_ipc: false,
+};
+pub const MEOW: RealCore = RealCore {
+    kind: CoreKind::Meow,
+    name: "meow",
+    system_ipc: false,
+};
+
+pub const REAL_CORES: &[RealCore] = &[MIHOMO, CLASH_RS, CLASH_PREMIUM, MEOW];
+
+pub fn workspace_root() -> Utf8PathBuf {
+    let manifest = Utf8PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    manifest
+        .parent()
+        .and_then(Utf8Path::parent)
+        .expect("crate lives in <workspace>/crates")
+        .to_owned()
+}
+
+/// Locates the core binary in `tests/bin`; `<NAME>_BIN` (e.g. `MIHOMO_BIN`,
+/// `CLASH_RS_BIN`) overrides the path.
+pub fn real_core_bin(core: &RealCore) -> Utf8PathBuf {
+    let env_name = format!("{}_BIN", core.name.to_uppercase().replace('-', "_"));
+    let binary = std::env::var_os(&env_name)
+        .map(|p| Utf8PathBuf::from_path_buf(p.into()).expect("{env_name} must be UTF-8"))
+        .unwrap_or_else(|| {
+            workspace_root().join("tests/bin").join(format!(
+                "{}{}",
+                core.name,
+                std::env::consts::EXE_SUFFIX
+            ))
+        });
+    assert!(
+        binary.is_file(),
+        "{} was not found at {binary}; run `deno run -A scripts/prepare-cores.ts` or set {env_name}",
+        core.name,
+    );
+    binary
+}
+
+pub fn real_spec(core: &RealCore, dir: &Utf8Path, config_path: Utf8PathBuf) -> InstanceSpec {
+    InstanceSpec {
+        core: CoreSpec {
+            kind: core.kind,
+            binary_path: real_core_bin(core),
+            version: None,
+            features: Vec::new(),
+        },
+        config_path,
+        working_dir: dir.to_owned(),
+        pid_file: None,
+        options: InstanceOptions {
+            startup_timeout: Duration::from_secs(20),
+            ..super::fast_options()
+        },
+    }
+}
+
+/// A config routing every connection through the test socks5 server, so tests
+/// can prove the core really loaded and uses the proxy node. The
+/// `external-controller` must be a real free port: the Prefer/Disable policies
+/// keep it as the control channel instead of rewriting it.
+pub fn proxy_config(mixed_port: u16, ctrl_port: u16, socks5_port: u16, extra: &str) -> String {
+    format!(
+        "mixed-port: {mixed_port}\n\
+         external-controller: 127.0.0.1:{ctrl_port}\n\
+         proxies:\n\
+         \x20 - name: out\n\
+         \x20   type: socks5\n\
+         \x20   server: 127.0.0.1\n\
+         \x20   port: {socks5_port}\n\
+         rules:\n\
+         \x20 - MATCH,out\n\
+         {extra}"
+    )
+}
+
+fn unique_template() -> Option<String> {
+    #[cfg(windows)]
+    {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        static COUNTER: AtomicU32 = AtomicU32::new(0);
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        Some(format!(
+            r"\\.\pipe\nyanpasu-real-{}-{n}-{{epoch}}",
+            std::process::id()
+        ))
+    }
+    #[cfg(not(windows))]
+    {
+        None // unix default derives the socket under derived_dir (already unique)
+    }
+}
+
+pub async fn managed_manager(dir: &Utf8Path, local_ipc_policy: LocalIpcPolicy) -> CoreManager {
+    CoreManager::new(ManagerOptions {
+        controller_mode: ControllerMode::Managed {
+            derived_dir: dir.join("derived"),
+            controller_template: unique_template(),
+            local_ipc_policy,
+        },
+        control_timeout: Duration::from_secs(15),
+        reconcile_timeout: Duration::from_secs(15),
+        ..ManagerOptions::default()
+    })
+    .await
+    .expect("construct manager")
+}

--- a/crates/nyanpasu-core-manager/tests/common/socks5.rs
+++ b/crates/nyanpasu-core-manager/tests/common/socks5.rs
@@ -1,0 +1,221 @@
+//! Minimal SOCKS5 plumbing for real-core integration tests.
+//!
+//! The server implements just enough of RFC 1928 for a clash-family core to
+//! use it as an outbound `socks5` proxy node: version-5 handshake with
+//! no-auth, CONNECT command, then a plain TCP relay. The client helper plays
+//! the other side, so tests can drive traffic through a core's inbound
+//! (mixed port) and assert it comes out the far end of the chain:
+//!
+//! test client → core inbound → core `socks5` outbound node → this server →
+//! echo target.
+
+use std::{
+    io,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+};
+
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::{TcpListener, TcpStream},
+    task::JoinHandle,
+};
+
+/// A running SOCKS5 server. Dropping it aborts the accept loop.
+pub struct Socks5Server {
+    port: u16,
+    connections: Arc<AtomicUsize>,
+    task: JoinHandle<()>,
+}
+
+impl Socks5Server {
+    pub async fn start() -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind socks5 server");
+        let port = listener.local_addr().expect("local addr").port();
+        let connections = Arc::new(AtomicUsize::new(0));
+        let counter = connections.clone();
+        let task = tokio::spawn(async move {
+            loop {
+                match listener.accept().await {
+                    Ok((mut stream, _)) => {
+                        counter.fetch_add(1, Ordering::Relaxed);
+                        tokio::spawn(async move {
+                            let _ = handle_session(&mut stream).await;
+                        });
+                    }
+                    Err(_) => return,
+                }
+            }
+        });
+        Self {
+            port,
+            connections,
+            task,
+        }
+    }
+
+    pub fn port(&self) -> u16 {
+        self.port
+    }
+
+    /// How many core-side connections the server has accepted so far.
+    pub fn connection_count(&self) -> usize {
+        self.connections.load(Ordering::Relaxed)
+    }
+}
+
+impl Drop for Socks5Server {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+async fn read_exact<const N: usize>(stream: &mut TcpStream) -> io::Result<[u8; N]> {
+    let mut buf = [0u8; N];
+    stream.read_exact(&mut buf).await?;
+    Ok(buf)
+}
+
+async fn handle_session(mut stream: &mut TcpStream) -> io::Result<()> {
+    // Greeting: VER, NMETHODS, METHODS...
+    let [ver, nmethods] = read_exact(stream).await?;
+    if ver != 0x05 {
+        return Err(io::Error::new(io::ErrorKind::InvalidData, "not socks5"));
+    }
+    let mut methods = vec![0u8; nmethods as usize];
+    stream.read_exact(&mut methods).await?;
+    // VER, no-auth selected.
+    stream.write_all(&[0x05, 0x00]).await?;
+
+    // Request: VER, CMD, RSV, ATYP, DST.ADDR, DST.PORT
+    let [ver, cmd, _rsv, atyp] = read_exact(stream).await?;
+    if ver != 0x05 || cmd != 0x01 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "only CONNECT is supported",
+        ));
+    }
+    let host = match atyp {
+        0x01 => {
+            let octets = read_exact::<4>(stream).await?;
+            std::net::Ipv4Addr::from(octets).to_string()
+        }
+        0x03 => {
+            let [len] = read_exact(stream).await?;
+            let mut name = vec![0u8; len as usize];
+            stream.read_exact(&mut name).await?;
+            String::from_utf8(name)
+                .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "bad domain"))?
+        }
+        0x04 => {
+            let octets = read_exact::<16>(stream).await?;
+            std::net::Ipv6Addr::from(octets).to_string()
+        }
+        _ => return Err(io::Error::new(io::ErrorKind::InvalidData, "bad atyp")),
+    };
+    let port = {
+        let [hi, lo] = read_exact(stream).await?;
+        u16::from_be_bytes([hi, lo])
+    };
+
+    let mut target = match TcpStream::connect((host.as_str(), port)).await {
+        Ok(target) => target,
+        Err(_) => {
+            // Reply: connection refused (REP=0x05).
+            stream
+                .write_all(&[0x05, 0x05, 0x00, 0x01, 0, 0, 0, 0, 0, 0])
+                .await?;
+            return Ok(());
+        }
+    };
+    // Reply: succeeded.
+    stream
+        .write_all(&[0x05, 0x00, 0x00, 0x01, 0, 0, 0, 0, 0, 0])
+        .await?;
+    tokio::io::copy_bidirectional(&mut stream, &mut target).await?;
+    Ok(())
+}
+
+/// Connects to a SOCKS5 proxy at `proxy_port` and issues CONNECT to
+/// `target_host:target_port`, returning the relay-ready stream.
+pub async fn connect_via(
+    proxy_port: u16,
+    target_host: &str,
+    target_port: u16,
+) -> io::Result<TcpStream> {
+    let mut stream = TcpStream::connect(("127.0.0.1", proxy_port)).await?;
+    stream.write_all(&[0x05, 0x01, 0x00]).await?;
+    let [ver, method] = read_exact(&mut stream).await?;
+    if ver != 0x05 || method == 0xff {
+        return Err(io::Error::other("no acceptable method"));
+    }
+
+    let mut request = vec![0x05, 0x01, 0x00];
+    if let Ok(octets) = target_host.parse::<std::net::Ipv4Addr>() {
+        request.push(0x01);
+        request.extend_from_slice(&octets.octets());
+    } else {
+        request.push(0x03);
+        request.push(target_host.len() as u8);
+        request.extend_from_slice(target_host.as_bytes());
+    }
+    request.extend_from_slice(&target_port.to_be_bytes());
+    stream.write_all(&request).await?;
+
+    let [ver, rep, _rsv, atyp] = read_exact(&mut stream).await?;
+    if ver != 0x05 || rep != 0x00 {
+        return Err(io::Error::other(format!("connect failed with rep={rep}")));
+    }
+    // Consume BND.ADDR + BND.PORT.
+    match atyp {
+        0x01 => {
+            read_exact::<4>(&mut stream).await?;
+        }
+        0x03 => {
+            let [len] = read_exact(&mut stream).await?;
+            let mut name = vec![0u8; len as usize];
+            stream.read_exact(&mut name).await?;
+        }
+        0x04 => {
+            read_exact::<16>(&mut stream).await?;
+        }
+        _ => return Err(io::Error::new(io::ErrorKind::InvalidData, "bad atyp")),
+    }
+    read_exact::<2>(&mut stream).await?;
+    Ok(stream)
+}
+
+/// A TCP echo server; returns its port. Everything sent to it comes back.
+pub async fn echo_server() -> (u16, JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind echo server");
+    let port = listener.local_addr().expect("local addr").port();
+    let task = tokio::spawn(async move {
+        loop {
+            match listener.accept().await {
+                Ok((mut stream, _)) => {
+                    tokio::spawn(async move {
+                        let mut buf = [0u8; 4096];
+                        loop {
+                            match stream.read(&mut buf).await {
+                                Ok(0) | Err(_) => return,
+                                Ok(n) => {
+                                    if stream.write_all(&buf[..n]).await.is_err() {
+                                        return;
+                                    }
+                                }
+                            }
+                        }
+                    });
+                }
+                Err(_) => return,
+            }
+        }
+    });
+    (port, task)
+}

--- a/crates/nyanpasu-core-manager/tests/graceful_switch.rs
+++ b/crates/nyanpasu-core-manager/tests/graceful_switch.rs
@@ -3,7 +3,7 @@ mod common;
 use std::time::Duration;
 
 use nyanpasu_core_manager::{
-    ControllerMode, ControllerVersionProbe, CoreKind, CoreState, DegradeReason, Error, HealthProbe,
+    ControllerMode, ControllerVersionProbe, CoreState, DegradeReason, Error, HealthProbe,
     LocalIpcPolicy, ManagerOptions, ProbeHandle, ProbeResult, StopReason, manager::CoreManager,
 };
 
@@ -79,16 +79,17 @@ async fn managed_start_injects_the_epoch_endpoint_and_advertises_it() {
 async fn managed_spawn_error_removes_secret_derived_config() {
     let (_guard, dir) = common::utf8_tempdir();
     let derived_dir = dir.join("derived");
-    let config = common::write_config(&dir, "mixed-port: 0\nsecret: test-secret\n");
-    let manager = managed_manager(derived_dir.clone()).await;
-    let mut spec = common::mihomo_spec(&dir, config);
-    spec.core.kind = CoreKind::Meow;
-
-    let error = manager.start(spec).await.expect_err("spawn must fail");
-    assert!(
-        matches!(error, Error::UnsupportedCore(CoreKind::Meow)),
-        "got {error}"
+    let config = common::write_config(
+        &dir,
+        "mixed-port: 0\nsecret: test-secret\nx-fake-core:\n  check-fail: boom\n",
     );
+    let manager = managed_manager(derived_dir.clone()).await;
+
+    let error = manager
+        .start(common::mihomo_spec(&dir, config))
+        .await
+        .expect_err("config check must fail");
+    assert!(matches!(error, Error::ConfigCheckFailed(_)), "got {error}");
     assert!(matches!(
         manager.status().state,
         CoreState::Stopped {

--- a/crates/nyanpasu-core-manager/tests/real_cores.rs
+++ b/crates/nyanpasu-core-manager/tests/real_cores.rs
@@ -75,33 +75,54 @@ async fn start_bed(core: &RealCore, policy: LocalIpcPolicy) -> (TestBed, CoreMan
 /// Drives traffic through the core's inbound and asserts it comes back via
 /// the socks5 outbound node: client → core mixed-port → `out` proxy →
 /// socks5 server → echo target.
+///
+/// The whole exchange is retried, not just the connect: on a busy runner the
+/// core can accept the inbound connection before its outbound dial is ready
+/// and drop the client mid-stream.
 async fn assert_proxy_chain(bed: &TestBed) {
-    let payload = b"nyanpasu-probe";
+    let payload: &[u8; 14] = b"nyanpasu-probe";
     let before = bed.socks5.connection_count();
-    // The inbound listener can lag the readiness probe briefly; retry.
-    let mut stream = {
-        let mut attempt = tokio::time::interval(Duration::from_millis(100));
-        let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
-        loop {
-            attempt.tick().await;
-            match socks5::connect_via(bed.mixed_port, "127.0.0.1", bed.echo_port).await {
-                Ok(stream) => break stream,
-                Err(_) if tokio::time::Instant::now() < deadline => continue,
-                Err(error) => panic!("cannot connect through the core: {error}"),
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(20);
+    let mut last_error: Option<std::io::Error> = None;
+    while tokio::time::Instant::now() < deadline {
+        match tokio::time::timeout(
+            Duration::from_secs(5),
+            roundtrip(bed.mixed_port, bed.echo_port, payload),
+        )
+        .await
+        {
+            Ok(Ok(())) => {
+                assert!(
+                    bed.socks5.connection_count() > before,
+                    "traffic must flow through the socks5 outbound node"
+                );
+                return;
+            }
+            Ok(Err(error)) => last_error = Some(error),
+            Err(_) => {
+                last_error = Some(std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    "echo timed out",
+                ));
             }
         }
-    };
-    stream.write_all(payload).await.expect("write payload");
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    panic!("proxy chain never came up: {last_error:?}");
+}
+
+async fn roundtrip(mixed_port: u16, echo_port: u16, payload: &[u8; 14]) -> std::io::Result<()> {
+    let mut stream = socks5::connect_via(mixed_port, "127.0.0.1", echo_port).await?;
+    stream.write_all(payload).await?;
     let mut buf = [0u8; 14];
-    tokio::time::timeout(Duration::from_secs(5), stream.read_exact(&mut buf))
-        .await
-        .expect("echo timed out")
-        .expect("read echo");
-    assert_eq!(&buf, payload, "echo payload mismatch");
-    assert!(
-        bed.socks5.connection_count() > before,
-        "traffic must flow through the socks5 outbound node"
-    );
+    stream.read_exact(&mut buf).await?;
+    if &buf != payload {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "echo payload mismatch",
+        ));
+    }
+    Ok(())
 }
 
 fn assert_transport(host: &Host, expect_local: bool, context: &str) {

--- a/crates/nyanpasu-core-manager/tests/real_cores.rs
+++ b/crates/nyanpasu-core-manager/tests/real_cores.rs
@@ -1,0 +1,394 @@
+//! Integration tests against the four real cores (mihomo, clash-rs,
+//! clash premium, meow), covering start/stop, config updates, and the
+//! Force/Prefer/Disable local IPC policies.
+//!
+//! Prepare the binaries with `deno run -A scripts/prepare-cores.ts`, then run:
+//! `cargo test -p nyanpasu-core-manager --test real_cores -- --ignored --nocapture`.
+
+mod common;
+
+use std::time::Duration;
+
+use camino::Utf8PathBuf;
+use common::{
+    real::{self, RealCore},
+    socks5::{self, Socks5Server},
+};
+use nyanpasu_core_manager::{
+    ApplyOutcome, CoreState, Error, Host, LocalIpcPolicy, RevisionId, manager::CoreManager,
+};
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    task::JoinHandle,
+};
+
+/// Shared per-test fixture: a socks5 outbound server, an echo target behind
+/// it, and free ports for the core's inbound and HTTP controller.
+struct TestBed {
+    _guard: tempfile::TempDir,
+    dir: Utf8PathBuf,
+    socks5: Socks5Server,
+    echo_port: u16,
+    _echo: JoinHandle<()>,
+    mixed_port: u16,
+    ctrl_port: u16,
+}
+
+async fn bed() -> TestBed {
+    let (guard, dir) = common::utf8_tempdir();
+    let socks5 = Socks5Server::start().await;
+    let (echo_port, echo) = socks5::echo_server().await;
+    TestBed {
+        _guard: guard,
+        dir,
+        socks5,
+        echo_port,
+        _echo: echo,
+        mixed_port: common::free_port(),
+        ctrl_port: common::free_port(),
+    }
+}
+
+fn write_proxy_config(bed: &TestBed, extra: &str) -> Utf8PathBuf {
+    common::write_config(
+        &bed.dir,
+        &real::proxy_config(bed.mixed_port, bed.ctrl_port, bed.socks5.port(), extra),
+    )
+}
+
+async fn start_bed(core: &RealCore, policy: LocalIpcPolicy) -> (TestBed, CoreManager) {
+    let bed = bed().await;
+    let config = write_proxy_config(&bed, "");
+    let manager = real::managed_manager(&bed.dir, policy).await;
+    manager
+        .start(real::real_spec(core, &bed.dir, config))
+        .await
+        .unwrap_or_else(|error| panic!("{} failed to start: {error}", core.name));
+    assert!(
+        matches!(manager.status().state, CoreState::Running { .. }),
+        "{} should be running",
+        core.name
+    );
+    (bed, manager)
+}
+
+/// Drives traffic through the core's inbound and asserts it comes back via
+/// the socks5 outbound node: client → core mixed-port → `out` proxy →
+/// socks5 server → echo target.
+async fn assert_proxy_chain(bed: &TestBed) {
+    let payload = b"nyanpasu-probe";
+    let before = bed.socks5.connection_count();
+    // The inbound listener can lag the readiness probe briefly; retry.
+    let mut stream = {
+        let mut attempt = tokio::time::interval(Duration::from_millis(100));
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+        loop {
+            attempt.tick().await;
+            match socks5::connect_via(bed.mixed_port, "127.0.0.1", bed.echo_port).await {
+                Ok(stream) => break stream,
+                Err(_) if tokio::time::Instant::now() < deadline => continue,
+                Err(error) => panic!("cannot connect through the core: {error}"),
+            }
+        }
+    };
+    stream.write_all(payload).await.expect("write payload");
+    let mut buf = [0u8; 14];
+    tokio::time::timeout(Duration::from_secs(5), stream.read_exact(&mut buf))
+        .await
+        .expect("echo timed out")
+        .expect("read echo");
+    assert_eq!(&buf, payload, "echo payload mismatch");
+    assert!(
+        bed.socks5.connection_count() > before,
+        "traffic must flow through the socks5 outbound node"
+    );
+}
+
+fn assert_transport(host: &Host, expect_local: bool, context: &str) {
+    #[cfg(windows)]
+    let is_local = matches!(host, Host::NamedPipe(_));
+    #[cfg(not(windows))]
+    let is_local = matches!(host, Host::UnixSocket(_));
+    if expect_local {
+        assert!(is_local, "{context}: expected system IPC, got {host:?}");
+    } else {
+        assert!(
+            matches!(host, Host::Http(_)),
+            "{context}: expected HTTP, got {host:?}"
+        );
+    }
+}
+
+// === start / stop ===
+
+async fn start_stop(core: RealCore) {
+    let (bed, manager) = start_bed(&core, LocalIpcPolicy::Prefer).await;
+    let controller = manager.status().controller.expect("controller advertised");
+    assert_transport(&controller, core.system_ipc, core.name);
+    assert_proxy_chain(&bed).await;
+
+    manager.stop().await.expect("stop");
+    assert!(matches!(manager.status().state, CoreState::Stopped { .. }));
+    common::wait_port_refused(bed.mixed_port).await;
+}
+
+#[ignore = "requires the platform core binaries in tests/bin"]
+#[tokio::test]
+async fn mihomo_starts_proxies_and_stops() {
+    start_stop(real::MIHOMO).await;
+}
+
+#[ignore = "requires the platform core binaries in tests/bin"]
+#[tokio::test]
+async fn clash_rs_starts_proxies_and_stops() {
+    start_stop(real::CLASH_RS).await;
+}
+
+#[ignore = "requires the platform core binaries in tests/bin"]
+#[tokio::test]
+async fn clash_premium_starts_proxies_and_stops() {
+    start_stop(real::CLASH_PREMIUM).await;
+}
+
+#[ignore = "requires the platform core binaries in tests/bin"]
+#[tokio::test]
+async fn meow_starts_proxies_and_stops() {
+    start_stop(real::MEOW).await;
+}
+
+// === config update ===
+
+async fn config_update(core: RealCore) {
+    let (mut bed, manager) = start_bed(&core, LocalIpcPolicy::Prefer).await;
+    let spec = || real::real_spec(&core, &bed.dir, bed.dir.join("config.yaml"));
+    let mut extra = String::new();
+
+    // Noop: applying the unchanged config is a no-op.
+    let outcome = manager
+        .apply_config(spec(), None)
+        .await
+        .expect("noop apply");
+    assert!(
+        matches!(outcome, ApplyOutcome::Noop { .. }),
+        "unchanged config should be a noop, got {outcome:?}"
+    );
+
+    // CAS: a stale expected revision is rejected.
+    let bogus = RevisionId {
+        epoch: u64::MAX,
+        generation: u64::MAX,
+        effective_hash: "bogus".into(),
+    };
+    let error = manager
+        .apply_config(spec(), Some(bogus))
+        .await
+        .expect_err("stale revision must conflict");
+    assert!(
+        matches!(error, Error::RevisionConflict { .. }),
+        "got {error}"
+    );
+
+    // Scalar change (log-level). Mihomo patches it at runtime; the other
+    // kinds conservatively restart into a new epoch.
+    extra.push_str("log-level: debug\n");
+    write_proxy_config(&bed, &extra);
+    let outcome = manager
+        .apply_config(spec(), None)
+        .await
+        .expect("log-level apply");
+    match core.kind {
+        nyanpasu_core_manager::CoreKind::Mihomo => assert!(
+            matches!(outcome, ApplyOutcome::Patched { .. }),
+            "mihomo log-level change should patch in place, got {outcome:?}"
+        ),
+        _ => assert!(
+            matches!(outcome, ApplyOutcome::Restarted { .. }),
+            "{} log-level change should restart, got {outcome:?}",
+            core.name
+        ),
+    }
+    assert!(matches!(manager.status().state, CoreState::Running { .. }));
+    assert_proxy_chain(&bed).await;
+
+    // Collection change in the reload set (hosts). Only meaningful for
+    // mihomo, which can reload without a restart.
+    if matches!(core.kind, nyanpasu_core_manager::CoreKind::Mihomo) {
+        extra.push_str("hosts:\n  fixture.test: 198.18.0.1\n");
+        write_proxy_config(&bed, &extra);
+        let outcome = manager
+            .apply_config(spec(), None)
+            .await
+            .expect("hosts apply");
+        assert!(
+            matches!(outcome, ApplyOutcome::Reloaded { .. }),
+            "mihomo hosts change should reload, got {outcome:?}"
+        );
+        assert_proxy_chain(&bed).await;
+    }
+
+    // Inbound change (mixed-port). Mihomo re-binds the listener at runtime;
+    // the others restart. Either way the new port must serve and the old one
+    // must be gone.
+    let old_port = bed.mixed_port;
+    bed.mixed_port = common::free_port();
+    write_proxy_config(&bed, &extra);
+    let outcome = manager
+        .apply_config(spec(), None)
+        .await
+        .expect("mixed-port apply");
+    match core.kind {
+        nyanpasu_core_manager::CoreKind::Mihomo => assert!(
+            matches!(outcome, ApplyOutcome::Patched { .. }),
+            "mihomo mixed-port change should patch in place, got {outcome:?}"
+        ),
+        _ => assert!(
+            matches!(outcome, ApplyOutcome::Restarted { .. }),
+            "{} mixed-port change should restart, got {outcome:?}",
+            core.name
+        ),
+    }
+    assert_proxy_chain(&bed).await;
+    common::wait_port_refused(old_port).await;
+
+    manager.stop().await.expect("stop");
+}
+
+#[ignore = "requires the platform core binaries in tests/bin"]
+#[tokio::test]
+async fn mihomo_config_update() {
+    config_update(real::MIHOMO).await;
+}
+
+#[ignore = "requires the platform core binaries in tests/bin"]
+#[tokio::test]
+async fn clash_rs_config_update() {
+    config_update(real::CLASH_RS).await;
+}
+
+#[ignore = "requires the platform core binaries in tests/bin"]
+#[tokio::test]
+async fn clash_premium_config_update() {
+    config_update(real::CLASH_PREMIUM).await;
+}
+
+#[ignore = "requires the platform core binaries in tests/bin"]
+#[tokio::test]
+async fn meow_config_update() {
+    config_update(real::MEOW).await;
+}
+
+// === IPC modes ===
+
+/// Starts the core in the given IPC mode, asserts the resolved transport, and
+/// proves the control channel works over it with a config patch.
+async fn ipc_mode_start(core: RealCore, policy: LocalIpcPolicy, expect_local: bool) {
+    let (bed, manager) = start_bed(&core, policy).await;
+    let controller = manager.status().controller.expect("controller advertised");
+    assert_transport(&controller, expect_local, core.name);
+    assert_proxy_chain(&bed).await;
+
+    // The control channel must work over the negotiated transport.
+    write_proxy_config(&bed, "log-level: debug\n");
+    let outcome = manager
+        .apply_config(
+            real::real_spec(&core, &bed.dir, bed.dir.join("config.yaml")),
+            None,
+        )
+        .await
+        .expect("apply over the negotiated transport");
+    match core.kind {
+        nyanpasu_core_manager::CoreKind::Mihomo => assert!(
+            matches!(outcome, ApplyOutcome::Patched { .. }),
+            "got {outcome:?}"
+        ),
+        _ => assert!(
+            matches!(outcome, ApplyOutcome::Restarted { .. }),
+            "got {outcome:?}"
+        ),
+    }
+
+    manager.stop().await.expect("stop");
+}
+
+/// Force on an HTTP-only core must fail the start with `RequiredLocalIpcUnsupported`.
+async fn ipc_mode_force_rejected(core: RealCore) {
+    let bed = bed().await;
+    let config = write_proxy_config(&bed, "");
+    let manager = real::managed_manager(&bed.dir, LocalIpcPolicy::Force).await;
+    let error = manager
+        .start(real::real_spec(&core, &bed.dir, config))
+        .await
+        .expect_err("Force must reject HTTP-only cores");
+    assert!(
+        matches!(error, Error::RequiredLocalIpcUnsupported { .. }),
+        "{}: got {error}",
+        core.name
+    );
+}
+
+macro_rules! ipc_mode_tests {
+    ($force:ident, $prefer:ident, $http:ident, $core:expr) => {
+        #[ignore = "requires the platform core binaries in tests/bin"]
+        #[tokio::test]
+        async fn $force() {
+            ipc_mode_start($core, LocalIpcPolicy::Force, true).await;
+        }
+        #[ignore = "requires the platform core binaries in tests/bin"]
+        #[tokio::test]
+        async fn $prefer() {
+            ipc_mode_start($core, LocalIpcPolicy::Prefer, true).await;
+        }
+        #[ignore = "requires the platform core binaries in tests/bin"]
+        #[tokio::test]
+        async fn $http() {
+            ipc_mode_start($core, LocalIpcPolicy::Disable, false).await;
+        }
+    };
+}
+
+ipc_mode_tests!(
+    mihomo_ipc_force,
+    mihomo_ipc_prefer,
+    mihomo_ipc_use_http,
+    real::MIHOMO
+);
+ipc_mode_tests!(
+    clash_rs_ipc_force,
+    clash_rs_ipc_prefer,
+    clash_rs_ipc_use_http,
+    real::CLASH_RS
+);
+
+// HTTP-only cores: Force fails, Prefer falls back to HTTP, UseHttp is HTTP.
+macro_rules! ipc_mode_http_only_tests {
+    ($force:ident, $prefer:ident, $http:ident, $core:expr) => {
+        #[ignore = "requires the platform core binaries in tests/bin"]
+        #[tokio::test]
+        async fn $force() {
+            ipc_mode_force_rejected($core).await;
+        }
+        #[ignore = "requires the platform core binaries in tests/bin"]
+        #[tokio::test]
+        async fn $prefer() {
+            ipc_mode_start($core, LocalIpcPolicy::Prefer, false).await;
+        }
+        #[ignore = "requires the platform core binaries in tests/bin"]
+        #[tokio::test]
+        async fn $http() {
+            ipc_mode_start($core, LocalIpcPolicy::Disable, false).await;
+        }
+    };
+}
+
+ipc_mode_http_only_tests!(
+    clash_premium_ipc_force,
+    clash_premium_ipc_prefer,
+    clash_premium_ipc_use_http,
+    real::CLASH_PREMIUM
+);
+ipc_mode_http_only_tests!(
+    meow_ipc_force,
+    meow_ipc_prefer,
+    meow_ipc_use_http,
+    real::MEOW
+);

--- a/crates/nyanpasu-core-manager/tests/real_cores.rs
+++ b/crates/nyanpasu-core-manager/tests/real_cores.rs
@@ -122,6 +122,7 @@ fn assert_transport(host: &Host, expect_local: bool, context: &str) {
 // === start / stop ===
 
 async fn start_stop(core: RealCore) {
+    let _serial = real::serial_lock().await;
     let (bed, manager) = start_bed(&core, LocalIpcPolicy::Prefer).await;
     let controller = manager.status().controller.expect("controller advertised");
     assert_transport(&controller, core.system_ipc, core.name);
@@ -159,6 +160,7 @@ async fn meow_starts_proxies_and_stops() {
 // === config update ===
 
 async fn config_update(core: RealCore) {
+    let _serial = real::serial_lock().await;
     let (mut bed, manager) = start_bed(&core, LocalIpcPolicy::Prefer).await;
     let spec = || real::real_spec(&core, &bed.dir, bed.dir.join("config.yaml"));
     let mut extra = String::new();
@@ -282,6 +284,7 @@ async fn meow_config_update() {
 /// Starts the core in the given IPC mode, asserts the resolved transport, and
 /// proves the control channel works over it with a config patch.
 async fn ipc_mode_start(core: RealCore, policy: LocalIpcPolicy, expect_local: bool) {
+    let _serial = real::serial_lock().await;
     let (bed, manager) = start_bed(&core, policy).await;
     let controller = manager.status().controller.expect("controller advertised");
     assert_transport(&controller, expect_local, core.name);
@@ -312,6 +315,7 @@ async fn ipc_mode_start(core: RealCore, policy: LocalIpcPolicy, expect_local: bo
 
 /// Force on an HTTP-only core must fail the start with `RequiredLocalIpcUnsupported`.
 async fn ipc_mode_force_rejected(core: RealCore) {
+    let _serial = real::serial_lock().await;
     let bed = bed().await;
     let config = write_proxy_config(&bed, "");
     let manager = real::managed_manager(&bed.dir, LocalIpcPolicy::Force).await;

--- a/docs/superpowers/specs/2026-07-18-nyanpasu-core-manager-design.md
+++ b/docs/superpowers/specs/2026-07-18-nyanpasu-core-manager-design.md
@@ -30,7 +30,7 @@
 | 内核建模 | kind 与元数据分离(alpha 变体降为 binary/metadata 差异);service 边界做旧 IPC `CoreType` 映射,wire 不变 |
 | 并发模型 | 混合:控制面 async Mutex 串行 + 每 Instance 一个监视 task + watch 发布 |
 | 无 controller 配置 | `start` 严格报错(不降级为存活即成功) |
-| Meow | 保留 kind 声明位,launch profile 未定义前 spawn 返回 `UnsupportedCore` |
+| Meow | 与 Mihomo 共用 launch profile(`-m -d -f`,meow 兼容 mihomo CLI) |
 
 ## 2. 目标与非目标
 
@@ -91,7 +91,7 @@ pub enum CoreKind { Mihomo, ClashPremium, ClashRs, Meow }
   - `Mihomo`:`-m -d <working_dir> -f <config>`
   - `ClashRs`:`-d <working_dir> -c <config>`
   - `ClashPremium`:`-d <working_dir> -f <config>`
-  - `Meow`:未定义,spawn 返回 `Error::UnsupportedCore`(保留声明位)
+  - `Meow`:与 `Mihomo` 相同(meow 兼容 mihomo CLI)
 - alpha 变体不是独立 kind:`kind = Mihomo` + 不同 `binary_path` + `CoreSpec.version/features` 元数据。
 - `check_config`:迁移旧 `CoreInstance::check_config_`,用 `process::Command::output()` 一次性执行(`mihomo -t` 等),mihomo 系错误输出经 `parse_check_output` 提炼。
 

--- a/scripts/prepare-cores.ts
+++ b/scripts/prepare-cores.ts
@@ -115,7 +115,7 @@ const args = parseArgs(Deno.args, {
 
 for (const core of CORES) {
   const override = args[`${core.name}-version`];
-  if (override) core.version = override;
+  if (typeof override === "string") core.version = override;
 }
 
 const selected = args.only
@@ -229,13 +229,13 @@ async function extractTarGz(
   // meow tarballs ship a single `meow` binary, possibly inside a directory.
   for (const entry of Deno.readDirSync(destDir)) {
     const full = path.join(destDir, entry.name);
-    if (entry.isFile() && entry.name.startsWith("meow")) {
+    if (entry.isFile && entry.name.startsWith("meow")) {
       await Deno.rename(full, targetPath);
       return;
     }
     if (entry.isDirectory) {
       for (const nested of Deno.readDirSync(full)) {
-        if (nested.isFile() && nested.name.startsWith("meow")) {
+        if (nested.isFile && nested.name.startsWith("meow")) {
           await Deno.rename(path.join(full, nested.name), targetPath);
           return;
         }

--- a/scripts/prepare-cores.ts
+++ b/scripts/prepare-cores.ts
@@ -1,0 +1,342 @@
+#!/usr/bin/env -S deno run -A
+/**
+ * Download the four cores used by integration tests into `tests/bin/`:
+ * mihomo, clash-rs, clash premium, meow.
+ *
+ * Usage:
+ *   deno run -A scripts/prepare-cores.ts [--force] [--only mihomo,clash-rs]
+ *     [--mihomo-version v1.19.29] [--clash-rs-version v0.10.8]
+ *     [--clash-version 2023-09-05-gdcc8d87] [--meow-version v0.18.0]
+ *
+ * Versions and asset templates are kept in sync with clash-nyanpasu's
+ * manifest/version.json and scripts/check.ts.
+ */
+import { parseArgs } from "jsr:@std/cli@1/parse-args";
+import { ensureDir, exists } from "jsr:@std/fs";
+import * as path from "jsr:@std/path";
+// @ts-types="npm:@types/adm-zip"
+import AdmZip from "npm:adm-zip";
+
+const WORKSPACE_ROOT = path.join(import.meta.dirname!, "..");
+const BIN_DIR = path.join(WORKSPACE_ROOT, "tests", "bin");
+
+const IS_WIN = Deno.build.os === "windows";
+const EXE_SUFFIX = IS_WIN ? ".exe" : "";
+
+type ArchiveKind = "zip" | "gz" | "tar.gz" | "raw";
+
+interface CoreDef {
+  /** Target file name in tests/bin (without .exe suffix). */
+  name: string;
+  version: string;
+  /** Download URL with the asset name as `{}`. */
+  urlTemplate: string;
+  /** Asset name template per `os-arch`, `{}` is the version. */
+  archTemplate: Record<string, string>;
+  archive: ArchiveKind;
+}
+
+// Same templates as clash-nyanpasu's manifest/version.json (arch_template.*)
+const CORES: CoreDef[] = [
+  {
+    name: "mihomo",
+    version: "v1.19.29",
+    urlTemplate:
+      "https://github.com/MetaCubeX/mihomo/releases/download/{ver}/{}",
+    archTemplate: {
+      "windows-x86_64": "mihomo-windows-amd64-v2-{}.zip",
+      "windows-aarch64": "mihomo-windows-arm64-{}.zip",
+      "linux-aarch64": "mihomo-linux-arm64-{}.gz",
+      "linux-x86_64": "mihomo-linux-amd64-v2-{}.gz",
+      "darwin-aarch64": "mihomo-darwin-arm64-{}.gz",
+      "darwin-x86_64": "mihomo-darwin-amd64-v2-{}.gz",
+    },
+    archive: IS_WIN ? "zip" : "gz",
+  },
+  {
+    name: "clash-rs",
+    version: "v0.10.8",
+    urlTemplate:
+      "https://github.com/Watfaq/clash-rs/releases/download/{ver}/{}",
+    archTemplate: {
+      "windows-x86_64": "clash-rs-x86_64-pc-windows-msvc.exe",
+      "windows-aarch64": "clash-rs-aarch64-pc-windows-msvc.exe",
+      "linux-aarch64": "clash-rs-aarch64-unknown-linux-gnu",
+      "linux-x86_64": "clash-rs-x86_64-unknown-linux-gnu-static-crt",
+      "darwin-aarch64": "clash-rs-aarch64-apple-darwin",
+      "darwin-x86_64": "clash-rs-x86_64-apple-darwin",
+    },
+    archive: "raw",
+  },
+  {
+    // Dreamacro's premium release was taken down; use the community backup,
+    // same as clash-nyanpasu's check.ts (getClashBackupInfo).
+    name: "clash",
+    version: "2023-09-05-gdcc8d87",
+    urlTemplate:
+      "https://github.com/zhongfly/Clash-premium-backup/releases/download/{ver}/{}",
+    archTemplate: {
+      "windows-x86_64": "clash-windows-amd64-n{}.zip",
+      "windows-aarch64": "clash-windows-arm64-n{}.zip",
+      "linux-aarch64": "clash-linux-arm64-n{}.gz",
+      "linux-x86_64": "clash-linux-amd64-n{}.gz",
+      "darwin-aarch64": "clash-darwin-arm64-n{}.gz",
+      "darwin-x86_64": "clash-darwin-amd64-n{}.gz",
+    },
+    archive: IS_WIN ? "zip" : "gz",
+  },
+  {
+    name: "meow",
+    version: "v0.18.0",
+    urlTemplate:
+      "https://github.com/madeye/meow-rs/releases/download/{ver}/{}",
+    archTemplate: {
+      "windows-x86_64": "meow-{}-x86_64-pc-windows-msvc.zip",
+      "windows-aarch64": "meow-{}-aarch64-pc-windows-msvc.zip",
+      "linux-aarch64": "meow-{}-aarch64-unknown-linux-musl.tar.gz",
+      "linux-x86_64": "meow-{}-x86_64-unknown-linux-musl.tar.gz",
+      "darwin-aarch64": "meow-{}-aarch64-apple-darwin.tar.gz",
+      "darwin-x86_64": "meow-{}-x86_64-apple-darwin.tar.gz",
+    },
+    archive: IS_WIN ? "zip" : "tar.gz",
+  },
+];
+
+const args = parseArgs(Deno.args, {
+  boolean: ["force"],
+  string: [
+    "only",
+    "mihomo-version",
+    "clash-rs-version",
+    "clash-version",
+    "meow-version",
+  ],
+});
+
+for (const core of CORES) {
+  const override = args[`${core.name}-version`];
+  if (override) core.version = override;
+}
+
+const selected = args.only
+  ? CORES.filter((core) => args.only!.split(",").includes(core.name))
+  : CORES;
+if (selected.length === 0) {
+  console.error(
+    `no cores selected; valid names: ${CORES.map((c) => c.name).join(", ")}`,
+  );
+  Deno.exit(1);
+}
+
+function formatSize(size: number): string {
+  const units = ["B", "KB", "MB", "GB"];
+  let value = size;
+  let unitIndex = 0;
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex++;
+  }
+  return `${value.toFixed(unitIndex === 0 ? 0 : 1)} ${units[unitIndex]}`;
+}
+
+async function writeAll(file: Deno.FsFile, bytes: Uint8Array): Promise<void> {
+  let written = 0;
+  while (written < bytes.byteLength) {
+    written += await file.write(bytes.subarray(written));
+  }
+}
+
+async function downloadFile(url: string, filePath: string): Promise<number> {
+  const response = await fetch(url, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/octet-stream",
+      "User-Agent":
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:131.0) Gecko/20100101 Firefox/131.0",
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `download failed: ${response.statusText} (${response.status})`,
+    );
+  }
+  if (!response.body) throw new Error("download failed: empty response body");
+
+  const totalHeader = response.headers.get("content-length");
+  const total = totalHeader ? Number.parseInt(totalHeader, 10) : undefined;
+  const isTTY = Deno.stdout.isTerminal();
+  let downloaded = 0;
+  let lastLogAt = 0;
+
+  const file = await Deno.open(filePath, {
+    create: true,
+    truncate: true,
+    write: true,
+  });
+
+  try {
+    const reader = response.body.getReader();
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      await writeAll(file, value);
+      downloaded += value.byteLength;
+
+      const now = performance.now();
+      if (isTTY && now - lastLogAt >= 200) {
+        lastLogAt = now;
+        const progress = total
+          ? `${formatSize(downloaded)}/${formatSize(total)}`
+          : formatSize(downloaded);
+        await Deno.stdout.write(new TextEncoder().encode(`\r  ${progress}`));
+      }
+    }
+  } finally {
+    file.close();
+  }
+
+  if (isTTY) await Deno.stdout.write(new TextEncoder().encode("\n"));
+  return downloaded;
+}
+
+function extractZip(zipPath: string, targetPath: string): void {
+  const zip = new AdmZip(zipPath);
+  const entries = zip.getEntries();
+  const entry = entries.find((entry) =>
+    IS_WIN ? entry.entryName.endsWith(".exe") : !entry.isDirectory
+  );
+  if (!entry) throw new Error("cannot find binary in zip");
+  Deno.writeFileSync(targetPath, entry.getData());
+}
+
+async function extractTarGz(
+  tarPath: string,
+  destDir: string,
+  targetPath: string,
+): Promise<void> {
+  const { code, stderr } = await new Deno.Command("tar", {
+    args: ["-xzf", tarPath, "-C", destDir],
+    stdout: "piped",
+    stderr: "piped",
+  }).output();
+  if (code !== 0) {
+    throw new Error(
+      `tar extraction failed: ${new TextDecoder().decode(stderr)}`,
+    );
+  }
+  // meow tarballs ship a single `meow` binary, possibly inside a directory.
+  for (const entry of Deno.readDirSync(destDir)) {
+    const full = path.join(destDir, entry.name);
+    if (entry.isFile() && entry.name.startsWith("meow")) {
+      await Deno.rename(full, targetPath);
+      return;
+    }
+    if (entry.isDirectory) {
+      for (const nested of Deno.readDirSync(full)) {
+        if (nested.isFile() && nested.name.startsWith("meow")) {
+          await Deno.rename(path.join(full, nested.name), targetPath);
+          return;
+        }
+      }
+    }
+  }
+  throw new Error("cannot find meow binary in tarball");
+}
+
+async function gunzipFile(
+  inputPath: string,
+  outputPath: string,
+): Promise<void> {
+  const input = await Deno.open(inputPath, { read: true });
+  const output = await Deno.open(outputPath, { write: true, create: true });
+  await input.readable
+    .pipeThrough(new DecompressionStream("gzip"))
+    .pipeTo(output.writable);
+}
+
+async function sanityCheck(targetPath: string, name: string): Promise<void> {
+  // `-v` works for mihomo/clash; clash-rs/meow may only know `--version`.
+  for (const flag of ["-v", "--version"]) {
+    const { code, stdout, stderr } = await new Deno.Command(targetPath, {
+      args: [flag],
+      stdout: "piped",
+      stderr: "piped",
+    }).output();
+    if (code === 0) {
+      const out = new TextDecoder().decode(stdout).trim() ||
+        new TextDecoder().decode(stderr).trim();
+      console.log(`${name} ready: ${out.split("\n")[0]}`);
+      console.log(`  -> ${targetPath}`);
+      return;
+    }
+  }
+  console.error(`sanity check failed: \`${name} -v/--version\` failed`);
+  Deno.exit(1);
+}
+
+// === Main ===
+
+const platformKey = `${Deno.build.os}-${Deno.build.arch}`;
+
+await ensureDir(BIN_DIR);
+
+for (const core of selected) {
+  const targetFile = `${core.name}${EXE_SUFFIX}`;
+  const targetPath = path.join(BIN_DIR, targetFile);
+
+  if (!args.force && (await exists(targetPath))) {
+    console.log(`${targetFile} already exists, skip (use --force)`);
+    continue;
+  }
+
+  const template = core.archTemplate[platformKey];
+  if (!template) {
+    console.error(`unsupported platform for ${core.name}: ${platformKey}`);
+    Deno.exit(1);
+  }
+
+  const assetName = template.replace("{}", core.version);
+  const downloadURL = core.urlTemplate
+    .replace("{ver}", core.version)
+    .replace("{}", assetName);
+  const tmpFile = path.join(BIN_DIR, assetName);
+  const tmpDir = path.join(BIN_DIR, `.tmp-${core.name}`);
+
+  try {
+    console.log(`downloading ${downloadURL}`);
+    const size = await downloadFile(downloadURL, tmpFile);
+    console.log(`downloaded ${assetName} (${formatSize(size)})`);
+
+    switch (core.archive) {
+      case "zip":
+        extractZip(tmpFile, targetPath);
+        break;
+      case "gz":
+        await gunzipFile(tmpFile, targetPath);
+        break;
+      case "tar.gz":
+        await ensureDir(tmpDir);
+        await extractTarGz(tmpFile, tmpDir, targetPath);
+        break;
+      case "raw":
+        await Deno.rename(tmpFile, targetPath);
+        break;
+    }
+
+    if (!IS_WIN) {
+      await Deno.chmod(targetPath, 0o755);
+    }
+  } catch (err) {
+    await Deno.remove(targetPath).catch(() => {});
+    throw err;
+  } finally {
+    await Deno.remove(tmpFile).catch(() => {});
+    await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
+  }
+
+  await sanityCheck(targetPath, core.name);
+}
+
+console.log("all cores ready");

--- a/scripts/prepare-cores.ts
+++ b/scripts/prepare-cores.ts
@@ -321,7 +321,8 @@ for (const core of selected) {
         await extractTarGz(tmpFile, tmpDir, targetPath);
         break;
       case "raw":
-        await Deno.rename(tmpFile, targetPath);
+        // copyFile overwrites an existing target; rename cannot on Windows.
+        await Deno.copyFile(tmpFile, targetPath);
         break;
     }
 


### PR DESCRIPTION
## Summary

Integration-test the core manager against the four real cores (mihomo, clash-rs, clash premium, meow), and fix the real-core issues uncovered along the way.

- `fix(clash-api)`: clash premium's `GET /version` has no `meta` field, so the controller version probe never passed — `meta` now defaults to `false`
- `feat(core-manager)`:
  - meow gets the mihomo launch profile (`-m -d -f`); meow accepts the mihomo CLI including `-t`, so `Error::UnsupportedCore` is gone
  - clash-rs IPC endpoints are passed as `--controller-ipc`: clash-bin unconditionally overwrites the config's `external_controller_ipc` with its CLI flag, so the YAML key never takes effect and a managed named pipe would never come up
  - `classify()` reports `Noop` for identical configs on every kind instead of restarting non-mihomo cores
- `test(core-manager)`: `tests/real_cores.rs` (ignored by default) covers all four cores — start/stop with real traffic through a test SOCKS5 outbound, config updates (noop / CAS conflict / patch / reload / restart per kind), and the `Force`/`Prefer`/`Disable` local IPC policies, asserting the negotiated controller transport
- `chore(scripts)`: `scripts/prepare-cores.ts` downloads the four cores into `tests/bin` (versions mirror clash-nyanpasu's manifest)
- docs updated accordingly

## Test plan

- [x] `cargo test -p nyanpasu-core-manager` (fake-core suite incl. capabilities) — all green
- [x] `deno run -A scripts/prepare-cores.ts && cargo test -p nyanpasu-core-manager --test real_cores -- --ignored` — 20/20 on Windows (mihomo/clash-rs over named pipe Force/Prefer + HTTP Disable; premium/meow Force rejected, Prefer falls back to HTTP)
- [x] `cargo clippy -p nyanpasu-core-manager -p clash-api --all-targets` — no warnings

Unix coverage (unix socket instead of named pipe) is compile-gated but only exercised on Windows so far; a CI run would be a good follow-up.
