### PR TITLE
feat(core-manager): normalize core console output into LogFrame

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1952,6 +1952,7 @@ name = "nyanpasu-core-manager"
 version = "0.1.1"
 dependencies = [
  "camino",
+ "chrono",
  "clash-api",
  "enumset",
  "nyanpasu-core-manager",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,7 +62,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0a8acea8c2f1c60f0a92a8cd26bf96ca97db56f10bbcab238bbe0cceba659ee"
 dependencies = [
- "nom",
+ "nom 7.1.3",
  "vte",
 ]
 
@@ -118,25 +118,25 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "async-trait"
-version = "0.1.89"
+version = "0.1.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -169,9 +169,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.1"
+version = "1.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
+checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -179,9 +179,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.42.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
+checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
 dependencies = [
  "cc",
  "cmake",
@@ -198,7 +198,7 @@ checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
  "axum-macros",
- "base64 0.22.1",
+ "base64",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -276,7 +276,7 @@ checksum = "7aa268c23bfbbd2c4363b9cd302a4f504fb2a9dfe7e3451d66f35dd392e20aca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -307,12 +307,6 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
-
-[[package]]
-name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -336,15 +330,15 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex 1.3.0",
- "syn",
+ "syn 2.0.119",
  "which",
 ]
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "block-buffer"
@@ -384,24 +378,24 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "camino"
-version = "1.2.4"
+version = "1.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f2d30e4173c4026932d51d31d6b0613b1fd3014bf3f9f8943d4ba139c437ba0"
+checksum = "bb1307f12aa967b5a58416e87b3653360e0fd614a016b6e970db08fecbb1b80d"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "cc"
-version = "1.2.65"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -415,7 +409,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -426,9 +420,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
@@ -477,9 +471,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.2"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd059f9da4f5c36b3787f65d38ccaab1cc315f07b01f89abc8359ee6a8205011"
+checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -499,14 +493,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -533,7 +527,7 @@ dependencies = [
  "serde",
  "serde_json",
  "specta",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-util",
  "url",
@@ -686,18 +680,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.15"
+version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crypto-common"
@@ -751,7 +745,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -764,7 +758,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -775,7 +769,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -786,7 +780,7 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -833,7 +827,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -843,7 +837,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -911,13 +905,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -940,9 +934,9 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "encoding-utils"
@@ -983,7 +977,7 @@ dependencies = [
  "darling 0.21.3",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1026,9 +1020,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "find-msvc-tools"
@@ -1090,53 +1084,53 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-core",
  "futures-io",
@@ -1205,9 +1199,9 @@ checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "glob"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "gloo-timers"
@@ -1275,14 +1269,14 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hdrhistogram"
-version = "7.5.4"
+version = "7.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d"
+checksum = "f49d1053f4708f0af3cf9fc5bffc7e68a914a3c45becb231c80068c9c3f78bea"
 dependencies = [
- "base64 0.21.7",
+ "base64",
  "byteorder",
  "flate2",
- "nom",
+ "nom 8.0.0",
  "num-traits",
 ]
 
@@ -1292,7 +1286,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "headers-core",
  "http",
@@ -1337,9 +1331,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
  "http",
@@ -1372,15 +1366,15 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "humantime"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+checksum = "15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15"
 
 [[package]]
 name = "hyper"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1432,7 +1426,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -1677,7 +1671,7 @@ dependencies = [
  "jni-sys",
  "log",
  "simd_cesu8",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "walkdir",
  "windows-link",
 ]
@@ -1692,7 +1686,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1711,7 +1705,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1762,9 +1756,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libloading"
@@ -1778,9 +1772,9 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
+checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
 dependencies = [
  "libc",
 ]
@@ -1841,9 +1835,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "mime"
@@ -1869,9 +1863,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
@@ -1909,6 +1903,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1960,7 +1963,7 @@ dependencies = [
  "serde_yaml_ng",
  "specta",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-util",
  "tracing",
@@ -1995,7 +1998,7 @@ dependencies = [
  "serde",
  "serde_json",
  "specta",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tower",
  "tracing",
@@ -2036,7 +2039,7 @@ dependencies = [
  "simd-json",
  "supports-color",
  "sysinfo",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "timeago",
  "tokio",
  "tokio-util",
@@ -2076,7 +2079,7 @@ dependencies = [
  "sysinfo",
  "tempfile",
  "test-log",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-util",
  "tracing",
@@ -2275,7 +2278,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2292,11 +2295,11 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plist"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
+checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "indexmap",
  "quick-xml",
  "serde",
@@ -2334,14 +2337,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -2354,7 +2357,7 @@ dependencies = [
  "async-trait",
  "encoding_rs",
  "libc",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -2382,7 +2385,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2396,9 +2399,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.39.4"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
@@ -2417,7 +2420,7 @@ dependencies = [
  "rustc-hash 2.1.3",
  "rustls",
  "socket2",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "web-time",
@@ -2440,7 +2443,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tinyvec",
  "tracing",
  "web-time",
@@ -2462,9 +2465,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -2483,9 +2486,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.5",
@@ -2570,34 +2573,34 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
 name = "ref-cast"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2607,9 +2610,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2628,7 +2631,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -2676,7 +2679,7 @@ dependencies = [
  "bytes",
  "futures-util",
  "reqwest",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-util",
  "tracing",
@@ -2700,9 +2703,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
 
 [[package]]
 name = "rustc-hash"
@@ -2779,9 +2782,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "web-time",
  "zeroize",
@@ -2828,9 +2831,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "ryu"
@@ -2858,9 +2861,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -2871,14 +2874,14 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+checksum = "d98c67716b46af2f0b8cf752abc930f6f9aecfbf671ecfb531db8a31dbe4e2ba"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2922,9 +2925,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -2932,40 +2935,40 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "serde_derive_internals"
-version = "0.29.1"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -3028,9 +3031,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
@@ -3102,9 +3105,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "simd-json"
@@ -3156,9 +3159,9 @@ checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -3187,7 +3190,7 @@ dependencies = [
  "Inflector",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3225,9 +3228,20 @@ checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3251,7 +3265,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3322,7 +3336,7 @@ checksum = "c26ef8b00e4d382e59f6a8ddb3cd790b3a5bb29f21a358a9a69ea2f29f13f27b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3331,7 +3345,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "944ad38adcbb71eaa682c56bceeb079e4ca82b4b3edc2a0fde5cb297b77dac8d"
 dependencies = [
- "syn",
+ "syn 2.0.119",
  "test-log-core",
 ]
 
@@ -3346,11 +3360,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
- "thiserror-impl 2.0.18",
+ "thiserror-impl 2.0.19",
 ]
 
 [[package]]
@@ -3361,34 +3375,34 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.51"
+version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85c17d80feb7334b40c484e45ed1a5273dfd8bfda537c3be2e74a06a6686f327"
+checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
 dependencies = [
  "deranged",
  "num-conv",
@@ -3406,9 +3420,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.30"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcef1a61bdb119096e153208ec5cbec23944ce8bca13be5c7f60c634f7403935"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -3451,9 +3465,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -3469,13 +3483,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3490,9 +3504,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -3513,15 +3527,16 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-io",
  "futures-sink",
  "futures-util",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]
@@ -3534,7 +3549,7 @@ checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
  "async-trait",
  "axum",
- "base64 0.22.1",
+ "base64",
  "bytes",
  "h2",
  "http",
@@ -3653,7 +3668,7 @@ dependencies = [
  "crossbeam-channel",
  "parking_lot",
  "symlink",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "time",
  "tracing-subscriber",
 ]
@@ -3666,7 +3681,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3749,9 +3764,9 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.9.4",
+ "rand 0.9.5",
  "sha1",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "utf-8",
 ]
 
@@ -3766,9 +3781,9 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.9.4",
+ "rand 0.9.5",
  "sha1",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -3964,7 +3979,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
@@ -4012,9 +4027,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -4172,7 +4187,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4183,7 +4198,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4510,28 +4525,28 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.52"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.52"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4551,7 +4566,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -4591,11 +4606,11 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/crates/nyanpasu-core-manager/Cargo.toml
+++ b/crates/nyanpasu-core-manager/Cargo.toml
@@ -21,6 +21,7 @@ path = "tests/helpers/manager_host.rs"
 
 [dependencies]
 camino = { version = "1.1", features = ["serde1"] }
+chrono.workspace = true
 clash-api = { path = "../clash-api" }
 enumset = "1"
 nyanpasu-core-metadata = { path = "../nyanpasu-core-metadata" }

--- a/crates/nyanpasu-core-manager/src/error.rs
+++ b/crates/nyanpasu-core-manager/src/error.rs
@@ -55,9 +55,11 @@ pub enum Error {
         source: Box<Error>,
         warning: String,
     },
-    #[error("core did not become healthy before the startup timeout; stderr tail:\n{stderr_tail}")]
+    #[error(
+        "core did not become healthy before the startup timeout; diagnostic log tail:\n{stderr_tail}"
+    )]
     StartupTimeout { stderr_tail: String },
-    #[error("core failed to start; stderr tail:\n{stderr_tail}")]
+    #[error("core failed to start; diagnostic log tail:\n{stderr_tail}")]
     StartupFailed { stderr_tail: String },
     #[error(transparent)]
     Process(#[from] nyanpasu_utils::process::ProcessError),

--- a/crates/nyanpasu-core-manager/src/instance.rs
+++ b/crates/nyanpasu-core-manager/src/instance.rs
@@ -13,7 +13,7 @@ use nyanpasu_utils::process::{
     Supervisor, SupervisorEvent, TerminatedPayload, reap_epoch_pid_file,
 };
 use tokio::{
-    sync::{mpsc, oneshot, watch},
+    sync::{broadcast, mpsc, oneshot, watch},
     time::Instant,
 };
 use tokio_util::sync::CancellationToken;
@@ -24,13 +24,17 @@ use crate::{
         HealthTracker, TrackerState,
         driver::{ProbeDriver, ProbeObservation},
     },
-    kind::{self, MIHOMO_SAFE_PATHS_ENV_NAME},
+    kind::{self, CLICOLOR_FORCE_ENV_NAME, MIHOMO_SAFE_PATHS_ENV_NAME},
+    log::{
+        LOG_CHANNEL_CAPACITY, LogFrame, LogLevel, LogParser, LogStream, ParsedFrames,
+        error_summary, format_tail,
+    },
     probe::{ControllerVersionProbe, ProbeHandle, ProbePhase, ProbeResult},
     spec::{InstanceOptions, InstanceSpec, ResolvedController},
     state::{HealthState, HealthStatus, InstanceState, InstanceStatus, StopReason, now_ms},
 };
 
-const STDERR_TAIL_LINES: usize = 32;
+const LOG_TAIL_FRAMES: usize = 32;
 
 /// One epoch of a running core. The spec is immutable; a config change means a
 /// new `Instance` with a new epoch (created by `CoreManager`).
@@ -46,7 +50,9 @@ struct Shared {
     state_tx: watch::Sender<InstanceStatus>,
     user_stop: AtomicBool,
     probe_timeout: AtomicBool,
-    stderr_tail: parking_lot::Mutex<VecDeque<String>>,
+    parser: parking_lot::Mutex<LogParser>,
+    log_tail: parking_lot::Mutex<VecDeque<LogFrame>>,
+    log_tx: broadcast::Sender<LogFrame>,
     cancel: CancellationToken,
     probe_cancel: CancellationToken,
     probe_request_tx: mpsc::UnboundedSender<ProbeNowRequest>,
@@ -68,9 +74,56 @@ impl Shared {
         let _ = self.state_tx.send(status);
     }
 
-    fn tail(&self) -> String {
-        let buf = self.stderr_tail.lock();
-        buf.iter().cloned().collect::<Vec<_>>().join("\n")
+    /// The parser lock is released before logging, buffering and broadcasting:
+    /// this runs inline on the supervision loop.
+    fn parse(&self, stream: LogStream, line: String) -> ParsedFrames {
+        self.parser.lock().push(stream, line)
+    }
+
+    fn finish_log_record(&self) -> ParsedFrames {
+        self.parser.lock().finish()
+    }
+
+    fn publish_log_frame(&self, frame: LogFrame) {
+        let record = frame.raw.as_str();
+        match frame.level {
+            LogLevel::Trace => tracing::trace!(target: "core", "{record}"),
+            LogLevel::Debug => tracing::debug!(target: "core", "{record}"),
+            LogLevel::Info => tracing::info!(target: "core", "{record}"),
+            LogLevel::Warning => tracing::warn!(target: "core", "{record}"),
+            LogLevel::Error | LogLevel::Fatal => tracing::error!(target: "core", "{record}"),
+        }
+        let mut tail = self.log_tail.lock();
+        if tail.len() == LOG_TAIL_FRAMES {
+            tail.pop_front();
+        }
+        tail.push_back(frame.clone());
+        drop(tail);
+        let _ = self.log_tx.send(frame);
+    }
+
+    /// `Terminated` is best-effort, so every terminal path releases the pending
+    /// record itself: a fatal block that never saw its terminating event still
+    /// reaches the tail and the subscribers.
+    fn flush_log_record(&self) {
+        for frame in self.finish_log_record().into_iter().flatten() {
+            self.publish_log_frame(frame);
+        }
+    }
+
+    fn diagnostic_frames(&self) -> Vec<LogFrame> {
+        self.flush_log_record();
+        self.log_tail.lock().iter().cloned().collect()
+    }
+
+    fn diagnostics(&self) -> String {
+        format_tail(&self.diagnostic_frames())
+    }
+
+    /// The lifecycle text already carries the raw tail, so it stands in when the
+    /// core logged nothing above `Info`.
+    fn failure_summary(&self, lifecycle: &str) -> String {
+        error_summary(&self.diagnostic_frames()).unwrap_or_else(|| lifecycle.to_owned())
     }
 }
 
@@ -86,6 +139,7 @@ pub struct InstanceBuilder {
     readiness_probe: Option<ProbeHandle>,
     liveness_probe: Option<ProbeHandle>,
     liveness_with_readiness: bool,
+    log_tx: Option<broadcast::Sender<LogFrame>>,
 }
 
 impl Instance {
@@ -103,6 +157,7 @@ impl Instance {
             readiness_probe: None,
             liveness_probe: None,
             liveness_with_readiness: false,
+            log_tx: None,
         }
     }
 
@@ -124,6 +179,7 @@ impl Instance {
             readiness_probe,
             liveness_probe,
             liveness_with_readiness,
+            log_tx,
         } = builder;
         if tokio::fs::metadata(&spec.config_path).await.is_err() {
             return Err(Error::ConfigNotFound(spec.config_path.clone()));
@@ -156,7 +212,9 @@ impl Instance {
             state_tx,
             user_stop: AtomicBool::new(false),
             probe_timeout: AtomicBool::new(false),
-            stderr_tail: parking_lot::Mutex::new(VecDeque::with_capacity(STDERR_TAIL_LINES)),
+            parser: parking_lot::Mutex::new(LogParser::new(spec.core.kind, epoch)),
+            log_tail: parking_lot::Mutex::new(VecDeque::with_capacity(LOG_TAIL_FRAMES)),
+            log_tx: log_tx.unwrap_or_else(|| broadcast::channel(LOG_CHANNEL_CAPACITY).0),
             cancel: cancel.clone(),
             probe_cancel,
             probe_request_tx,
@@ -179,20 +237,20 @@ impl Instance {
         })
         .on_process_event({
             let shared = shared.clone();
-            move |event| match event {
-                ProcessEvent::Stdout(line) => tracing::info!(target: "core", "{line}"),
-                ProcessEvent::Stderr(line) => {
-                    tracing::warn!(target: "core", "{line}");
-                    let mut tail = shared.stderr_tail.lock();
-                    if tail.len() == STDERR_TAIL_LINES {
-                        tail.pop_front();
+            move |event| {
+                let frames = match event {
+                    ProcessEvent::Stdout(line) => shared.parse(LogStream::Stdout, line),
+                    ProcessEvent::Stderr(line) => shared.parse(LogStream::Stderr, line),
+                    ProcessEvent::Terminated(_) => shared.finish_log_record(),
+                    ProcessEvent::Error(error) => {
+                        tracing::warn!(target: "core", "output pump: {error}");
+                        [None, None]
                     }
-                    tail.push_back(line);
+                    _ => [None, None],
+                };
+                for frame in frames.into_iter().flatten() {
+                    shared.publish_log_frame(frame);
                 }
-                ProcessEvent::Error(error) => {
-                    tracing::warn!(target: "core", "output pump: {error}")
-                }
-                _ => {}
             }
         })
         .spawn()
@@ -223,6 +281,10 @@ impl Instance {
 
     pub fn state(&self) -> watch::Receiver<InstanceStatus> {
         self.state_rx.clone()
+    }
+
+    pub fn subscribe_logs(&self) -> broadcast::Receiver<LogFrame> {
+        self.shared.log_tx.subscribe()
     }
 
     pub fn epoch(&self) -> u64 {
@@ -257,7 +319,7 @@ impl Instance {
                         StopReason::Error(text) => text,
                         other => format!("stopped before ready: {other:?}"),
                     };
-                    let stderr_tail = kind::error_summary(self.spec.core.kind, &text);
+                    let stderr_tail = self.shared.failure_summary(&text);
                     return Err(if self.shared.probe_timeout.load(Ordering::SeqCst) {
                         Error::StartupTimeout { stderr_tail }
                     } else {
@@ -268,7 +330,7 @@ impl Instance {
             }
             if rx.changed().await.is_err() {
                 return Err(Error::StartupFailed {
-                    stderr_tail: self.shared.tail(),
+                    stderr_tail: self.shared.diagnostics(),
                 });
             }
         }
@@ -412,6 +474,13 @@ impl InstanceBuilder {
         self
     }
 
+    /// Lets the manager keep one log channel across epochs so subscriptions
+    /// survive restarts and core switches.
+    pub(crate) fn log_sender(mut self, log_tx: broadcast::Sender<LogFrame>) -> Self {
+        self.log_tx = Some(log_tx);
+        self
+    }
+
     pub async fn spawn(self) -> Result<Instance, Error> {
         Instance::spawn_configured(self).await
     }
@@ -441,6 +510,7 @@ fn build_command(spec: &InstanceSpec, epoch: u64, controller: &ResolvedControlle
             MIHOMO_SAFE_PATHS_ENV_NAME,
             kind::mihomo_safe_paths(&spec.working_dir, config_dir),
         )
+        .env(CLICOLOR_FORCE_ENV_NAME, "0")
         .current_dir(spec.working_dir.as_str());
     if let Some(pid_file) = &spec.pid_file {
         command = if epoch_pid_path(spec, epoch).is_some() {
@@ -560,7 +630,7 @@ async fn monitor_loop(
                     shared.publish_status(InstanceStatus {
                         state: InstanceState::Stopped(StopReason::Error(format!(
                         "core kept crashing; restart budget exhausted\n{}",
-                        shared.tail()
+                        shared.diagnostics()
                         ))),
                         health: None,
                     });
@@ -805,16 +875,19 @@ fn health_status(
 }
 
 fn publish_terminal(shared: &Shared, last_exit: Option<&TerminatedPayload>) {
+    // The clean-exit and user-stop arms never read the diagnostics, so without
+    // this a held fatal record would never reach the log subscribers.
+    shared.flush_log_record();
     let reason = if shared.user_stop.load(Ordering::SeqCst) {
         StopReason::User
     } else if shared.probe_timeout.load(Ordering::SeqCst) {
-        StopReason::Error(format!("health probe timed out\n{}", shared.tail()))
+        StopReason::Error(format!("health probe timed out\n{}", shared.diagnostics()))
     } else if last_exit.is_some_and(|payload| payload.code == Some(0)) {
         StopReason::Finished
     } else {
         StopReason::Error(format!(
             "core exited unexpectedly ({last_exit:?})\n{}",
-            shared.tail()
+            shared.diagnostics()
         ))
     };
     let _ = shared.state_tx.send(InstanceStatus {
@@ -866,6 +939,53 @@ mod tests {
     }
 
     #[test]
+    fn terminal_publication_releases_a_held_record() {
+        let (state_tx, _state_rx) = watch::channel(InstanceStatus::initial());
+        let (probe_request_tx, _probe_request_rx) = mpsc::unbounded_channel();
+        let (log_tx, mut logs) = broadcast::channel(LOG_CHANNEL_CAPACITY);
+        let shared = Shared {
+            state_tx,
+            user_stop: AtomicBool::new(true),
+            probe_timeout: AtomicBool::new(false),
+            parser: parking_lot::Mutex::new(LogParser::new(kind::CoreKind::Mihomo, 1)),
+            log_tail: parking_lot::Mutex::new(VecDeque::new()),
+            log_tx,
+            cancel: CancellationToken::new(),
+            probe_cancel: CancellationToken::new(),
+            probe_request_tx,
+            supervisor: tokio::sync::Mutex::new(None),
+            monitor: tokio::sync::Mutex::new(None),
+        };
+        // A fatal record is held back waiting for continuation lines.
+        for frame in shared
+            .parse(
+                LogStream::Stdout,
+                r#"time="2026-07-29T00:17:26+08:00" level=fatal msg="final record""#.to_owned(),
+            )
+            .into_iter()
+            .flatten()
+        {
+            shared.publish_log_frame(frame);
+        }
+        assert!(logs.try_recv().is_err());
+
+        // A user stop reads no diagnostics, so the flush has to happen anyway.
+        publish_terminal(&shared, None);
+        assert_eq!(
+            logs.try_recv().expect("held record").message,
+            "final record"
+        );
+        assert!(matches!(
+            state_rx_state(&shared),
+            InstanceState::Stopped(StopReason::User)
+        ));
+    }
+
+    fn state_rx_state(shared: &Shared) -> InstanceState {
+        shared.state_tx.borrow().state.clone()
+    }
+
+    #[test]
     #[ignore = "spawned as the managed child by the deadline-drain test"]
     fn deadline_drain_test_child() {
         std::thread::sleep(Duration::from_secs(60));
@@ -907,7 +1027,9 @@ mod tests {
             state_tx,
             user_stop: AtomicBool::new(false),
             probe_timeout: AtomicBool::new(false),
-            stderr_tail: parking_lot::Mutex::new(VecDeque::new()),
+            parser: parking_lot::Mutex::new(LogParser::new(kind::CoreKind::Mihomo, 1)),
+            log_tail: parking_lot::Mutex::new(VecDeque::new()),
+            log_tx: broadcast::channel(LOG_CHANNEL_CAPACITY).0,
             cancel: CancellationToken::new(),
             probe_cancel: CancellationToken::new(),
             probe_request_tx,

--- a/crates/nyanpasu-core-manager/src/kind.rs
+++ b/crates/nyanpasu-core-manager/src/kind.rs
@@ -4,12 +4,17 @@ use std::ffi::OsString;
 
 use camino::Utf8Path;
 
-use crate::error::Error;
+use crate::{error::Error, log::summarize_output};
 
 pub use nyanpasu_core_metadata::ClashCoreKind as CoreKind;
 
 /// The environment variable Mihomo consults for permitted file-system roots.
 pub const MIHOMO_SAFE_PATHS_ENV_NAME: &str = "SAFE_PATHS";
+
+/// Logrus honours this when `EnvironmentOverrideColors` is set, which Mihomo
+/// does (`log/log.go`). Pinning it to `0` keeps the logfmt layout the log parser
+/// expects even when the service inherits a colour-forcing environment.
+pub(crate) const CLICOLOR_FORCE_ENV_NAME: &str = "CLICOLOR_FORCE";
 
 #[cfg(windows)]
 const SAFE_PATHS_SEPARATOR: &str = ";";
@@ -82,61 +87,17 @@ pub async fn check_config(spec: &crate::spec::InstanceSpec) -> Result<(), Error>
             MIHOMO_SAFE_PATHS_ENV_NAME,
             mihomo_safe_paths(&spec.working_dir, config_dir),
         )
+        .env(CLICOLOR_FORCE_ENV_NAME, "0")
         .output()
         .await?;
     if output.success() {
         return Ok(());
     }
-    let message = match spec.core.kind {
-        CoreKind::ClashRust => format!("{}\n{}", output.stdout, output.stderr),
-        _ => parse_check_output(output.stdout.trim().to_owned()),
-    };
-    Err(Error::ConfigCheckFailed(message))
-}
-
-/// Extracts the human-readable message from a Mihomo error log line.
-/// Behavioral port of the legacy `core::utils::parse_check_output`.
-pub(crate) fn parse_check_output(log: String) -> String {
-    let t = log.find("time=");
-    let m = log.find("msg=");
-    let mr = log.rfind('"');
-
-    if let (Some(_), Some(m), Some(mr)) = (t, m, mr) {
-        let e = match log.find("level=error msg=") {
-            Some(e) => e + 17,
-            None => m + 5,
-        };
-
-        if mr > m {
-            return log[e..mr].to_owned();
-        }
-    }
-
-    let l = log.find("error=");
-    let r = log.find("path=").unwrap_or(log.len());
-
-    if let Some(l) = l {
-        let start = l + 6;
-        if r >= start {
-            return log[start..r].trim_end().to_owned();
-        }
-    }
-
-    log
-}
-
-/// Condenses a stderr tail into an error message. Mihomo logs are structured,
-/// so the last `level=error` line carries the actual cause.
-pub(crate) fn error_summary(kind: CoreKind, stderr_tail: &str) -> String {
-    if matches!(kind, CoreKind::Mihomo)
-        && let Some(line) = stderr_tail
-            .lines()
-            .rev()
-            .find(|l| l.contains("level=error"))
-    {
-        return parse_check_output(line.to_string());
-    }
-    stderr_tail.to_owned()
+    Err(Error::ConfigCheckFailed(summarize_output(
+        spec.core.kind,
+        &output.stdout,
+        &output.stderr,
+    )))
 }
 
 #[cfg(test)]
@@ -185,41 +146,28 @@ mod tests {
     }
 
     #[test]
-    fn parse_check_output_extracts_mihomo_msg() {
-        let log = r#"time="2026-07-18T10:00:00Z" level=error msg="configuration file /x.yaml test failed""#;
+    fn check_output_condenses_the_last_error_record() {
+        let log = "time=\"2026-07-18T10:00:00Z\" level=info msg=\"start\"\n\
+                   time=\"2026-07-18T10:00:01Z\" level=error msg=\"configuration file /x.yaml test failed\"";
         assert_eq!(
-            parse_check_output(log.to_string()),
+            summarize_output(CoreKind::Mihomo, log, ""),
             "configuration file /x.yaml test failed"
         );
     }
 
     #[test]
-    fn parse_check_output_extracts_error_field() {
-        assert_eq!(parse_check_output("error=bad path=/etc".to_string()), "bad");
-    }
-
-    #[test]
-    fn parse_check_output_handles_fallback_error_boundaries() {
-        assert_eq!(parse_check_output("error=bad".to_string()), "bad");
+    fn check_output_keeps_unrecognized_text() {
         assert_eq!(
-            parse_check_output("path=/etc error=bad".to_string()),
-            "path=/etc error=bad"
-        );
-    }
-
-    #[test]
-    fn parse_check_output_falls_back_to_input() {
-        assert_eq!(
-            parse_check_output("plain failure".to_string()),
+            summarize_output(CoreKind::Mihomo, "plain failure", ""),
             "plain failure"
         );
     }
 
     #[test]
-    fn error_summary_parses_last_mihomo_error_line() {
-        let tail = "line one\ntime=\"x\" level=error msg=\"boom\"\nafter";
-        assert_eq!(error_summary(CoreKind::Mihomo, tail), "boom");
-        assert_eq!(error_summary(CoreKind::ClashRust, tail), tail);
-        assert_eq!(error_summary(CoreKind::Mihomo, "no marker"), "no marker");
+    fn check_output_no_longer_special_cases_clash_rs() {
+        assert_eq!(
+            summarize_output(CoreKind::ClashRust, "", "Error: invalid config"),
+            "Error: invalid config"
+        );
     }
 }

--- a/crates/nyanpasu-core-manager/src/lib.rs
+++ b/crates/nyanpasu-core-manager/src/lib.rs
@@ -9,6 +9,7 @@ mod error;
 mod health;
 pub mod instance;
 pub mod kind;
+mod log;
 pub mod manager;
 pub mod spec;
 pub mod state;
@@ -20,6 +21,7 @@ pub use error::Error;
 pub use health::{HealthPolicy, probe};
 pub use instance::{Instance, InstanceBuilder};
 pub use kind::CoreKind;
+pub use log::{LogFrame, LogLevel, LogStream, LogTimestamp};
 pub use manager::{ApplyOutcome, CoreManager, CoreManagerBuilder, DegradeReason, SwitchOutcome};
 pub use probe::{
     ControllerVersionProbe, HealthProbe, ProbeContext, ProbeFuture, ProbeHandle, ProbePhase,

--- a/crates/nyanpasu-core-manager/src/log.rs
+++ b/crates/nyanpasu-core-manager/src/log.rs
@@ -1,0 +1,1143 @@
+//! Normalization of core console output into a single [`LogFrame`] shape.
+//!
+//! Each kind prints its own layout (mihomo logfmt, clash premium's `PrettyPrint`,
+//! and two different tracing formats), all of them on stdout, and only meow keeps
+//! ANSI when writing to a pipe. Parsing is header-only and per kind: a line whose
+//! header does not match degrades to an unformatted frame instead of being lost.
+
+use chrono::{DateTime, Duration, FixedOffset, NaiveDate, NaiveTime, TimeZone};
+use clash_api::LogField;
+
+use crate::kind::CoreKind;
+
+pub(crate) const LOG_CHANNEL_CAPACITY: usize = 256;
+const MAX_CONTINUATION_LINES: usize = 16;
+const MAX_LOGICAL_FRAME_BYTES: usize = 16 * 1024;
+
+/// Normalized severity. Go's `fatal` and `panic` both terminate the process, so
+/// they collapse into `Fatal`; the original spelling survives in [`LogFrame::raw`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum LogLevel {
+    Trace,
+    Debug,
+    Info,
+    Warning,
+    Error,
+    Fatal,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LogStream {
+    Stdout,
+    Stderr,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LogTimestamp {
+    /// Exactly as the core printed it.
+    pub raw: String,
+    /// Unix milliseconds, the same convention as `state::now_ms`.
+    pub unix_ms: Option<i64>,
+    /// The date or the zone offset came from the observation instant because the
+    /// core did not print one (clash premium and clash-rs).
+    pub inferred: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LogFrame {
+    pub epoch: u64,
+    pub kind: CoreKind,
+    pub stream: LogStream,
+    pub timestamp: Option<LogTimestamp>,
+    pub level: LogLevel,
+    /// clash premium's `[Tag]` prefix (a message convention, not a field), meow's
+    /// tracing target, or clash-rs's `file:line`.
+    pub target: Option<String>,
+    pub message: String,
+    /// Filled only where field boundaries are decidable, which today means
+    /// mihomo's quoted logfmt.
+    pub fields: Vec<LogField>,
+    /// The whole logical record with ANSI removed, continuations included.
+    pub raw: String,
+    /// Continuations were dropped after hitting a size limit.
+    pub truncated: bool,
+}
+
+/// At most two frames leave the parser per line: a flushed multi-line record and
+/// the line that ended it.
+pub(crate) type ParsedFrames = [Option<LogFrame>; 2];
+
+struct ParsedLine {
+    timestamp: Option<LogTimestamp>,
+    level: LogLevel,
+    target: Option<String>,
+    message: String,
+    fields: Vec<LogField>,
+}
+
+struct Pending {
+    frame: LogFrame,
+    continuations: usize,
+}
+
+impl Pending {
+    fn append(&mut self, line: &str) {
+        if self.continuations == MAX_CONTINUATION_LINES
+            || self.frame.raw.len() + 1 + line.len() > MAX_LOGICAL_FRAME_BYTES
+        {
+            self.frame.truncated = true;
+            return;
+        }
+        self.frame.raw.push('\n');
+        self.frame.raw.push_str(line);
+        self.frame.message.push('\n');
+        self.frame.message.push_str(line);
+        self.continuations += 1;
+    }
+}
+
+/// Stateful because clash premium needs the previous timestamp to infer date
+/// rollovers, and because a fatal record can span several lines.
+pub(crate) struct LogParser {
+    kind: CoreKind,
+    epoch: u64,
+    premium_clock: Option<(NaiveDate, NaiveTime)>,
+    pending: [Option<Pending>; 2],
+    newest_pending: Option<LogStream>,
+}
+
+impl LogParser {
+    pub(crate) fn new(kind: CoreKind, epoch: u64) -> Self {
+        Self {
+            kind,
+            epoch,
+            premium_clock: None,
+            pending: [None, None],
+            newest_pending: None,
+        }
+    }
+
+    pub(crate) fn push(&mut self, stream: LogStream, line: String) -> ParsedFrames {
+        self.push_at(stream, line, chrono::Local::now().fixed_offset())
+    }
+
+    pub(crate) fn push_at(
+        &mut self,
+        stream: LogStream,
+        line: String,
+        observed_at: DateTime<FixedOffset>,
+    ) -> ParsedFrames {
+        let line = strip_ansi(line);
+        if let Some(parsed) = self.parse_header(&line, observed_at) {
+            let hold = parsed.level >= LogLevel::Error;
+            let frame = LogFrame {
+                epoch: self.epoch,
+                kind: self.kind,
+                stream,
+                timestamp: parsed.timestamp,
+                level: parsed.level,
+                target: parsed.target,
+                message: parsed.message,
+                fields: parsed.fields,
+                raw: line,
+                truncated: false,
+            };
+            return self.emit(stream, frame, hold);
+        }
+
+        // clash-rs and meow also write plain, level-less text to stderr.
+        let error_root = line.starts_with("Error:");
+        let warning_root = line.starts_with("warning:");
+        if !error_root
+            && !warning_root
+            && let Some(pending) = self.pending[stream_index(stream)].as_mut()
+        {
+            pending.append(&line);
+            return [None, None];
+        }
+        let level = match (error_root, warning_root, stream) {
+            (true, _, _) => LogLevel::Error,
+            (_, true, _) => LogLevel::Warning,
+            (.., LogStream::Stdout) => LogLevel::Info,
+            (.., LogStream::Stderr) => LogLevel::Warning,
+        };
+        let frame = LogFrame {
+            epoch: self.epoch,
+            kind: self.kind,
+            stream,
+            timestamp: None,
+            level,
+            target: None,
+            message: line.clone(),
+            fields: Vec::new(),
+            raw: line,
+            truncated: false,
+        };
+        self.emit(stream, frame, error_root && stream == LogStream::Stderr)
+    }
+
+    /// Releases records still waiting for continuations, for process termination
+    /// and for buffered one-shot output.
+    pub(crate) fn finish(&mut self) -> ParsedFrames {
+        let stdout = self.pending[0].take().map(|pending| pending.frame);
+        let stderr = self.pending[1].take().map(|pending| pending.frame);
+        // Oldest first, so consumers that read the tail backwards still see the
+        // newest record first when both streams held one.
+        match self.newest_pending.take() {
+            Some(LogStream::Stdout) => [stderr, stdout],
+            _ => [stdout, stderr],
+        }
+    }
+
+    fn parse_header(
+        &mut self,
+        line: &str,
+        observed_at: DateTime<FixedOffset>,
+    ) -> Option<ParsedLine> {
+        match self.kind {
+            CoreKind::Mihomo => parse_mihomo(line),
+            CoreKind::Meow => parse_meow(line),
+            CoreKind::ClashRust => parse_clash_rs(line, observed_at),
+            CoreKind::ClashPremium => parse_premium(line, observed_at, &mut self.premium_clock),
+        }
+    }
+
+    /// Continuations only ever attach to a root from the same stream, so an
+    /// interleaved stdout line cannot be glued onto a stderr error block.
+    fn emit(&mut self, stream: LogStream, frame: LogFrame, hold: bool) -> ParsedFrames {
+        let index = stream_index(stream);
+        let flushed = self.pending[index].take().map(|pending| pending.frame);
+        if hold {
+            self.newest_pending = Some(stream);
+            self.pending[index] = Some(Pending {
+                frame,
+                continuations: 0,
+            });
+            [flushed, None]
+        } else {
+            [flushed, Some(frame)]
+        }
+    }
+}
+
+/// The most severe recent frame, latest first within that severity. `None` when
+/// nothing above `Info` was logged.
+pub(crate) fn error_summary(frames: &[LogFrame]) -> Option<String> {
+    let level = frames
+        .iter()
+        .map(|frame| frame.level)
+        .filter(|level| *level >= LogLevel::Warning)
+        .max()?;
+    frames
+        .iter()
+        .rev()
+        .find(|frame| frame.level == level)
+        .map(|frame| frame.message.clone())
+}
+
+pub(crate) fn format_tail(frames: &[LogFrame]) -> String {
+    frames
+        .iter()
+        .map(|frame| frame.raw.as_str())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Condenses the buffered output of a one-shot run into a single cause.
+pub(crate) fn summarize_output(kind: CoreKind, stdout: &str, stderr: &str) -> String {
+    let mut parser = LogParser::new(kind, 0);
+    let mut frames = Vec::new();
+    let mut drain = |stream, text: &str| {
+        for line in text.lines() {
+            frames.extend(parser.push(stream, line.to_owned()).into_iter().flatten());
+        }
+    };
+    drain(LogStream::Stdout, stdout);
+    drain(LogStream::Stderr, stderr);
+    frames.extend(parser.finish().into_iter().flatten());
+    error_summary(&frames).unwrap_or_else(|| verbatim_output(stdout, stderr))
+}
+
+fn verbatim_output(stdout: &str, stderr: &str) -> String {
+    let output = [stdout.trim(), stderr.trim()]
+        .into_iter()
+        .filter(|text| !text.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n");
+    if output.is_empty() {
+        "core reported no output".to_owned()
+    } else {
+        output
+    }
+}
+
+fn stream_index(stream: LogStream) -> usize {
+    match stream {
+        LogStream::Stdout => 0,
+        LogStream::Stderr => 1,
+    }
+}
+
+/// Drops complete CSI sequences rather than bare escapes, so `[32m` cannot leak
+/// into a level or target. Lines without an escape keep their allocation.
+fn strip_ansi(line: String) -> String {
+    if !line.as_bytes().contains(&0x1b) {
+        return line;
+    }
+    let bytes = line.into_bytes();
+    let mut output = Vec::with_capacity(bytes.len());
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] != 0x1b {
+            output.push(bytes[index]);
+            index += 1;
+            continue;
+        }
+        if bytes.get(index + 1) != Some(&b'[') {
+            index += 1;
+            continue;
+        }
+        index += 2;
+        // Parameter and intermediate bytes run until the final byte, which is the
+        // only ASCII byte in the sequence and therefore never splits a character.
+        while index < bytes.len() && !(0x40..=0x7e).contains(&bytes[index]) {
+            index += 1;
+        }
+        index = (index + 1).min(bytes.len());
+    }
+    String::from_utf8(output).expect("dropping ASCII escapes preserves UTF-8")
+}
+
+fn parse_level(level: &str) -> Option<LogLevel> {
+    match level {
+        "trace" | "TRC" | "TRACE" => Some(LogLevel::Trace),
+        "debug" | "DBG" | "DEBUG" => Some(LogLevel::Debug),
+        "info" | "INF" | "INFO" => Some(LogLevel::Info),
+        "warn" | "warning" | "WRN" | "WARN" => Some(LogLevel::Warning),
+        "error" | "ERR" | "ERROR" => Some(LogLevel::Error),
+        "fatal" | "panic" | "FTL" | "PNC" => Some(LogLevel::Fatal),
+        // phuslu/log's placeholder for a level it does not know.
+        "???" => Some(LogLevel::Info),
+        _ => None,
+    }
+}
+
+/// logrus logfmt: `time="..." level=... msg="..."` followed by the call site's
+/// own fields, all of them quoted when they need to be.
+fn parse_mihomo(line: &str) -> Option<ParsedLine> {
+    let mut raw_time = None;
+    let mut level = None;
+    let mut message = None;
+    let mut fields = Vec::new();
+    for (key, value) in scan_logfmt(line)? {
+        match key.as_str() {
+            "time" => raw_time = Some(value),
+            "level" => level = parse_level(&value),
+            "msg" => message = Some(value),
+            _ => fields.push(LogField { key, value }),
+        }
+    }
+    let raw_time = raw_time?;
+    Some(ParsedLine {
+        timestamp: Some(LogTimestamp {
+            unix_ms: parse_rfc3339_ms(&raw_time),
+            raw: raw_time,
+            inferred: false,
+        }),
+        level: level?,
+        target: None,
+        message: message?,
+        fields,
+    })
+}
+
+fn scan_logfmt(line: &str) -> Option<Vec<(String, String)>> {
+    let bytes = line.as_bytes();
+    let mut fields = Vec::new();
+    let mut index = 0;
+    while index < bytes.len() {
+        while bytes.get(index).is_some_and(u8::is_ascii_whitespace) {
+            index += 1;
+        }
+        if index == bytes.len() {
+            break;
+        }
+        let key_start = index;
+        while index < bytes.len() && bytes[index] != b'=' {
+            if bytes[index].is_ascii_whitespace() {
+                return None;
+            }
+            index += 1;
+        }
+        if index == key_start || index == bytes.len() {
+            return None;
+        }
+        let key = line.get(key_start..index)?.to_owned();
+        index += 1;
+
+        let value = if bytes.get(index) == Some(&b'"') {
+            index += 1;
+            let mut value = Vec::new();
+            let mut closed = false;
+            while index < bytes.len() {
+                match bytes[index] {
+                    b'"' => {
+                        index += 1;
+                        closed = true;
+                        break;
+                    }
+                    b'\\' => {
+                        let escaped = *bytes.get(index + 1)?;
+                        match escaped {
+                            b'"' | b'\\' => value.push(escaped),
+                            b'n' => value.push(b'\n'),
+                            b'r' => value.push(b'\r'),
+                            b't' => value.push(b'\t'),
+                            _ => value.extend_from_slice(&[b'\\', escaped]),
+                        }
+                        index += 2;
+                    }
+                    byte => {
+                        value.push(byte);
+                        index += 1;
+                    }
+                }
+            }
+            if !closed
+                || bytes
+                    .get(index)
+                    .is_some_and(|byte| !byte.is_ascii_whitespace())
+            {
+                return None;
+            }
+            String::from_utf8(value).ok()?
+        } else {
+            let value_start = index;
+            while index < bytes.len() && !bytes[index].is_ascii_whitespace() {
+                index += 1;
+            }
+            line.get(value_start..index)?.to_owned()
+        };
+        fields.push((key, value));
+    }
+    Some(fields)
+}
+
+/// tracing-subscriber's default layout:
+/// `<RFC3339 UTC> <right-aligned level> <target>: message`.
+fn parse_meow(line: &str) -> Option<ParsedLine> {
+    let (raw_time, rest) = take_token(line)?;
+    let (level, rest) = take_token(rest)?;
+    let level = parse_level(level)?;
+    let (target, message) = rest.split_once(": ")?;
+    if target.is_empty() {
+        return None;
+    }
+    Some(ParsedLine {
+        timestamp: Some(LogTimestamp {
+            unix_ms: parse_rfc3339_ms(raw_time),
+            raw: raw_time.to_owned(),
+            inferred: false,
+        }),
+        level,
+        target: Some(target.to_owned()),
+        message: message.to_owned(),
+        fields: Vec::new(),
+    })
+}
+
+/// `<timestamp> <LEVEL> [ThreadId(N)] [target] <file:line>: message`. The two
+/// middle segments only exist in debug builds of the core, so the header ends at
+/// the first `file:line` anchor rather than at a fixed offset from the level.
+fn parse_clash_rs(line: &str, observed_at: DateTime<FixedOffset>) -> Option<ParsedLine> {
+    let timestamp_end = clash_rs_timestamp_end(line)?;
+    let raw_time = line.get(..timestamp_end)?;
+    let (level, rest) = take_token(line.get(timestamp_end..)?)?;
+    let level = parse_level(level)?;
+    let (target, message) = clash_rs_source(rest)?;
+    Some(ParsedLine {
+        timestamp: Some(LogTimestamp {
+            unix_ms: clash_rs_unix_ms(raw_time, observed_at.offset()),
+            raw: raw_time.to_owned(),
+            inferred: true,
+        }),
+        level,
+        target: Some(target.to_owned()),
+        message: message.to_owned(),
+        fields: Vec::new(),
+    })
+}
+
+/// `yy-MM-dd HH:mm:ss:<subsecond>`. The separator before the subsecond is a
+/// colon and `time`'s `[subsecond]` prints 1 to 9 digits, so no RFC3339 parser
+/// applies.
+fn clash_rs_timestamp_end(line: &str) -> Option<usize> {
+    const SEPARATORS: [(usize, u8); 6] = [
+        (2, b'-'),
+        (5, b'-'),
+        (8, b' '),
+        (11, b':'),
+        (14, b':'),
+        (17, b':'),
+    ];
+    const NUMBERS: [(usize, usize); 6] = [(0, 2), (3, 5), (6, 8), (9, 11), (12, 14), (15, 17)];
+    let bytes = line.as_bytes();
+    if !SEPARATORS
+        .iter()
+        .all(|(index, separator)| bytes.get(*index) == Some(separator))
+        || !NUMBERS
+            .iter()
+            .all(|(start, end)| bytes[*start..*end].iter().all(u8::is_ascii_digit))
+    {
+        return None;
+    }
+    let digits = bytes[18..]
+        .iter()
+        .take_while(|byte| byte.is_ascii_digit())
+        .count();
+    // The trailing space is what separates the header from the level; without it
+    // an arbitrary line of the same shape would be accepted as a record root.
+    ((1..=9).contains(&digits) && bytes.get(18 + digits) == Some(&b' ')).then_some(18 + digits)
+}
+
+fn clash_rs_unix_ms(raw: &str, offset: &FixedOffset) -> Option<i64> {
+    let number = |range: std::ops::Range<usize>| raw.get(range)?.parse::<u32>().ok();
+    let subsecond = raw.get(18..)?;
+    let nanos = subsecond.parse::<u32>().ok()? * 10_u32.pow(9 - subsecond.len() as u32);
+    let date = NaiveDate::from_ymd_opt(2000 + number(0..2)? as i32, number(3..5)?, number(6..8)?)?;
+    let time =
+        NaiveTime::from_hms_nano_opt(number(9..11)?, number(12..14)?, number(15..17)?, nanos)?;
+    local_unix_ms(date, time, offset)
+}
+
+/// Scans forward: neither `ThreadId(N)` nor a tracing target can look like
+/// `<path>:<line>: `, so the first match closes the header, while a later one
+/// may well be an ordinary `file:line:` reference inside the message.
+fn clash_rs_source(rest: &str) -> Option<(&str, &str)> {
+    for (separator, _) in rest.match_indices(": ") {
+        let head = &rest[..separator];
+        let Some(colon) = head.rfind(':') else {
+            continue;
+        };
+        if head[colon + 1..].is_empty()
+            || !head[colon + 1..].bytes().all(|byte| byte.is_ascii_digit())
+        {
+            continue;
+        }
+        let start = head[..colon]
+            .rfind(char::is_whitespace)
+            .map_or(0, |index| index + 1);
+        if start == colon {
+            continue;
+        }
+        return Some((&head[start..], &rest[separator + 2..]));
+    }
+    None
+}
+
+/// `HH:MM:SS LVL message (key=value)*`. The trailing pairs are printed without
+/// quoting and their values may contain spaces and colons, so they stay in the
+/// message instead of becoming fields.
+fn parse_premium(
+    line: &str,
+    observed_at: DateTime<FixedOffset>,
+    clock: &mut Option<(NaiveDate, NaiveTime)>,
+) -> Option<ParsedLine> {
+    let bytes = line.as_bytes();
+    if bytes.get(8) != Some(&b' ') || bytes.get(12) != Some(&b' ') {
+        return None;
+    }
+    let raw_time = line.get(..8)?;
+    let time = NaiveTime::parse_from_str(raw_time, "%H:%M:%S").ok()?;
+    let level = parse_level(line.get(9..12)?)?;
+    let (target, message) = premium_target(line.get(13..)?);
+    Some(ParsedLine {
+        timestamp: Some(LogTimestamp {
+            unix_ms: premium_unix_ms(time, observed_at, clock),
+            raw: raw_time.to_owned(),
+            inferred: true,
+        }),
+        level,
+        target,
+        message,
+        fields: Vec::new(),
+    })
+}
+
+/// The `[Tag]` prefix is a literal the call site writes into the message, not a
+/// structured field, so failing to find one is normal.
+fn premium_target(body: &str) -> (Option<String>, String) {
+    let tagged = body
+        .strip_prefix('[')
+        .and_then(|rest| rest.split_once("] "));
+    match tagged {
+        Some((tag, message)) if !tag.is_empty() && !tag.contains(' ') => {
+            (Some(tag.to_owned()), message.to_owned())
+        }
+        _ => (None, body.to_owned()),
+    }
+}
+
+/// premium prints no date. The first line adopts the observed one — a printed
+/// time more than half a day ahead of it belongs to the previous day — and later
+/// lines roll forward when the clock falls from end-of-day back to start-of-day.
+fn premium_unix_ms(
+    time: NaiveTime,
+    observed_at: DateTime<FixedOffset>,
+    clock: &mut Option<(NaiveDate, NaiveTime)>,
+) -> Option<i64> {
+    let date = match *clock {
+        Some((date, previous)) if previous.signed_duration_since(time) > Duration::hours(12) => {
+            date.succ_opt()?
+        }
+        Some((date, _)) => date,
+        None => {
+            let observed = observed_at.date_naive();
+            if time.signed_duration_since(observed_at.time()) > Duration::hours(12) {
+                observed.pred_opt()?
+            } else {
+                observed
+            }
+        }
+    };
+    *clock = Some((date, time));
+    local_unix_ms(date, time, observed_at.offset())
+}
+
+fn local_unix_ms(date: NaiveDate, time: NaiveTime, offset: &FixedOffset) -> Option<i64> {
+    offset
+        .from_local_datetime(&date.and_time(time))
+        .single()
+        .map(|timestamp| timestamp.timestamp_millis())
+}
+
+fn parse_rfc3339_ms(raw: &str) -> Option<i64> {
+    DateTime::parse_from_rfc3339(raw)
+        .ok()
+        .map(|timestamp| timestamp.timestamp_millis())
+}
+
+fn take_token(input: &str) -> Option<(&str, &str)> {
+    let input = input.trim_start();
+    let end = input.find(char::is_whitespace)?;
+    Some((&input[..end], input[end..].trim_start()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn observed(raw: &str) -> DateTime<FixedOffset> {
+        DateTime::parse_from_rfc3339(raw).expect("test observation instant")
+    }
+
+    fn unix_ms(raw: &str) -> Option<i64> {
+        Some(
+            DateTime::parse_from_rfc3339(raw)
+                .expect("test timestamp")
+                .timestamp_millis(),
+        )
+    }
+
+    fn collect(frames: ParsedFrames) -> Vec<LogFrame> {
+        frames.into_iter().flatten().collect()
+    }
+
+    fn parse_one(kind: CoreKind, stream: LogStream, line: &str, at: &str) -> LogFrame {
+        let mut parser = LogParser::new(kind, 7);
+        let mut frames = collect(parser.push_at(stream, line.to_owned(), observed(at)));
+        frames.extend(parser.finish().into_iter().flatten());
+        assert_eq!(frames.len(), 1, "expected exactly one frame for {line:?}");
+        frames.remove(0)
+    }
+
+    #[test]
+    fn strip_ansi_keeps_plain_lines_and_drops_truncated_sequences() {
+        let line = "plain line".to_owned();
+        let allocation = line.as_ptr();
+        let stripped = strip_ansi(line);
+        assert_eq!(stripped, "plain line");
+        assert_eq!(stripped.as_ptr(), allocation);
+
+        assert_eq!(strip_ansi("prefix\u{1b}[31".to_owned()), "prefix");
+        assert_eq!(strip_ansi("\u{1b}[2m配置\u{1b}[0m".to_owned()), "配置");
+    }
+
+    #[test]
+    fn parses_mihomo_logfmt_including_escapes() {
+        let info = parse_one(
+            CoreKind::Mihomo,
+            LogStream::Stdout,
+            r#"time="2026-07-29T00:16:22.646059400+08:00" level=info msg="Mixed(http+socks) proxy listening at: 127.0.0.1:17890""#,
+            "2026-07-29T00:16:23+08:00",
+        );
+        assert_eq!(info.level, LogLevel::Info);
+        assert_eq!(info.target, None);
+        assert_eq!(
+            info.message,
+            "Mixed(http+socks) proxy listening at: 127.0.0.1:17890"
+        );
+        let timestamp = info.timestamp.expect("mihomo prints a timestamp");
+        assert!(!timestamp.inferred);
+        assert_eq!(
+            timestamp.unix_ms,
+            unix_ms("2026-07-29T00:16:22.646059400+08:00")
+        );
+
+        let fatal = parse_one(
+            CoreKind::Mihomo,
+            LogStream::Stdout,
+            r#"time="2026-07-29T00:17:26.518376100+08:00" level=fatal msg="Parse config error: yaml: line 2: did not find expected node content""#,
+            "2026-07-29T00:17:27+08:00",
+        );
+        assert_eq!(fatal.level, LogLevel::Fatal);
+        assert_eq!(
+            fatal.message,
+            "Parse config error: yaml: line 2: did not find expected node content"
+        );
+
+        let escaped = parse_one(
+            CoreKind::Mihomo,
+            LogStream::Stdout,
+            r#"time="2026-07-29T00:17:26+08:00" level=warning msg="say \"hello\" on \\path" request=7"#,
+            "2026-07-29T00:17:27+08:00",
+        );
+        assert_eq!(escaped.level, LogLevel::Warning);
+        assert_eq!(escaped.message, r#"say "hello" on \path"#);
+        assert_eq!(
+            escaped.fields,
+            [LogField {
+                key: "request".into(),
+                value: "7".into(),
+            }]
+        );
+    }
+
+    #[test]
+    fn colored_mihomo_layout_degrades_instead_of_being_dropped() {
+        let frame = parse_one(
+            CoreKind::Mihomo,
+            LogStream::Stdout,
+            "\u{1b}[36mINFO\u{1b}[0m[2026-07-29T00:16:22.646059400+08:00] proxy listening",
+            "2026-07-29T00:16:23+08:00",
+        );
+        assert_eq!(frame.level, LogLevel::Info);
+        assert_eq!(frame.timestamp, None);
+        assert_eq!(
+            frame.raw,
+            "INFO[2026-07-29T00:16:22.646059400+08:00] proxy listening"
+        );
+        assert_eq!(frame.message, frame.raw);
+    }
+
+    #[test]
+    fn parses_premium_pretty_print() {
+        let mmdb = parse_one(
+            CoreKind::ClashPremium,
+            LogStream::Stdout,
+            "00:16:30 INF [MMDB] can't find DB, start download path=C:/.../Country.mmdb",
+            "2026-07-29T00:16:31+08:00",
+        );
+        assert_eq!(mmdb.level, LogLevel::Info);
+        assert_eq!(mmdb.target.as_deref(), Some("MMDB"));
+        assert_eq!(
+            mmdb.message,
+            "can't find DB, start download path=C:/.../Country.mmdb"
+        );
+        assert!(mmdb.fields.is_empty());
+        let timestamp = mmdb.timestamp.expect("premium prints a time of day");
+        assert!(timestamp.inferred);
+        assert_eq!(timestamp.raw, "00:16:30");
+        assert_eq!(timestamp.unix_ms, unix_ms("2026-07-29T00:16:30+08:00"));
+
+        let inbound = parse_one(
+            CoreKind::ClashPremium,
+            LogStream::Stdout,
+            "00:16:33 INF inbound create success inbound=mixed addr=127.0.0.1:17890 network=tcp",
+            "2026-07-29T00:16:34+08:00",
+        );
+        assert_eq!(inbound.target, None);
+        assert_eq!(
+            inbound.message,
+            "inbound create success inbound=mixed addr=127.0.0.1:17890 network=tcp"
+        );
+
+        let fatal = parse_one(
+            CoreKind::ClashPremium,
+            LogStream::Stdout,
+            "00:17:26 FTL [Config] parse config failed error=yaml: line 2: did not find expected node content",
+            "2026-07-29T00:17:27+08:00",
+        );
+        assert_eq!(fatal.level, LogLevel::Fatal);
+        assert_eq!(fatal.target.as_deref(), Some("Config"));
+        assert_eq!(
+            fatal.message,
+            "parse config failed error=yaml: line 2: did not find expected node content"
+        );
+
+        let unknown = parse_one(
+            CoreKind::ClashPremium,
+            LogStream::Stdout,
+            "00:17:26 ??? unlabelled record",
+            "2026-07-29T00:17:27+08:00",
+        );
+        assert_eq!(unknown.level, LogLevel::Info);
+        assert_eq!(unknown.message, "unlabelled record");
+    }
+
+    #[test]
+    fn premium_rolls_over_midnight_but_ignores_small_backward_drift() {
+        let mut parser = LogParser::new(CoreKind::ClashPremium, 1);
+        let before = collect(parser.push_at(
+            LogStream::Stdout,
+            "23:59:59 INF before".to_owned(),
+            observed("2026-07-29T23:59:59+08:00"),
+        ))
+        .remove(0);
+        let after = collect(parser.push_at(
+            LogStream::Stdout,
+            "00:00:01 INF after".to_owned(),
+            observed("2026-07-30T00:00:01+08:00"),
+        ))
+        .remove(0);
+        assert_eq!(
+            before.timestamp.unwrap().unix_ms,
+            unix_ms("2026-07-29T23:59:59+08:00")
+        );
+        assert_eq!(
+            after.timestamp.unwrap().unix_ms,
+            unix_ms("2026-07-30T00:00:01+08:00")
+        );
+
+        let mut parser = LogParser::new(CoreKind::ClashPremium, 1);
+        parser.push_at(
+            LogStream::Stdout,
+            "10:00:00 INF first".to_owned(),
+            observed("2026-07-29T10:00:00+08:00"),
+        );
+        let drifted = collect(parser.push_at(
+            LogStream::Stdout,
+            "09:59:59 INF drifted".to_owned(),
+            observed("2026-07-29T10:00:01+08:00"),
+        ))
+        .remove(0);
+        assert_eq!(
+            drifted.timestamp.unwrap().unix_ms,
+            unix_ms("2026-07-29T09:59:59+08:00")
+        );
+    }
+
+    #[test]
+    fn premium_first_line_from_the_previous_day() {
+        let frame = parse_one(
+            CoreKind::ClashPremium,
+            LogStream::Stdout,
+            "23:59:59 INF late",
+            "2026-07-30T00:00:02+08:00",
+        );
+        assert_eq!(
+            frame.timestamp.unwrap().unix_ms,
+            unix_ms("2026-07-29T23:59:59+08:00")
+        );
+    }
+
+    #[test]
+    fn strips_ansi_from_meow_before_parsing() {
+        let info = parse_one(
+            CoreKind::Meow,
+            LogStream::Stdout,
+            "\u{1b}[2m2026-07-28T16:16:26.616489Z\u{1b}[0m \u{1b}[32m INFO\u{1b}[0m \u{1b}[2mmeow\u{1b}[0m\u{1b}[2m:\u{1b}[0m meow-rs starting...",
+            "2026-07-29T00:16:27+08:00",
+        );
+        assert_eq!(info.level, LogLevel::Info);
+        assert_eq!(info.target.as_deref(), Some("meow"));
+        assert_eq!(info.message, "meow-rs starting...");
+        assert_eq!(
+            info.raw,
+            "2026-07-28T16:16:26.616489Z  INFO meow: meow-rs starting..."
+        );
+        assert_eq!(
+            info.timestamp.unwrap().unix_ms,
+            unix_ms("2026-07-28T16:16:26.616489Z")
+        );
+
+        let error = parse_one(
+            CoreKind::Meow,
+            LogStream::Stdout,
+            "\u{1b}[2m2026-07-28T16:17:26.719459Z\u{1b}[0m \u{1b}[31mERROR\u{1b}[0m \u{1b}[2mmeow\u{1b}[0m\u{1b}[2m:\u{1b}[0m meow-rs stopped with an error \u{1b}[3merror\u{1b}[0m\u{1b}[2m=\u{1b}[0mdid not find expected node content at line 3 column 1",
+            "2026-07-29T00:17:27+08:00",
+        );
+        assert_eq!(error.level, LogLevel::Error);
+        assert_eq!(error.target.as_deref(), Some("meow"));
+        assert_eq!(
+            error.message,
+            "meow-rs stopped with an error error=did not find expected node content at line 3 column 1"
+        );
+        assert!(!error.raw.contains('\u{1b}'));
+    }
+
+    #[test]
+    fn infers_levels_for_plain_stderr_text() {
+        let warning = parse_one(
+            CoreKind::Meow,
+            LogStream::Stderr,
+            "warning: --geodata-mode is not supported and will be ignored",
+            "2026-07-29T00:17:27+08:00",
+        );
+        assert_eq!(warning.level, LogLevel::Warning);
+        assert_eq!(warning.timestamp, None);
+
+        let error = parse_one(
+            CoreKind::ClashRust,
+            LogStream::Stderr,
+            "Error: invalid config",
+            "2026-07-29T00:17:27+08:00",
+        );
+        assert_eq!(error.level, LogLevel::Error);
+
+        let noise = parse_one(
+            CoreKind::ClashRust,
+            LogStream::Stderr,
+            "using env log level: debug",
+            "2026-07-29T00:17:27+08:00",
+        );
+        assert_eq!(noise.level, LogLevel::Warning);
+    }
+
+    #[test]
+    fn parses_clash_rs_release_and_debug_layouts() {
+        let debug = parse_one(
+            CoreKind::ClashRust,
+            LogStream::Stdout,
+            r"26-07-29 00:16:35:0919421 DEBUG clash-lib\src\lib.rs:445: initializing cache store",
+            "2026-07-29T00:16:36+08:00",
+        );
+        assert_eq!(debug.level, LogLevel::Debug);
+        assert_eq!(debug.target.as_deref(), Some(r"clash-lib\src\lib.rs:445"));
+        assert_eq!(debug.message, "initializing cache store");
+        let timestamp = debug.timestamp.expect("clash-rs prints a timestamp");
+        assert!(timestamp.inferred);
+        assert_eq!(timestamp.raw, "26-07-29 00:16:35:0919421");
+        assert_eq!(
+            timestamp.unix_ms,
+            unix_ms("2026-07-29T00:16:35.0919421+08:00")
+        );
+
+        let warning = parse_one(
+            CoreKind::ClashRust,
+            LogStream::Stdout,
+            r"26-07-29 00:16:35:0926205  WARN clash-lib\src\app\profile\mod.rs:153: failed to read cache file: stream did not contain valid UTF-8",
+            "2026-07-29T00:16:36+08:00",
+        );
+        assert_eq!(warning.level, LogLevel::Warning);
+        assert_eq!(
+            warning.target.as_deref(),
+            Some(r"clash-lib\src\app\profile\mod.rs:153")
+        );
+        assert_eq!(
+            warning.message,
+            "failed to read cache file: stream did not contain valid UTF-8"
+        );
+
+        let six_digits = parse_one(
+            CoreKind::ClashRust,
+            LogStream::Stdout,
+            r"26-07-29 00:16:35:093078 INFO clash-lib\src\lib.rs:446: six digit subsecond",
+            "2026-07-29T00:16:36+08:00",
+        );
+        assert_eq!(
+            six_digits.timestamp.unwrap().unix_ms,
+            unix_ms("2026-07-29T00:16:35.093078+08:00")
+        );
+
+        let instrumented = parse_one(
+            CoreKind::ClashRust,
+            LogStream::Stdout,
+            r"26-07-29 00:16:35:093078 DEBUG ThreadId(1) clash_lib::app clash-lib\src\lib.rs:445: debug build shape",
+            "2026-07-29T00:16:36+08:00",
+        );
+        assert_eq!(
+            instrumented.target.as_deref(),
+            Some(r"clash-lib\src\lib.rs:445")
+        );
+        assert_eq!(instrumented.message, "debug build shape");
+
+        // A `file:line`-shaped reference inside the message must not win over the
+        // real source anchor that closes the header.
+        let quoted_source = parse_one(
+            CoreKind::ClashRust,
+            LogStream::Stdout,
+            r"26-07-29 00:16:35:093078 ERROR clash-lib\src\lib.rs:445: failed at config.yaml:3: invalid value",
+            "2026-07-29T00:16:36+08:00",
+        );
+        assert_eq!(
+            quoted_source.target.as_deref(),
+            Some(r"clash-lib\src\lib.rs:445")
+        );
+        assert_eq!(
+            quoted_source.message,
+            "failed at config.yaml:3: invalid value"
+        );
+    }
+
+    #[test]
+    fn clash_rs_header_shape_alone_does_not_make_a_root() {
+        let mut parser = LogParser::new(CoreKind::ClashRust, 1);
+        let at = observed("2026-07-29T00:17:27+08:00");
+        parser.push_at(LogStream::Stderr, "Error: invalid config".to_owned(), at);
+        for line in [
+            // Separators line up but the numeric slots do not hold digits.
+            "xx-xx-xx xx:xx:xx:1 ERROR fake.rs:1: not a header",
+            // No space between the subsecond and the level.
+            "26-07-29 00:16:35:1ERROR fake.rs:1: no separator",
+        ] {
+            assert!(collect(parser.push_at(LogStream::Stderr, line.to_owned(), at)).is_empty());
+        }
+        let frame = collect(parser.finish()).remove(0);
+        assert_eq!(frame.level, LogLevel::Error);
+        assert_eq!(
+            frame.message,
+            "Error: invalid config\n\
+             xx-xx-xx xx:xx:xx:1 ERROR fake.rs:1: not a header\n\
+             26-07-29 00:16:35:1ERROR fake.rs:1: no separator"
+        );
+    }
+
+    #[test]
+    fn finish_releases_pending_roots_oldest_first() {
+        let mut parser = LogParser::new(CoreKind::Meow, 1);
+        let at = observed("2026-07-29T00:17:27+08:00");
+        parser.push_at(LogStream::Stderr, "Error: stderr first".to_owned(), at);
+        parser.push_at(
+            LogStream::Stdout,
+            "2026-07-28T16:17:26.719459Z ERROR meow: stdout second".to_owned(),
+            at,
+        );
+        let frames = collect(parser.finish());
+        assert_eq!(frames[0].message, "Error: stderr first");
+        assert_eq!(frames[1].message, "stdout second");
+        assert_eq!(error_summary(&frames).as_deref(), Some("stdout second"));
+    }
+
+    #[test]
+    fn aggregates_multi_line_records_within_one_stream() {
+        let mut parser = LogParser::new(CoreKind::ClashRust, 1);
+        let at = observed("2026-07-29T00:17:27+08:00");
+        for line in [
+            "Error: invalid config: couldn't not parse config content mixed-port: not-a-port",
+            "proxies: [[[",
+            ": did not find expected node content at line 3 column 1, while parsing a flow node",
+        ] {
+            assert!(collect(parser.push_at(LogStream::Stderr, line.to_owned(), at)).is_empty());
+        }
+        let frame = collect(parser.finish()).remove(0);
+        assert_eq!(frame.level, LogLevel::Error);
+        assert!(!frame.truncated);
+        assert_eq!(
+            frame.message,
+            "Error: invalid config: couldn't not parse config content mixed-port: not-a-port\nproxies: [[[\n: did not find expected node content at line 3 column 1, while parsing a flow node"
+        );
+    }
+
+    #[test]
+    fn premium_stack_stays_attached_to_its_record() {
+        let mut parser = LogParser::new(CoreKind::ClashPremium, 1);
+        let at = observed("2026-07-29T00:17:27+08:00");
+        for line in [
+            "00:17:26 FTL [Config] parse config failed error=bad",
+            "goroutine 1 [running]:",
+            "main.main()",
+        ] {
+            parser.push_at(LogStream::Stdout, line.to_owned(), at);
+        }
+        let frame = collect(parser.finish()).remove(0);
+        assert_eq!(
+            frame.message,
+            "parse config failed error=bad\ngoroutine 1 [running]:\nmain.main()"
+        );
+    }
+
+    #[test]
+    fn oversized_stacks_keep_the_root_and_mark_truncation() {
+        let mut parser = LogParser::new(CoreKind::Mihomo, 1);
+        let at = observed("2026-07-29T00:17:27+08:00");
+        parser.push_at(
+            LogStream::Stdout,
+            r#"time="2026-07-29T00:17:26+08:00" level=panic msg="boom""#.to_owned(),
+            at,
+        );
+        for index in 0..MAX_CONTINUATION_LINES + 4 {
+            parser.push_at(LogStream::Stdout, format!("stack frame {index}"), at);
+        }
+        let frame = collect(parser.finish()).remove(0);
+        assert_eq!(frame.level, LogLevel::Fatal);
+        assert!(frame.truncated);
+        assert!(frame.message.starts_with("boom\nstack frame 0\n"));
+        assert!(frame.message.contains("stack frame 15"));
+        assert!(!frame.message.contains("stack frame 16"));
+    }
+
+    #[test]
+    fn continuations_never_cross_streams() {
+        let mut parser = LogParser::new(CoreKind::ClashRust, 1);
+        let at = observed("2026-07-29T00:17:27+08:00");
+        parser.push_at(LogStream::Stderr, "Error: invalid config".to_owned(), at);
+        let stdout =
+            collect(parser.push_at(LogStream::Stdout, "unrelated stdout noise".to_owned(), at));
+        assert_eq!(stdout.len(), 1);
+        assert_eq!(stdout[0].message, "unrelated stdout noise");
+        let pending = collect(parser.finish()).remove(0);
+        assert_eq!(pending.message, "Error: invalid config");
+    }
+
+    #[test]
+    fn summarizes_bad_config_output_for_every_kind() {
+        assert_eq!(
+            summarize_output(
+                CoreKind::Mihomo,
+                r#"time="2026-07-29T00:17:26.518376100+08:00" level=fatal msg="Parse config error: yaml: line 2: did not find expected node content""#,
+                "",
+            ),
+            "Parse config error: yaml: line 2: did not find expected node content"
+        );
+
+        assert_eq!(
+            summarize_output(
+                CoreKind::ClashPremium,
+                "00:16:30 INF [MMDB] can't find DB\n00:17:26 FTL [Config] parse config failed error=yaml: line 2: did not find expected node content",
+                "",
+            ),
+            "parse config failed error=yaml: line 2: did not find expected node content"
+        );
+
+        let meow = summarize_output(
+            CoreKind::Meow,
+            "\u{1b}[2m2026-07-28T16:17:26.719459Z\u{1b}[0m \u{1b}[31mERROR\u{1b}[0m \u{1b}[2mmeow\u{1b}[0m\u{1b}[2m:\u{1b}[0m meow-rs stopped with an error \u{1b}[3merror\u{1b}[0m\u{1b}[2m=\u{1b}[0mdid not find expected node content at line 3 column 1",
+            "warning: --geodata-mode is not supported and will be ignored\nError: did not find expected node content at line 3 column 1, while parsing a flow node",
+        );
+        assert!(
+            meow.contains("did not find expected node content"),
+            "{meow}"
+        );
+
+        let clash_rs = summarize_output(
+            CoreKind::ClashRust,
+            "",
+            "Error: invalid config: couldn't not parse config content mixed-port: not-a-port\nproxies: [[[\n: did not find expected node content at line 3 column 1, while parsing a flow node",
+        );
+        assert!(clash_rs.contains("invalid config"), "{clash_rs}");
+        assert!(clash_rs.contains("proxies: [[["), "{clash_rs}");
+    }
+
+    #[test]
+    fn summary_falls_back_to_verbatim_output() {
+        assert_eq!(
+            summarize_output(CoreKind::Mihomo, "  ", ""),
+            "core reported no output"
+        );
+        assert_eq!(
+            summarize_output(CoreKind::Mihomo, "unstructured note", ""),
+            "unstructured note"
+        );
+    }
+}

--- a/crates/nyanpasu-core-manager/src/manager/mod.rs
+++ b/crates/nyanpasu-core-manager/src/manager/mod.rs
@@ -13,7 +13,7 @@ use std::sync::{
 
 use enumset::EnumSet;
 use serde_yaml_ng::Mapping;
-use tokio::sync::watch;
+use tokio::sync::{broadcast, watch};
 
 use crate::{
     Feature, RuntimeFeature,
@@ -21,6 +21,7 @@ use crate::{
     config::{self, ConfigSnapshot, mihomo},
     error::Error,
     instance::Instance,
+    log::{LOG_CHANNEL_CAPACITY, LogFrame},
     probe::ProbeHandle,
     runtime_store::{RuntimeConfigStore, RuntimeDirectoryLock, StagedRuntimeConfig},
     spec::{
@@ -101,6 +102,9 @@ struct Inner {
     store: RuntimeConfigStore,
     ctrl: tokio::sync::Mutex<Ctrl>,
     status_tx: watch::Sender<CoreStatus>,
+    /// Outlives every epoch, so callers can subscribe before the first start and
+    /// keep receiving across restarts and core switches.
+    log_tx: broadcast::Sender<LogFrame>,
     epoch: AtomicU64,
     version_cache: VersionCache,
     // Declared last so ordinary Inner destruction drops instances/tasks before
@@ -238,6 +242,7 @@ impl CoreManager {
                 store,
                 ctrl: tokio::sync::Mutex::default(),
                 status_tx,
+                log_tx: broadcast::channel(LOG_CHANNEL_CAPACITY).0,
                 epoch: AtomicU64::new(max_epoch),
                 version_cache: VersionCache::default(),
                 _runtime_lock: runtime_lock,
@@ -247,6 +252,10 @@ impl CoreManager {
 
     pub fn subscribe(&self) -> watch::Receiver<CoreStatus> {
         self.inner.status_tx.subscribe()
+    }
+
+    pub fn subscribe_logs(&self) -> broadcast::Receiver<LogFrame> {
+        self.inner.log_tx.subscribe()
     }
 
     pub fn status(&self) -> CoreStatus {
@@ -549,7 +558,8 @@ impl CoreManager {
             epoch,
             controller,
             self.inner.options.cancel_token.clone(),
-        );
+        )
+        .log_sender(self.inner.log_tx.clone());
         if let Some(probe) = self.inner.probes.readiness.clone() {
             builder = builder.readiness_probe(probe);
         }

--- a/crates/nyanpasu-core-manager/tests/helpers/fake_core.rs
+++ b/crates/nyanpasu-core-manager/tests/helpers/fake_core.rs
@@ -29,6 +29,7 @@ struct Behavior {
     ready_delay_ms: u64,
     never_ready: bool,
     exit_code: Option<i32>,
+    stdout_lines: Vec<String>,
     stderr_lines: Vec<String>,
     crash_after_ms: u64,
     crash_times: u64,
@@ -62,6 +63,18 @@ fn b(doc: &Mapping, key: &str) -> bool {
         .unwrap_or(false)
 }
 
+fn lines(doc: &Mapping, key: &str) -> Vec<String> {
+    doc.get(Value::String(key.into()))
+        .and_then(Value::as_sequence)
+        .map(|seq| {
+            seq.iter()
+                .filter_map(Value::as_str)
+                .map(str::to_owned)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
 fn parse(config: &str) -> Behavior {
     let doc: Mapping = serde_yaml_ng::from_str(config).expect("valid yaml");
     let x = doc
@@ -82,16 +95,8 @@ fn parse(config: &str) -> Behavior {
             .get(Value::String("exit-code".into()))
             .and_then(Value::as_i64)
             .map(|c| c as i32),
-        stderr_lines: x
-            .get(Value::String("stderr-lines".into()))
-            .and_then(Value::as_sequence)
-            .map(|seq| {
-                seq.iter()
-                    .filter_map(Value::as_str)
-                    .map(str::to_owned)
-                    .collect()
-            })
-            .unwrap_or_default(),
+        stdout_lines: lines(&x, "stdout-lines"),
+        stderr_lines: lines(&x, "stderr-lines"),
         crash_after_ms: u(&x, "crash-after-ms"),
         crash_times: u(&x, "crash-times"),
         state_file: s(&x, "state-file"),
@@ -158,6 +163,9 @@ async fn main() {
         }
     }
 
+    for line in &behavior.stdout_lines {
+        println!("{line}");
+    }
     for line in &behavior.stderr_lines {
         eprintln!("{line}");
     }

--- a/crates/nyanpasu-core-manager/tests/instance_lifecycle.rs
+++ b/crates/nyanpasu-core-manager/tests/instance_lifecycle.rs
@@ -130,6 +130,34 @@ async fn immediate_exit_reports_stderr_tail() {
     }
 }
 
+/// mihomo and clash premium print their fatal record on stdout and leave stderr
+/// empty, so the diagnostic tail has to follow severity rather than the stream.
+#[tokio::test]
+async fn immediate_exit_reports_a_stdout_fatal() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let port = common::free_port();
+    let config = common::write_config(
+        &dir,
+        &format!(
+            "external-controller: 127.0.0.1:{port}\nx-fake-core:\n  exit-code: 1\n  stdout-lines:\n    - 'time=\"2026-07-29T00:17:26.518376100+08:00\" level=fatal msg=\"Parse config error: bad port\"'\n"
+        ),
+    );
+    let mut spec = common::mihomo_spec(&dir, config);
+    spec.options.restart_policy =
+        nyanpasu_utils::process::RestartPolicy::OnFailure { max_restarts: 1 };
+
+    let instance = Instance::spawn(spec, 1, http_controller(port), CancellationToken::new())
+        .await
+        .expect("spawn succeeds; the failure is the exit");
+    let err = instance.wait_ready().await.expect_err("must fail");
+    match err {
+        nyanpasu_core_manager::Error::StartupFailed { stderr_tail } => {
+            assert_eq!(stderr_tail, "Parse config error: bad port")
+        }
+        other => panic!("unexpected error: {other}"),
+    }
+}
+
 #[tokio::test]
 async fn crash_recovers_through_restart_and_reprobe() {
     let (_guard, dir) = common::utf8_tempdir();

--- a/crates/nyanpasu-core-manager/tests/manager_orchestration.rs
+++ b/crates/nyanpasu-core-manager/tests/manager_orchestration.rs
@@ -10,8 +10,8 @@ use std::{
 };
 
 use nyanpasu_core_manager::{
-    ControllerMode, CoreState, Error, HealthPolicy, HealthState, LocalIpcPolicy, ManagerOptions,
-    ProbeHandle, ProbeResult, StopReason, manager::CoreManager,
+    ControllerMode, CoreState, Error, HealthPolicy, HealthState, LocalIpcPolicy, LogLevel,
+    LogStream, ManagerOptions, ProbeHandle, ProbeResult, StopReason, manager::CoreManager,
 };
 
 async fn manager(runtime_dir: &camino::Utf8Path) -> CoreManager {
@@ -197,6 +197,44 @@ async fn start_publishes_running_and_rejects_double_start() {
     let err = manager.start(spec).await.expect_err("double start");
     assert!(matches!(err, Error::AlreadyRunning), "got {err}");
 
+    manager.shutdown().await.expect("shutdown");
+}
+
+#[tokio::test]
+async fn log_subscription_observes_startup_frames() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let port = common::free_port();
+    let config = common::write_config(
+        &dir,
+        &format!(
+            "external-controller: 127.0.0.1:{port}\nx-fake-core:\n  stdout-lines:\n    - 'time=\"2026-07-29T00:16:22.646059400+08:00\" level=info msg=\"startup frame\"'\n"
+        ),
+    );
+    let manager = manager(&dir).await;
+    // Subscribing before the first start must not miss the startup window.
+    let mut logs = manager.subscribe_logs();
+    manager
+        .start(common::mihomo_spec(&dir, config))
+        .await
+        .expect("start");
+
+    let frame = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            match logs.recv().await {
+                Ok(frame) if frame.message == "startup frame" => break frame,
+                Ok(_) | Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {}
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                    panic!("log channel closed")
+                }
+            }
+        }
+    })
+    .await
+    .expect("startup frame was never published");
+
+    assert_eq!(frame.epoch, 1);
+    assert_eq!(frame.level, LogLevel::Info);
+    assert_eq!(frame.stream, LogStream::Stdout);
     manager.shutdown().await.expect("shutdown");
 }
 

--- a/nyanpasu_ipc/Cargo.toml
+++ b/nyanpasu_ipc/Cargo.toml
@@ -25,11 +25,11 @@ axum = { version = "0.8", features = ["ws"], optional = true }
 axum-extra = { version = "0.12", features = ["typed-header"], optional = true }
 derive_builder = "0.20"
 futures-util = { workspace = true, optional = true }
-interprocess = { version = "2.3.1", features = ["tokio"] }
+interprocess = { version = "2.4.2", features = ["tokio"] }
 reqwest = { version = "0.13", features = ["json"], optional = true }
 reqwest-websocket = { version = "0.6.0", optional = true }
 serde = { workspace = true }
-specta = { version = "^2.0.0-rc.22", features = ["derive"], optional = true }
+specta = { version = "^2.0.0-rc.25", features = ["derive"], optional = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tower = { version = "0.5", features = ["util"], optional = true }


### PR DESCRIPTION
## Problem

The four supported cores each print a different console layout, **all of them on stdout**, and only meow keeps ANSI when writing to a pipe. `instance.rs` mapped stdout → `info` and stderr → `warn`, and kept a **stderr-only** 32-line tail.

Consequence: mihomo and clash premium print their fatal record on stdout and leave stderr empty, so `Error::StartupFailed { stderr_tail }` was **always an empty string** for those two cores. That is the defect this PR fixes.

Ground truth for every format was captured by running the real binaries in `tests/bin/` through a pipe, cross-checked against each core's upstream formatter source (and, for the closed-source clash premium, against a GoReSym + capstone reconstruction of its `PrettyPrint`).

## What changed

New `crates/nyanpasu-core-manager/src/log.rs`: a stateful, per-kind parser that strips **complete CSI sequences** before any semantic parsing and normalizes every line into one `LogFrame`:

```rust
pub struct LogFrame {
    pub epoch: u64,
    pub kind: CoreKind,
    pub stream: LogStream,
    pub timestamp: Option<LogTimestamp>,   // unix_ms + raw + inferred
    pub level: LogLevel,                   // Trace..Fatal, fatal/panic collapsed
    pub target: Option<String>,
    pub message: String,
    pub fields: Vec<clash_api::LogField>,
    pub raw: String,                       // ANSI-stripped, continuations included
    pub truncated: bool,
}
```

A line whose header does not match its kind **degrades to an unformatted frame** with a content-inferred level — the layer never drops a line.

| core | header | notes |
|------|--------|-------|
| mihomo | logfmt | escape-aware quoted values; the only kind with decidable field boundaries, so the only one that fills `fields` |
| clash premium | `HH:MM:SS LVL message` | no date printed → inferred from the observation instant with midnight-rollover rules; `[Tag]` is a message-prefix convention, extracted heuristically only |
| meow | tracing default layout | parsed after ANSI removal |
| clash-rs | `yy-MM-dd HH:mm:ss:<1-9 digit subsecond>` | second/subsecond separator is a **colon**, so no RFC3339 parser applies; header ends at the first `file:line` anchor, which skips the debug-build `ThreadId(N)` / target segments |

Multi-line records (Go stacks, clash-rs's three-line stderr block) attach to their root **within one stream only**, bounded to 16 lines / 16 KiB with a `truncated` flag; overflow lines are discarded rather than emitted as separate frames, so a long goroutine dump cannot push the real fatal root out of the tail.

Integration changes:

- `Shared` keeps a **32-frame tail across both streams** — the startup diagnostic now follows severity, not the stream.
- Frames are broadcast on a channel the **manager owns across epochs**, so callers can `subscribe_logs()` *before* `start()` and keep receiving across restarts and core switches (`Instance::subscribe_logs` / `CoreManager::subscribe_logs`).
- Pending records are flushed on `Terminated`, on `finish()`, when diagnostics are read, **and on every terminal publication** — `ProcessEvent::Terminated` is documented as best-effort, and the clean-exit / user-stop arms never read diagnostics.
- `kind::parse_check_output` and the old `error_summary` are replaced by a frame-based summary, which also removes the `ClashRust` special case in `check_config`.
- `CLICOLOR_FORCE=0` is injected on **both** spawn paths, so logrus cannot flip mihomo into its colored layout (`EnvironmentOverrideColors: true` in mihomo's `log/log.go`) and change the format out from under the parser.

## Compatibility

`Error::{StartupFailed, StartupTimeout}` keep the `stderr_tail` **field name** so existing match patterns still compile; only the `Display` wording changes to "diagnostic log tail". Everything else is additive. Following the existing `state.rs` convention, the new types derive no `serde`/`specta`/`schemars` — that can be added when a real IPC consumer lands.

## Testing

`cargo test -p nyanpasu-core-manager` — **141 passed, 0 failed** (23 ignored are the real-core suites that need binaries in `tests/bin/`). `cargo clippy --all-targets -- -D warnings` clean.

Unit tests assert every literal sample line captured from the real binaries: both meow ANSI samples, mihomo escaped-quote logfmt, mihomo's colored layout (must degrade, not drop), premium `INF`/`FTL`/`???` and midnight rollover in both directions, clash-rs 6- and 7-digit subseconds plus the debug-build shape with `ThreadId(1)`, Windows backslash paths, the three-line clash-rs stderr block collapsing into one frame, a premium stack staying attached to its record, and an oversized panic stack keeping its root with `truncated == true`.

Two new integration tests: a stdout-only mihomo fatal now yields a meaningful `StartupFailed` (this is the regression test for the bug above), and a log subscription taken before `start()` observes startup frames.

## Review

Both review models were run against the applied change. Four findings were raised and **all four fixed** in this branch:

1. clash-rs source anchoring searched right-to-left, so a `file:line`-shaped reference inside the message won over the real header anchor — *independently reported by both models*.
2. clash-rs header validation checked separators but not the numeric slots or the trailing space, so a similarly shaped continuation line could be misread as a new root and evict a pending fatal block.
3. `publish_terminal` did not flush on the clean-exit / user-stop arms, so a held fatal frame could never reach subscribers.
4. `finish()` released pending roots in fixed stdout-then-stderr order, which could invert "latest within severity" when both streams held one.

## Follow-ups (not in this PR)

- [ ] Run `--test real_cores -- --ignored` against the four real binaries to confirm the parsers on live output.
- [ ] The clash-rs debug-build sample is hand-constructed; worth confirming once against an actual debug build.
