### PR TITLE
feat: IPC protocol evolution (S7-S10) — service-client / core-manager capability parity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3181,6 +3181,7 @@ dependencies = [
  "chrono",
  "indexmap",
  "rustc_version",
+ "serde_json",
  "specta-macros",
  "url",
  "uuid",

--- a/crates/nyanpasu-core-manager/README.md
+++ b/crates/nyanpasu-core-manager/README.md
@@ -477,7 +477,9 @@ needed to eliminate that residual gap.
 
 ### One-shot config validation
 
-Runs the core with `-t` and condenses a failure into `Error::ConfigCheckFailed`:
+Runs the core with `-t` and condenses a failure into `Error::ConfigCheckFailed`.
+A run that exceeds `kind::CHECK_CONFIG_TIMEOUT` (30s) is killed, process tree
+included, and reported as the same error with a message naming the bound:
 
 ```rust
 manager.check_config(spec).await?;

--- a/crates/nyanpasu-core-manager/README.md
+++ b/crates/nyanpasu-core-manager/README.md
@@ -14,7 +14,7 @@ Key concepts:
   `ConfigRevision` identifies desired config within that epoch by generation
   and semantic hashes. Fully expressible changes can PATCH or reload the
   current epoch; switch-class changes allocate a new epoch.
-- **Manager-owned snapshots** — both controller modes run from a private,
+- **Manager-owned snapshots** — every controller policy runs from a private,
   stable `config-{epoch}.yaml`, never directly from the caller's mutable file.
   Supervisor respawns therefore reload the committed desired revision.
 - **Health-probed startup and runtime status** — a start is only confirmed once
@@ -25,10 +25,10 @@ Key concepts:
 - **Supervision** — crash → backoff → respawn → re-probe, bounded by
   `RestartPolicy`/`Backoff` from `nyanpasu-utils`. Dropping an `Instance`
   without `stop()` kills the whole process tree.
-- **Controller modes** — `Passthrough` preserves the endpoint written in the
-  snapshot. `Managed` selects local IPC according to `LocalIpcPolicy`: `Force`
-  requires it, `Prefer` falls back to the upstream-prepared HTTP controller
-  when unsupported, and `Disable` always uses that HTTP controller. Selecting
+- **Controller transport policy** — `LocalIpcPolicy` decides how the core's
+  control plane is reached: `Force` requires the platform-local transport,
+  `Prefer` falls back to the source config's HTTP controller when the core does
+  not support it, and `Disable` always uses that HTTP controller. Selecting
   local IPC removes all configured controller addresses and inserts only the
   epoch-specific platform-local key. It retains `secret` for effective-config
   compatibility, but local clients do not use it for authentication. The HTTP
@@ -36,14 +36,15 @@ Key concepts:
 
 ## Requirements on the config
 
-The config must declare an external controller whenever Passthrough or a
-Managed HTTP path (`Prefer` fallback or `Disable`) can be selected; the
-upstream caller owns that HTTP address and secret. `external-controller-pipe`
-(Windows) / `external-controller-unix` (Unix) take priority in Passthrough.
-Managed HTTP paths inspect only `external-controller`; a config with only a
-local key is rejected as missing its required HTTP controller. Wildcard HTTP
-binds (`0.0.0.0`, `::`, `:port`) are probed via loopback. For mihomo, the
-manager sets `SAFE_PATHS` to the working dir plus the config dir.
+The config must declare `external-controller` whenever an HTTP path can be
+selected (`Disable`, or a `Prefer` fallback); the upstream caller owns that
+address and secret. Only `external-controller` is read on those paths — a
+config that declares just `external-controller-pipe` (Windows) or
+`external-controller-unix` (Unix) is rejected as missing its required HTTP
+controller, because a caller-declared local path is not a channel the manager
+can own across overlapping epochs. Wildcard HTTP binds (`0.0.0.0`, `::`,
+`:port`) are probed via loopback. For mihomo, the manager sets `SAFE_PATHS` to
+the working dir plus the config dir.
 
 ## Instance state machine
 
@@ -128,7 +129,7 @@ sequenceDiagram
     participant C as Core process
 
     App->>M: start(spec)
-    M->>M: prepare(): inspect (Passthrough) or derive (Managed) config,<br/>resolve probe controller
+    M->>M: prepare(): preserve HTTP or derive local-IPC config,<br/>resolve probe controller
     M->>I: spawn(spec, N, controller)
     I->>S: spawn(-m -d dir -f cfg, SAFE_PATHS=…)
     S->>C: exec
@@ -167,7 +168,7 @@ kill/restart an epoch directly from the probe driver.
 
 ### Graceful switch
 
-Selected only when Managed mode resolves to a per-epoch local controller and
+Selected only when the policy resolves to a per-epoch local controller and
 every inbound is provably zeroable and restorable. A `Prefer` HTTP fallback or
 `Disable` uses a hard switch because both epochs would otherwise bind the same
 upstream HTTP controller. The old core keeps serving while the new one starts
@@ -207,8 +208,7 @@ cleanly: the old core is untouched and `Running` is re-published.
 | Condition | Outcome |
 | --- | --- |
 | No core currently running | plain start, `Hard { NotRunning }` |
-| `ControllerMode::Passthrough` | `Hard { PassthroughMode }` |
-| Managed mode resolves to the upstream HTTP controller | `Hard { HttpController }` |
+| The policy resolved to the source config's HTTP controller | `Hard { HttpController }` |
 | Core kind is not mihomo | `Hard { UnsupportedKind }` |
 | Config sets `dns.listen` | `Hard { DnsListen }` |
 | Another inbound cannot be proven safe for overlap | `Hard { InboundConflict }` |
@@ -222,7 +222,7 @@ warning while treating the nested outcome as the reconciled result.
 
 ## Usage
 
-### Start and stop (Passthrough)
+### Start and stop (HTTP controller)
 
 ```rust
 use camino::Utf8PathBuf;
@@ -247,7 +247,7 @@ let spec = InstanceSpec {
 let manager = CoreManager::new(ManagerOptions {
     runtime_dir: Some(Utf8PathBuf::from("/run/nyanpasu/core-runtime")),
     ..ManagerOptions::default()
-}).await?; // Passthrough controller, manager-owned runtime snapshot
+}).await?; // LocalIpcPolicy::Disable by default: the config's controller, as-is
 manager.start(spec).await?; // resolves once the version probe passes
 manager.stop().await?;
 ```
@@ -315,23 +315,21 @@ and must set `kill_on_drop(true)` so the child dies with the future.
 instance instead, `Instance::builder(spec, epoch, controller, parent)` exposes
 the same three methods before `.spawn()`.
 
-### Managed mode + graceful switch
+### Local IPC + graceful switch
 
 ```rust
 use camino::Utf8PathBuf;
 use nyanpasu_core_manager::{
-    ControllerMode, CoreManager, LocalIpcPolicy, ManagerOptions, SwitchOutcome,
+    CoreManager, LocalIpcPolicy, ManagerOptions, SwitchOutcome,
 };
 use tokio_util::sync::CancellationToken;
 
 let manager = CoreManager::new(ManagerOptions {
-    controller_mode: ControllerMode::Managed {
-        derived_dir: Utf8PathBuf::from("/run/nyanpasu/derived"),
-        // None → \\.\pipe\nyanpasu\core-{epoch} on Windows,
-        //        <derived_dir>/core-{epoch}.sock elsewhere
-        controller_template: None,
-        local_ipc_policy: LocalIpcPolicy::Force,
-    },
+    runtime_dir: Some(Utf8PathBuf::from("/run/nyanpasu/core-runtime")),
+    local_ipc_policy: LocalIpcPolicy::Force,
+    // None → \\.\pipe\nyanpasu\core-{epoch} on Windows,
+    //        <runtime_dir>/core-{epoch}.sock elsewhere
+    controller_template: None,
     cancel_token: CancellationToken::new(),
     ..ManagerOptions::default()
 }).await?;
@@ -360,10 +358,9 @@ local transports and is kept only for effective-config compatibility with the
 pre-policy behavior. The manager warns without exposing that secret, and
 callers can observe the selected channel through `CoreStatus`.
 
-The manager writes `config-{N}.yaml` and `core-{N}.pid` in its runtime
-directory. Managed mode may use `derived_dir` as the compatibility runtime-dir
-alias; Passthrough requires `runtime_dir` explicitly. The advertised endpoint
-is available as `CoreStatus.controller` in both modes.
+The manager writes `config-{N}.yaml` and `core-{N}.pid` in `runtime_dir`, which
+is required. The advertised endpoint is available as `CoreStatus.controller`
+under every policy.
 
 Managed endpoints are per-kind: mihomo and clash-rs (new enough versions) take
 a named pipe / unix socket, clash premium and meow are HTTP-only. clash-rs is

--- a/crates/nyanpasu-core-manager/src/capability.rs
+++ b/crates/nyanpasu-core-manager/src/capability.rs
@@ -13,7 +13,7 @@ use specta::Type;
 
 use crate::{
     Error,
-    spec::{ControllerMode, CoreSpec, LocalIpcPolicy},
+    spec::{CoreSpec, LocalIpcPolicy},
 };
 
 /// Functionality the manager actually enabled for an epoch.
@@ -123,7 +123,7 @@ async fn probe_version(binary_path: &camino::Utf8Path) -> Result<String, Error> 
 pub(crate) async fn resolve_features(
     cache: &VersionCache,
     core: &CoreSpec,
-    mode: &ControllerMode,
+    policy: LocalIpcPolicy,
 ) -> Result<ResolvedFeatures, Error> {
     let (capabilities, version) = if core.kind.potential_features().is_empty() {
         (EnumSet::new(), core.version.clone())
@@ -134,7 +134,7 @@ pub(crate) async fn resolve_features(
             Some(version),
         )
     };
-    let runtime = resolve_runtime(mode, core, capabilities, version.as_deref())?;
+    let runtime = resolve_runtime(policy, core, capabilities, version.as_deref())?;
     Ok(ResolvedFeatures {
         capabilities,
         runtime,
@@ -146,19 +146,13 @@ pub(crate) async fn resolve_features(
 /// — before any config is staged, checked, or spawned — when the core cannot
 /// satisfy the platform transport.
 fn resolve_runtime(
-    mode: &ControllerMode,
+    policy: LocalIpcPolicy,
     core: &CoreSpec,
     capabilities: EnumSet<Feature>,
     resolved_version: Option<&str>,
 ) -> Result<EnumSet<RuntimeFeature>, Error> {
-    let ControllerMode::Managed {
-        local_ipc_policy, ..
-    } = mode
-    else {
-        return Ok(EnumSet::new());
-    };
     let local_supported = capabilities.contains(crate::config::LOCAL_TRANSPORT_FEATURE);
-    match (*local_ipc_policy, local_supported) {
+    match (policy, local_supported) {
         (LocalIpcPolicy::Force, false) => Err(Error::RequiredLocalIpcUnsupported {
             kind: core.kind,
             version: resolved_version

--- a/crates/nyanpasu-core-manager/src/config/mod.rs
+++ b/crates/nyanpasu-core-manager/src/config/mod.rs
@@ -16,11 +16,7 @@ use serde_yaml_ng::{Mapping, Value};
 
 pub(crate) use clash::LOCAL_TRANSPORT_FEATURE;
 
-use crate::{
-    capability::RuntimeFeature,
-    error::Error,
-    spec::{ControllerMode, ResolvedController},
-};
+use crate::{capability::RuntimeFeature, error::Error, spec::ResolvedController};
 
 #[derive(Debug, Clone)]
 pub(crate) struct ConfigSnapshot {
@@ -90,27 +86,27 @@ impl ConfigSnapshot {
 
     pub(crate) fn prepare_full(
         &self,
-        mode: &ControllerMode,
+        controller_template: Option<&str>,
         runtime_dir: &Utf8Path,
         epoch: u64,
         runtime: EnumSet<RuntimeFeature>,
     ) -> Result<PreparedConfig, Error> {
-        self.prepare(mode, runtime_dir, epoch, runtime, false)
+        self.prepare(controller_template, runtime_dir, epoch, runtime, false)
     }
 
     pub(crate) fn prepare_bootstrap(
         &self,
-        mode: &ControllerMode,
+        controller_template: Option<&str>,
         runtime_dir: &Utf8Path,
         epoch: u64,
         runtime: EnumSet<RuntimeFeature>,
     ) -> Result<PreparedConfig, Error> {
-        self.prepare(mode, runtime_dir, epoch, runtime, true)
+        self.prepare(controller_template, runtime_dir, epoch, runtime, true)
     }
 
     fn prepare(
         &self,
-        mode: &ControllerMode,
+        controller_template: Option<&str>,
         runtime_dir: &Utf8Path,
         epoch: u64,
         runtime: EnumSet<RuntimeFeature>,
@@ -122,29 +118,24 @@ impl ConfigSnapshot {
             mihomo::zero_inbounds(&mut document);
         }
 
-        let (rewrote_controller, inspect_http_only) = match mode {
-            ControllerMode::Passthrough => (false, false),
-            ControllerMode::Managed {
-                controller_template,
-                ..
-            } => {
-                let rewrite = runtime.contains(RuntimeFeature::LocalIpc);
-                if rewrite {
-                    let endpoint =
-                        managed_endpoint_path(runtime_dir, controller_template.as_deref(), epoch)?;
-                    clash::rewrite_managed_controller(&mut document, endpoint);
-                }
-                (rewrite, !rewrite)
-            }
-        };
+        // `RuntimeFeature::LocalIpc` is the single source of truth: the policy
+        // was already weighed in `capability::resolve_runtime`. Without it the
+        // source config's controller stays authoritative, and only
+        // `external-controller` is read — a user-declared pipe or socket path
+        // is not a channel this manager can own across epochs.
+        let rewrote_controller = runtime.contains(RuntimeFeature::LocalIpc);
+        if rewrote_controller {
+            let endpoint = managed_endpoint_path(runtime_dir, controller_template, epoch)?;
+            clash::rewrite_managed_controller(&mut document, endpoint);
+        }
 
         let Value::Mapping(document) = canonicalize(Value::Mapping(document))? else {
             unreachable!("canonical mapping remains a mapping")
         };
-        let info = if inspect_http_only {
-            clash::inspect_http(&document)
-        } else {
+        let info = if rewrote_controller {
             clash::inspect(&document)
+        } else {
+            clash::inspect_http(&document)
         };
         let controller = resolve_controller(&info)?;
         let bytes = serialize_mapping(&document)?;
@@ -314,19 +305,14 @@ mod tests {
     }
 
     #[test]
-    fn managed_http_path_ignores_a_configured_local_controller() {
+    fn the_http_path_ignores_a_configured_local_controller() {
         #[cfg(windows)]
         let source = snapshot(r"external-controller-pipe: \\.\pipe\source");
         #[cfg(not(windows))]
         let source = snapshot("external-controller-unix: /tmp/source.sock");
-        let mode = ControllerMode::Managed {
-            derived_dir: Utf8PathBuf::from("runtime"),
-            controller_template: None,
-            local_ipc_policy: crate::LocalIpcPolicy::Disable,
-        };
 
         let error = source
-            .prepare_full(&mode, Utf8Path::new("runtime"), 1, EnumSet::new())
+            .prepare_full(None, Utf8Path::new("runtime"), 1, EnumSet::new())
             .unwrap_err();
 
         assert!(matches!(error, Error::ControllerMissing));
@@ -354,14 +340,9 @@ mod tests {
         let source = snapshot(
             "mixed-port: 7890\nexternal-controller: 127.0.0.1:9090\nsecret: sc\ntun:\n  enable: true\n",
         );
-        let mode = ControllerMode::Managed {
-            derived_dir: Utf8PathBuf::from("runtime"),
-            controller_template: Some(r"\\.\pipe\ny-{epoch}".into()),
-            local_ipc_policy: crate::LocalIpcPolicy::Force,
-        };
         let prepared = source
             .prepare_bootstrap(
-                &mode,
+                Some(r"\\.\pipe\ny-{epoch}"),
                 Utf8Path::new("runtime"),
                 7,
                 EnumSet::only(RuntimeFeature::LocalIpc),

--- a/crates/nyanpasu-core-manager/src/kind.rs
+++ b/crates/nyanpasu-core-manager/src/kind.rs
@@ -1,8 +1,9 @@
 //! Core kinds, launch profiles, and config checking.
 
-use std::ffi::OsString;
+use std::{ffi::OsString, time::Duration};
 
 use camino::Utf8Path;
+use nyanpasu_utils::process::ProcessError;
 
 use crate::{error::Error, log::summarize_output};
 
@@ -74,9 +75,37 @@ pub fn mihomo_safe_paths(working_dir: &Utf8Path, config_dir: &Utf8Path) -> Strin
     [working_dir.as_str(), config_dir.as_str()].join(SAFE_PATHS_SEPARATOR)
 }
 
+/// Upper bound on a single `-t` validation run.
+///
+/// A `-t` run parses a config and exits; it never serves traffic, so a core that
+/// has not answered in this long is wedged, not slow. The bound covers every
+/// caller — `/core/check`, the staged check inside `apply_config`
+/// (`manager/apply.rs:174`) and the pre-flight checks on the start and switch
+/// paths (`manager/switching.rs:431,492,496`, which run while the control lock
+/// is held) — and sits far enough under the service's 120s request bound
+/// (`routing/middleware.rs:31`) that the caller receives this error rather than
+/// a dropped future.
+pub const CHECK_CONFIG_TIMEOUT: Duration = Duration::from_secs(30);
+
 /// One-shot `-t` config validation, replacing the legacy `check_config_`.
-/// A non-zero exit becomes [`Error::ConfigCheckFailed`] with a condensed message.
+/// A non-zero exit becomes [`Error::ConfigCheckFailed`] with a condensed message,
+/// and so does a run that exceeds [`CHECK_CONFIG_TIMEOUT`].
 pub async fn check_config(spec: &crate::spec::InstanceSpec) -> Result<(), Error> {
+    run_check(spec, CHECK_CONFIG_TIMEOUT).await
+}
+
+/// [`check_config`] with an explicit bound. Public only under `test-hooks`:
+/// production has exactly one bound, and a test that had to wait
+/// [`CHECK_CONFIG_TIMEOUT`] to observe the timeout would not be worth running.
+#[cfg(feature = "test-hooks")]
+pub async fn check_config_within(
+    spec: &crate::spec::InstanceSpec,
+    timeout: Duration,
+) -> Result<(), Error> {
+    run_check(spec, timeout).await
+}
+
+async fn run_check(spec: &crate::spec::InstanceSpec, timeout: Duration) -> Result<(), Error> {
     let config_dir = spec
         .config_path
         .parent()
@@ -88,8 +117,20 @@ pub async fn check_config(spec: &crate::spec::InstanceSpec) -> Result<(), Error>
             mihomo_safe_paths(&spec.working_dir, config_dir),
         )
         .env(CLICOLOR_FORCE_ENV_NAME, "0")
+        .timeout(timeout)
         .output()
-        .await?;
+        .await
+        .map_err(|error| match error {
+            // The process tree is already killed by the time this arrives
+            // (`Command::timeout`). Reported as a check failure rather than a
+            // process error because that is what the caller asked about: the
+            // config did not validate. Same wire kind (`config_check_failed`),
+            // and the message names the bound so a slow core is diagnosable.
+            ProcessError::Timeout { after } => {
+                Error::ConfigCheckFailed(format!("config check timed out after {after:?}"))
+            }
+            other => Error::Process(other),
+        })?;
     if output.success() {
         return Ok(());
     }

--- a/crates/nyanpasu-core-manager/src/lib.rs
+++ b/crates/nyanpasu-core-manager/src/lib.rs
@@ -32,8 +32,7 @@ pub use runtime_store::{
     StagedRuntimeConfig,
 };
 pub use spec::{
-    ControllerMode, CoreSpec, InstanceOptions, InstanceSpec, LocalIpcPolicy, ManagerOptions,
-    ResolvedController,
+    CoreSpec, InstanceOptions, InstanceSpec, LocalIpcPolicy, ManagerOptions, ResolvedController,
 };
 pub use state::{
     ConfigRevision, CoreState, CoreStatus, HealthState, HealthStatus, InstanceState,

--- a/crates/nyanpasu-core-manager/src/manager/apply.rs
+++ b/crates/nyanpasu-core-manager/src/manager/apply.rs
@@ -158,7 +158,7 @@ impl CoreManager {
         let resolved = self.resolve_features(&input.core).await?;
         let epoch = current.revision.epoch;
         let prepared = snapshot.prepare_full(
-            &self.inner.options.controller_mode,
+            self.inner.options.controller_template.as_deref(),
             self.inner.store.dir(),
             epoch,
             resolved.runtime,
@@ -528,7 +528,7 @@ impl CoreManager {
                 if let Err(error) = self.inner.store.cleanup_epoch(old_epoch).await {
                     tracing::warn!("failed to clean switched-out epoch: {error}");
                 }
-                Ok(ApplyOutcome::Restarted { revision })
+                Ok(ApplyOutcome::Switched { revision })
             }
             Err(error @ Error::StopUnconfirmed(_)) => {
                 Err(self.latch_quarantine(ctrl, desired.revision.epoch, error))

--- a/crates/nyanpasu-core-manager/src/manager/mod.rs
+++ b/crates/nyanpasu-core-manager/src/manager/mod.rs
@@ -24,9 +24,7 @@ use crate::{
     log::{LOG_CHANNEL_CAPACITY, LogFrame},
     probe::ProbeHandle,
     runtime_store::{RuntimeConfigStore, RuntimeDirectoryLock, StagedRuntimeConfig},
-    spec::{
-        ControllerMode, CoreSpec, InstanceSpec, LocalIpcPolicy, ManagerOptions, ResolvedController,
-    },
+    spec::{CoreSpec, InstanceSpec, LocalIpcPolicy, ManagerOptions, ResolvedController},
     state::{ConfigRevision, CoreState, CoreStatus, InstanceStatus, StopReason},
 };
 
@@ -36,7 +34,6 @@ use quarantine::{reject_quarantine, sweep_orphans};
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DegradeReason {
     NotRunning,
-    PassthroughMode,
     UnsupportedKind,
     DnsListen,
     InboundConflict,
@@ -68,6 +65,12 @@ pub enum ApplyOutcome {
         revision: ConfigRevision,
     },
     Restarted {
+        revision: ConfigRevision,
+    },
+    /// The process spec itself changed (a different core, binary, or launch
+    /// option), so the old epoch was stopped and a new one started. Distinct
+    /// from [`Self::Restarted`], which replaces the process inside one epoch.
+    Switched {
         revision: ConfigRevision,
     },
     RolledBack {
@@ -203,25 +206,18 @@ impl CoreManager {
 
     async fn build_configured(builder: CoreManagerBuilder) -> Result<Self, Error> {
         let CoreManagerBuilder { options, probes } = builder;
-        let runtime_dir = match (&options.runtime_dir, &options.controller_mode) {
-            (Some(runtime_dir), _) => runtime_dir.clone(),
-            (None, ControllerMode::Managed { derived_dir, .. }) => derived_dir.clone(),
-            (None, ControllerMode::Passthrough) => {
-                return Err(Error::InvalidManagerOptions(
-                    "Passthrough mode requires runtime_dir".into(),
-                ));
-            }
-        };
+        let runtime_dir = options
+            .runtime_dir
+            .clone()
+            .ok_or_else(|| Error::InvalidManagerOptions("runtime_dir is required".into()))?;
         let store = RuntimeConfigStore::new(runtime_dir).await?;
         let runtime_lock = store.acquire_ownership().await?;
 
-        if let ControllerMode::Managed {
-            controller_template,
-            ..
-        } = &options.controller_mode
-        {
-            config::managed_endpoint_path(store.dir(), controller_template.as_deref(), 0)?;
-        }
+        // Validated under every policy: a template that cannot produce an
+        // endpoint is a configuration error whether or not this core ends up
+        // selecting local IPC, and construction is the caller's last chance to
+        // fix it.
+        config::managed_endpoint_path(store.dir(), options.controller_template.as_deref(), 0)?;
         for (name, timeout) in [
             ("control_timeout", options.control_timeout),
             ("reconcile_timeout", options.reconcile_timeout),
@@ -467,7 +463,7 @@ impl CoreManager {
         crate::capability::resolve_features(
             &self.inner.version_cache,
             core,
-            &self.inner.options.controller_mode,
+            self.inner.options.local_ipc_policy,
         )
         .await
     }
@@ -478,13 +474,7 @@ impl CoreManager {
         resolved_version: Option<&str>,
         rewrote_controller: bool,
     ) {
-        let ControllerMode::Managed {
-            local_ipc_policy, ..
-        } = &self.inner.options.controller_mode
-        else {
-            return;
-        };
-        if *local_ipc_policy == LocalIpcPolicy::Prefer && !rewrote_controller {
+        if self.inner.options.local_ipc_policy == LocalIpcPolicy::Prefer && !rewrote_controller {
             tracing::warn!(
                 kind = %core.kind,
                 version = resolved_version.or(core.version.as_deref()).unwrap_or("unknown"),

--- a/crates/nyanpasu-core-manager/src/manager/switching.rs
+++ b/crates/nyanpasu-core-manager/src/manager/switching.rs
@@ -9,7 +9,7 @@ use crate::{
     instance::Instance,
     kind::CoreKind,
     probe::ProbePhase,
-    spec::{ControllerMode, InstanceSpec, ResolvedController},
+    spec::{InstanceSpec, ResolvedController},
     state::{ConfigRevision, CoreState},
 };
 
@@ -22,14 +22,10 @@ use super::{
 };
 
 fn graceful_degrade_reason(
-    managed: bool,
     local_controller: bool,
     kind: CoreKind,
     overlap_block: Option<OverlapBlock>,
 ) -> Option<DegradeReason> {
-    if !managed {
-        return Some(DegradeReason::PassthroughMode);
-    }
     if !local_controller {
         return Some(DegradeReason::HttpController);
     }
@@ -91,15 +87,10 @@ impl CoreManager {
         }
 
         let snapshot = ConfigSnapshot::load(&spec.config_path).await?;
-        let managed = matches!(
-            self.inner.options.controller_mode,
-            ControllerMode::Managed { .. }
-        );
         self.validate_launchable(&spec).await?;
         let resolved = self.resolve_features(&spec.core).await?;
         let local_controller = resolved.runtime.contains(RuntimeFeature::LocalIpc);
         match graceful_degrade_reason(
-            managed,
             local_controller,
             spec.core.kind,
             mihomo::overlap_block(snapshot.document()),
@@ -423,7 +414,7 @@ impl CoreManager {
     ) -> Result<PreparedLaunch, Error> {
         debug_assert_eq!(snapshot.source_path(), spec.config_path);
         let prepared = snapshot.prepare_full(
-            &self.inner.options.controller_mode,
+            self.inner.options.controller_template.as_deref(),
             self.inner.store.dir(),
             epoch,
             resolved.runtime,
@@ -470,13 +461,13 @@ impl CoreManager {
     ) -> Result<PreparedGraceful, Error> {
         debug_assert_eq!(snapshot.source_path(), spec.config_path);
         let full = snapshot.prepare_full(
-            &self.inner.options.controller_mode,
+            self.inner.options.controller_template.as_deref(),
             self.inner.store.dir(),
             epoch,
             resolved.runtime,
         )?;
         let bootstrap = snapshot.prepare_bootstrap(
-            &self.inner.options.controller_mode,
+            self.inner.options.controller_template.as_deref(),
             self.inner.store.dir(),
             epoch,
             resolved.runtime,
@@ -588,24 +579,21 @@ mod tests {
     #[test]
     fn switch_matrix_matches_the_spec() {
         assert_eq!(
-            graceful_degrade_reason(false, false, CoreKind::Mihomo, None),
-            Some(DegradeReason::PassthroughMode)
-        );
-        assert_eq!(
-            graceful_degrade_reason(true, true, CoreKind::ClashRust, None),
-            Some(DegradeReason::UnsupportedKind)
-        );
-        assert_eq!(
-            graceful_degrade_reason(true, true, CoreKind::Mihomo, Some(OverlapBlock::DnsListen)),
-            Some(DegradeReason::DnsListen)
-        );
-        assert_eq!(
-            graceful_degrade_reason(true, false, CoreKind::Mihomo, None),
+            graceful_degrade_reason(false, CoreKind::Mihomo, None),
             Some(DegradeReason::HttpController)
         );
         assert_eq!(
-            graceful_degrade_reason(true, true, CoreKind::Mihomo, None),
-            None
+            graceful_degrade_reason(true, CoreKind::ClashRust, None),
+            Some(DegradeReason::UnsupportedKind)
         );
+        assert_eq!(
+            graceful_degrade_reason(true, CoreKind::Mihomo, Some(OverlapBlock::DnsListen)),
+            Some(DegradeReason::DnsListen)
+        );
+        assert_eq!(
+            graceful_degrade_reason(true, CoreKind::Mihomo, Some(OverlapBlock::InboundSurface)),
+            Some(DegradeReason::InboundConflict)
+        );
+        assert_eq!(graceful_degrade_reason(true, CoreKind::Mihomo, None), None);
     }
 }

--- a/crates/nyanpasu-core-manager/src/spec.rs
+++ b/crates/nyanpasu-core-manager/src/spec.rs
@@ -56,13 +56,17 @@ pub struct ResolvedController {
     pub secret: Option<String>,
 }
 
-/// How managed mode selects the core's primary controller transport.
+/// How the manager selects the core's primary controller transport.
+///
+/// This is the manager's only controller knob. Local IPC means a manager-owned,
+/// epoch-parameterized named pipe (Windows) or Unix socket (elsewhere) written
+/// into the effective config; the HTTP paths keep the `external-controller`
+/// address the source config declares, untouched.
 #[non_exhaustive]
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LocalIpcPolicy {
     /// Require local IPC and fail startup or switching when the core does not
     /// support the platform transport.
-    #[default]
     Force,
     /// Use local IPC when supported; otherwise use the HTTP controller from
     /// the source config.
@@ -72,31 +76,17 @@ pub enum LocalIpcPolicy {
     Disable,
 }
 
-/// How the manager learns and controls the core's external controller.
-#[non_exhaustive]
-#[derive(Debug, Clone, Default)]
-pub enum ControllerMode {
-    /// Start the config as-is; extract the probe endpoint from it.
-    #[default]
-    Passthrough,
-    /// Use a manager-owned, epoch-parameterized local transport when selected
-    /// by policy; otherwise retain the config's HTTP controller.
-    Managed {
-        /// Where derived configs (and default unix sockets) live.
-        derived_dir: camino::Utf8PathBuf,
-        /// Endpoint template containing `{epoch}`; platform default when `None`.
-        controller_template: Option<String>,
-        /// Whether local IPC is required, preferred, or disabled.
-        local_ipc_policy: LocalIpcPolicy,
-    },
-}
-
 #[derive(Debug, Clone)]
 pub struct ManagerOptions {
-    pub controller_mode: ControllerMode,
-    /// Manager-owned runtime artifact directory. Required for Passthrough;
-    /// Managed mode falls back to `derived_dir` for compatibility.
+    /// Manager-owned runtime artifact directory: effective configs, pid files,
+    /// and by default the epoch-scoped Unix sockets. Required.
     pub runtime_dir: Option<Utf8PathBuf>,
+    /// Whether local IPC is required, preferred, or disabled.
+    pub local_ipc_policy: LocalIpcPolicy,
+    /// Endpoint template containing `{epoch}`; platform default when `None`.
+    /// Only consulted when the policy selects local IPC, but validated at
+    /// construction under every policy.
+    pub controller_template: Option<String>,
     pub control_timeout: Duration,
     pub reconcile_timeout: Duration,
     pub stop_timeout: Duration,
@@ -106,8 +96,13 @@ pub struct ManagerOptions {
 impl Default for ManagerOptions {
     fn default() -> Self {
         Self {
-            controller_mode: ControllerMode::default(),
             runtime_dir: None,
+            // The behavioural successor of the removed passthrough default:
+            // the source config's HTTP controller is authoritative and is
+            // never rewritten. Callers that want the epoch-scoped local
+            // transport ask for it.
+            local_ipc_policy: LocalIpcPolicy::Disable,
+            controller_template: None,
             control_timeout: Duration::from_secs(10),
             reconcile_timeout: Duration::from_secs(30),
             stop_timeout: Duration::from_secs(10),
@@ -133,5 +128,16 @@ mod tests {
             o.restart_policy,
             RestartPolicy::OnFailure { max_restarts: 5 }
         );
+    }
+
+    /// The compatibility pin for S10: `ManagerOptions::default()` must keep the
+    /// removed passthrough behavior — the source config's HTTP controller,
+    /// never rewritten.
+    #[test]
+    fn manager_options_default_to_the_non_rewriting_policy() {
+        let o = ManagerOptions::default();
+        assert_eq!(o.local_ipc_policy, LocalIpcPolicy::Disable);
+        assert!(o.controller_template.is_none());
+        assert!(o.runtime_dir.is_none());
     }
 }

--- a/crates/nyanpasu-core-manager/tests/capabilities.rs
+++ b/crates/nyanpasu-core-manager/tests/capabilities.rs
@@ -9,8 +9,8 @@ use std::{
 
 use camino::{Utf8Path, Utf8PathBuf};
 use nyanpasu_core_manager::{
-    ControllerMode, CoreKind, CoreManager, CoreState, Error, Feature, Host, LocalIpcPolicy,
-    ManagerOptions, RuntimeFeature,
+    CoreKind, CoreManager, CoreState, Error, Feature, Host, LocalIpcPolicy, ManagerOptions,
+    RuntimeFeature,
 };
 
 fn unique_template() -> Option<String> {
@@ -25,17 +25,15 @@ fn unique_template() -> Option<String> {
     }
     #[cfg(not(windows))]
     {
-        None
+        None // unix default derives the socket under the runtime dir (already unique)
     }
 }
 
-async fn managed_manager(runtime_dir: Utf8PathBuf, policy: LocalIpcPolicy) -> CoreManager {
+async fn manager_with_policy(runtime_dir: Utf8PathBuf, policy: LocalIpcPolicy) -> CoreManager {
     CoreManager::new(ManagerOptions {
-        controller_mode: ControllerMode::Managed {
-            derived_dir: runtime_dir,
-            controller_template: unique_template(),
-            local_ipc_policy: policy,
-        },
+        runtime_dir: Some(runtime_dir),
+        local_ipc_policy: policy,
+        controller_template: unique_template(),
         ..ManagerOptions::default()
     })
     .await
@@ -120,7 +118,7 @@ async fn force_rejects_unsupported_mihomo_before_staging_check_or_spawn() {
     );
     let mut spec = common::mihomo_spec(&dir, config);
     spec.core.version = Some(unsupported_mihomo_version().into());
-    let manager = managed_manager(runtime.clone(), LocalIpcPolicy::Force).await;
+    let manager = manager_with_policy(runtime.clone(), LocalIpcPolicy::Force).await;
 
     let error = manager.start(spec).await.expect_err("Force must reject");
 
@@ -151,7 +149,7 @@ async fn force_rejects_clash_premium_without_probing_its_version() {
     spec.core.kind = CoreKind::ClashPremium;
     spec.core.binary_path = binary.clone();
     spec.core.version = None;
-    let manager = managed_manager(runtime.clone(), LocalIpcPolicy::Force).await;
+    let manager = manager_with_policy(runtime.clone(), LocalIpcPolicy::Force).await;
 
     let error = manager.start(spec).await.expect_err("Force must reject");
 
@@ -180,7 +178,7 @@ async fn prefer_falls_back_to_the_upstream_http_controller_and_secret() {
     );
     let mut spec = common::mihomo_spec(&dir, config);
     spec.core.version = Some(unsupported_mihomo_version().into());
-    let manager = managed_manager(runtime, LocalIpcPolicy::Prefer).await;
+    let manager = manager_with_policy(runtime, LocalIpcPolicy::Prefer).await;
 
     manager.start(spec).await.expect("Prefer HTTP fallback");
 
@@ -210,7 +208,7 @@ async fn disable_uses_http_even_when_local_ipc_is_supported() {
             source_local_controller(&dir)
         ),
     );
-    let manager = managed_manager(dir.join("runtime"), LocalIpcPolicy::Disable).await;
+    let manager = manager_with_policy(dir.join("runtime"), LocalIpcPolicy::Disable).await;
 
     manager
         .start(common::mihomo_spec(&dir, config))
@@ -234,7 +232,7 @@ async fn force_uses_only_local_ipc_and_retains_the_secret() {
         &dir,
         &format!("external-controller: 127.0.0.1:{port}\nsecret: retained-secret\n"),
     );
-    let manager = managed_manager(dir.join("runtime"), LocalIpcPolicy::Force).await;
+    let manager = manager_with_policy(dir.join("runtime"), LocalIpcPolicy::Force).await;
 
     manager
         .start(common::mihomo_spec(&dir, config))
@@ -273,7 +271,7 @@ async fn version_probe_is_cached_by_path_and_mtime_and_supplied_versions_skip_it
     let mut probed = common::mihomo_spec(&dir, config.clone());
     probed.core.binary_path = binary.clone();
     probed.core.version = None;
-    let manager = managed_manager(dir.join("runtime"), LocalIpcPolicy::Force).await;
+    let manager = manager_with_policy(dir.join("runtime"), LocalIpcPolicy::Force).await;
 
     manager.start(probed.clone()).await.unwrap();
     manager.stop().await.unwrap();
@@ -299,7 +297,7 @@ async fn version_probe_is_cached_by_path_and_mtime_and_supplied_versions_skip_it
     let mut supplied = common::mihomo_spec(&dir, config);
     supplied.core.binary_path = supplied_binary.clone();
     let supplied_manager =
-        managed_manager(dir.join("supplied-runtime"), LocalIpcPolicy::Force).await;
+        manager_with_policy(dir.join("supplied-runtime"), LocalIpcPolicy::Force).await;
     supplied_manager.start(supplied).await.unwrap();
     supplied_manager.shutdown().await.unwrap();
     assert_eq!(probe_count(&supplied_binary), 0);

--- a/crates/nyanpasu-core-manager/tests/check_config.rs
+++ b/crates/nyanpasu-core-manager/tests/check_config.rs
@@ -23,3 +23,44 @@ async fn check_config_passes_and_fails() {
         other => panic!("unexpected error: {other}"),
     }
 }
+
+/// A core that never answers `-t` must not hold the caller — and must not
+/// survive being given up on. `check-delay-ms` is two orders of magnitude above
+/// the bound, so the elapsed time is the proof that the wait was cut short, and
+/// the marker file is the proof that a process really was spawned to cut short.
+///
+/// Gap, stated: this asserts the call returns, not that the child was reaped.
+/// The tree kill belongs to `nyanpasu_utils::process::Command::timeout`
+/// (`command.rs:105`) in a read-only crate, and there is no portable handle to
+/// assert on from here.
+#[tokio::test]
+async fn a_hung_check_is_bounded_by_its_timeout() {
+    use nyanpasu_core_manager::kind::check_config_within;
+    use std::time::{Duration, Instant};
+
+    let (_guard, dir) = common::utf8_tempdir();
+    let started = dir.join("check-started");
+    let config = dir.join("hang.yaml");
+    std::fs::write(
+        &config,
+        format!("x-fake-core:\n  check-delay-ms: 30000\n  check-started-file: '{started}'\n"),
+    )
+    .unwrap();
+    let spec = common::mihomo_spec(&dir, config);
+
+    let began = Instant::now();
+    let err = check_config_within(&spec, Duration::from_millis(300))
+        .await
+        .expect_err("a hung check must fail");
+    let elapsed = began.elapsed();
+
+    assert!(
+        elapsed < Duration::from_secs(10),
+        "the check must not wait for the core: {elapsed:?}"
+    );
+    assert!(started.exists(), "the fake core must actually have started");
+    match err {
+        Error::ConfigCheckFailed(msg) => assert!(msg.contains("timed out"), "{msg}"),
+        other => panic!("unexpected error: {other}"),
+    }
+}

--- a/crates/nyanpasu-core-manager/tests/common/real.rs
+++ b/crates/nyanpasu-core-manager/tests/common/real.rs
@@ -5,8 +5,7 @@ use std::time::Duration;
 
 use camino::{Utf8Path, Utf8PathBuf};
 use nyanpasu_core_manager::{
-    ControllerMode, CoreKind, CoreManager, CoreSpec, InstanceOptions, InstanceSpec, LocalIpcPolicy,
-    ManagerOptions,
+    CoreKind, CoreManager, CoreSpec, InstanceOptions, InstanceSpec, LocalIpcPolicy, ManagerOptions,
 };
 
 /// A real core under test: its manager kind and the binary name in tests/bin.
@@ -132,17 +131,15 @@ fn unique_template() -> Option<String> {
     }
     #[cfg(not(windows))]
     {
-        None // unix default derives the socket under derived_dir (already unique)
+        None // unix default derives the socket under the runtime dir (already unique)
     }
 }
 
-pub async fn managed_manager(dir: &Utf8Path, local_ipc_policy: LocalIpcPolicy) -> CoreManager {
+pub async fn manager_with_policy(dir: &Utf8Path, local_ipc_policy: LocalIpcPolicy) -> CoreManager {
     CoreManager::new(ManagerOptions {
-        controller_mode: ControllerMode::Managed {
-            derived_dir: dir.join("derived"),
-            controller_template: unique_template(),
-            local_ipc_policy,
-        },
+        runtime_dir: Some(dir.join("runtime")),
+        local_ipc_policy,
+        controller_template: unique_template(),
         control_timeout: Duration::from_secs(15),
         reconcile_timeout: Duration::from_secs(15),
         ..ManagerOptions::default()

--- a/crates/nyanpasu-core-manager/tests/config_apply.rs
+++ b/crates/nyanpasu-core-manager/tests/config_apply.rs
@@ -10,9 +10,8 @@ use std::{
 };
 
 use nyanpasu_core_manager::{
-    ApplyOutcome, ControllerMode, ControllerVersionProbe, CoreManager, CoreState, Error,
-    HealthProbe, InstanceSpec, LocalIpcPolicy, ManagerOptions, ProbeHandle, ProbePhase,
-    ProbeResult, RevisionId,
+    ApplyOutcome, ControllerVersionProbe, CoreManager, CoreState, Error, HealthProbe, InstanceSpec,
+    LocalIpcPolicy, ManagerOptions, ProbeHandle, ProbePhase, ProbeResult, RevisionId,
 };
 use parking_lot::Mutex;
 
@@ -44,7 +43,7 @@ fn spec(dir: &camino::Utf8Path, path: camino::Utf8PathBuf) -> InstanceSpec {
     common::mihomo_spec(dir, path)
 }
 
-fn passthrough_yaml(port: u16, extra: &str) -> String {
+fn http_controller_yaml(port: u16, extra: &str) -> String {
     format!("external-controller: 127.0.0.1:{port}\nmode: rule\n{extra}")
 }
 
@@ -55,12 +54,12 @@ async fn custom_probe_plan_reaches_desired_replacement_and_rollback() {
     let first = write_named(
         &dir,
         "probe-old.yaml",
-        &passthrough_yaml(port, "x-setting: old\n"),
+        &http_controller_yaml(port, "x-setting: old\n"),
     );
     let desired = write_named(
         &dir,
         "probe-desired.yaml",
-        &passthrough_yaml(port, "x-setting: desired\n"),
+        &http_controller_yaml(port, "x-setting: desired\n"),
     );
     let attempts = Arc::new(Mutex::new(Vec::<(u64, u32)>::new()));
     let readiness = ProbeHandle::from_fn("recorded-readiness", {
@@ -124,7 +123,7 @@ async fn custom_probe_plan_reaches_desired_replacement_and_rollback() {
 async fn apply_noop_keeps_the_current_revision_and_process() {
     let (_guard, dir) = common::utf8_tempdir();
     let port = common::free_port();
-    let body = passthrough_yaml(port, "rules:\n  - MATCH,DIRECT\n");
+    let body = http_controller_yaml(port, "rules:\n  - MATCH,DIRECT\n");
     let first = write_named(&dir, "first.yaml", &body);
     let reordered = write_named(
         &dir,
@@ -151,11 +150,11 @@ async fn apply_noop_keeps_the_current_revision_and_process() {
 async fn apply_patch_updates_the_revision_without_restarting() {
     let (_guard, dir) = common::utf8_tempdir();
     let port = common::free_port();
-    let first = write_named(&dir, "first.yaml", &passthrough_yaml(port, ""));
+    let first = write_named(&dir, "first.yaml", &http_controller_yaml(port, ""));
     let desired = write_named(
         &dir,
         "desired.yaml",
-        &passthrough_yaml(port, "allow-lan: true\n"),
+        &http_controller_yaml(port, "allow-lan: true\n"),
     );
     let manager = manager(&dir, Duration::from_secs(1)).await;
     manager.start(spec(&dir, first)).await.expect("start");
@@ -178,11 +177,15 @@ async fn apply_patch_updates_the_revision_without_restarting() {
 async fn custom_reconcile_failure_uses_the_existing_restart_path() {
     let (_guard, dir) = common::utf8_tempdir();
     let port = common::free_port();
-    let first = write_named(&dir, "reconcile-first.yaml", &passthrough_yaml(port, ""));
+    let first = write_named(
+        &dir,
+        "reconcile-first.yaml",
+        &http_controller_yaml(port, ""),
+    );
     let desired = write_named(
         &dir,
         "reconcile-desired.yaml",
-        &passthrough_yaml(port, "allow-lan: true\n"),
+        &http_controller_yaml(port, "allow-lan: true\n"),
     );
     let saw_reconcile = Arc::new(AtomicBool::new(false));
     let probe = ProbeHandle::from_fn("reconcile-aware", {
@@ -234,11 +237,11 @@ async fn custom_reconcile_failure_uses_the_existing_restart_path() {
 async fn installed_apply_with_parent_sync_failure_reports_real_outcome() {
     let (_guard, dir) = common::utf8_tempdir();
     let port = common::free_port();
-    let first = write_named(&dir, "first.yaml", &passthrough_yaml(port, ""));
+    let first = write_named(&dir, "first.yaml", &http_controller_yaml(port, ""));
     let desired = write_named(
         &dir,
         "desired.yaml",
-        &passthrough_yaml(port, "allow-lan: true\n"),
+        &http_controller_yaml(port, "allow-lan: true\n"),
     );
     let manager = manager(&dir, Duration::from_secs(1)).await;
     manager.start(spec(&dir, first)).await.expect("start");
@@ -266,12 +269,12 @@ async fn apply_reload_uses_put_without_restarting() {
     let first = write_named(
         &dir,
         "first.yaml",
-        &passthrough_yaml(port, "rules:\n  - MATCH,DIRECT\n"),
+        &http_controller_yaml(port, "rules:\n  - MATCH,DIRECT\n"),
     );
     let desired = write_named(
         &dir,
         "desired.yaml",
-        &passthrough_yaml(port, "rules:\n  - MATCH,REJECT\n"),
+        &http_controller_yaml(port, "rules:\n  - MATCH,REJECT\n"),
     );
     let manager = manager(&dir, Duration::from_secs(1)).await;
     manager.start(spec(&dir, first)).await.expect("start");
@@ -316,11 +319,9 @@ async fn prefer_http_fallback_keeps_controller_fields_across_patch_and_reload() 
         ),
     );
     let manager = CoreManager::new(ManagerOptions {
-        controller_mode: ControllerMode::Managed {
-            derived_dir: dir.join("runtime"),
-            controller_template: None,
-            local_ipc_policy: LocalIpcPolicy::Prefer,
-        },
+        runtime_dir: Some(dir.join("runtime")),
+        local_ipc_policy: LocalIpcPolicy::Prefer,
+        controller_template: None,
         reconcile_timeout: Duration::from_secs(5),
         ..ManagerOptions::default()
     })
@@ -374,18 +375,18 @@ async fn prefer_http_fallback_keeps_controller_fields_across_patch_and_reload() 
 }
 
 #[tokio::test]
-async fn apply_unknown_change_restarts_to_the_committed_desired_config() {
+async fn apply_switch_class_change_switches_to_the_committed_desired_config() {
     let (_guard, dir) = common::utf8_tempdir();
     let port = common::free_port();
     let first = write_named(
         &dir,
         "first.yaml",
-        &passthrough_yaml(port, "x-setting: old\n"),
+        &http_controller_yaml(port, "x-setting: old\n"),
     );
     let desired = write_named(
         &dir,
         "desired.yaml",
-        &passthrough_yaml(port, "x-setting: new\n"),
+        &http_controller_yaml(port, "x-setting: new\n"),
     );
     let manager = manager(&dir, Duration::from_secs(1)).await;
     manager.start(spec(&dir, first)).await.expect("start");
@@ -396,7 +397,7 @@ async fn apply_unknown_change_restarts_to_the_committed_desired_config() {
         .await
         .expect("restart");
 
-    assert!(matches!(outcome, ApplyOutcome::Restarted { .. }));
+    assert!(matches!(outcome, ApplyOutcome::Switched { .. }));
     let after = running(&manager);
     assert!(after.0 > before.0, "switch-class change gets a new epoch");
     assert_ne!(after.1, before.1);
@@ -408,11 +409,11 @@ async fn failed_desired_restart_restores_and_restarts_the_old_revision() {
     let (_guard, dir) = common::utf8_tempdir();
     let port = common::free_port();
     let behavior = "x-fake-core:\n  patch-no-effect: true\n  fail-start-when-allow-lan: true\n";
-    let first = write_named(&dir, "first.yaml", &passthrough_yaml(port, behavior));
+    let first = write_named(&dir, "first.yaml", &http_controller_yaml(port, behavior));
     let desired = write_named(
         &dir,
         "desired.yaml",
-        &passthrough_yaml(port, &format!("allow-lan: true\n{behavior}")),
+        &http_controller_yaml(port, &format!("allow-lan: true\n{behavior}")),
     );
     let manager = manager(&dir, Duration::from_secs(1)).await;
     manager.start(spec(&dir, first)).await.expect("start");
@@ -449,11 +450,11 @@ async fn desired_and_rollback_commits_preserve_both_durability_warnings() {
     let (_guard, dir) = common::utf8_tempdir();
     let port = common::free_port();
     let behavior = "x-fake-core:\n  patch-no-effect: true\n  fail-start-when-allow-lan: true\n";
-    let first = write_named(&dir, "first.yaml", &passthrough_yaml(port, behavior));
+    let first = write_named(&dir, "first.yaml", &http_controller_yaml(port, behavior));
     let desired = write_named(
         &dir,
         "desired.yaml",
-        &passthrough_yaml(port, &format!("allow-lan: true\n{behavior}")),
+        &http_controller_yaml(port, &format!("allow-lan: true\n{behavior}")),
     );
     let manager = manager(&dir, Duration::from_secs(1)).await;
     manager.start(spec(&dir, first)).await.expect("start");
@@ -479,11 +480,11 @@ async fn desired_and_rollback_commits_preserve_both_durability_warnings() {
 async fn revision_conflict_has_zero_process_file_and_status_side_effects() {
     let (_guard, dir) = common::utf8_tempdir();
     let port = common::free_port();
-    let first = write_named(&dir, "first.yaml", &passthrough_yaml(port, ""));
+    let first = write_named(&dir, "first.yaml", &http_controller_yaml(port, ""));
     let desired = write_named(
         &dir,
         "desired.yaml",
-        &passthrough_yaml(port, "allow-lan: true\n"),
+        &http_controller_yaml(port, "allow-lan: true\n"),
     );
     let manager = manager(&dir, Duration::from_secs(1)).await;
     manager.start(spec(&dir, first)).await.expect("start");
@@ -526,11 +527,11 @@ async fn patch_timeout_with_verified_effect_does_not_restart() {
     let (_guard, dir) = common::utf8_tempdir();
     let port = common::free_port();
     let behavior = "x-fake-core:\n  patch-delay-ms: 250\n";
-    let first = write_named(&dir, "first.yaml", &passthrough_yaml(port, behavior));
+    let first = write_named(&dir, "first.yaml", &http_controller_yaml(port, behavior));
     let desired = write_named(
         &dir,
         "desired.yaml",
-        &passthrough_yaml(port, &format!("allow-lan: true\n{behavior}")),
+        &http_controller_yaml(port, &format!("allow-lan: true\n{behavior}")),
     );
     let manager = manager(&dir, Duration::from_millis(50)).await;
     manager.start(spec(&dir, first)).await.expect("start");
@@ -555,11 +556,11 @@ async fn patch_success_with_get_mismatch_restarts_desired() {
     let (_guard, dir) = common::utf8_tempdir();
     let port = common::free_port();
     let behavior = "x-fake-core:\n  patch-no-effect: true\n";
-    let first = write_named(&dir, "first.yaml", &passthrough_yaml(port, behavior));
+    let first = write_named(&dir, "first.yaml", &http_controller_yaml(port, behavior));
     let desired = write_named(
         &dir,
         "desired.yaml",
-        &passthrough_yaml(port, &format!("allow-lan: true\n{behavior}")),
+        &http_controller_yaml(port, &format!("allow-lan: true\n{behavior}")),
     );
     let manager = manager(&dir, Duration::from_secs(1)).await;
     manager.start(spec(&dir, first)).await.expect("start");
@@ -594,12 +595,12 @@ async fn source_mutation_during_staged_check_cannot_change_the_apply() {
     let first = write_named(
         &dir,
         "first.yaml",
-        &passthrough_yaml(port, "x-setting: old\n"),
+        &http_controller_yaml(port, "x-setting: old\n"),
     );
     let desired = write_named(
         &dir,
         "desired.yaml",
-        &passthrough_yaml(
+        &http_controller_yaml(
             port,
             &format!(
                 "x-setting: desired\nx-fake-core:\n  check-delay-ms: 1000\n  check-started-file: '{check_started_path}'\n"
@@ -626,12 +627,12 @@ async fn source_mutation_during_staged_check_cannot_change_the_apply() {
     .expect("staged config check never started");
     std::fs::write(
         &desired,
-        passthrough_yaml(port, "x-setting: mutated\nx-fake-core:\n  exit-code: 91\n"),
+        http_controller_yaml(port, "x-setting: mutated\nx-fake-core:\n  exit-code: 91\n"),
     )
     .unwrap();
 
     let outcome = apply.await.unwrap().expect("snapshot apply");
-    assert!(matches!(outcome, ApplyOutcome::Restarted { .. }));
+    assert!(matches!(outcome, ApplyOutcome::Switched { .. }));
     let runtime =
         std::fs::read_to_string(manager.status().revision.expect("revision").runtime_path).unwrap();
     assert!(runtime.contains("x-setting: desired"));
@@ -652,12 +653,12 @@ async fn desired_and_rollback_restart_failures_report_both_errors() {
     let first = write_named(
         &dir,
         "first.yaml",
-        &passthrough_yaml(port, &format!("x-setting: old\n{behavior}")),
+        &http_controller_yaml(port, &format!("x-setting: old\n{behavior}")),
     );
     let desired = write_named(
         &dir,
         "desired.yaml",
-        &passthrough_yaml(
+        &http_controller_yaml(
             port,
             &format!("x-setting: desired\n{behavior}  exit-code: 23\n"),
         ),
@@ -699,7 +700,7 @@ async fn unconfirmed_replacement_stop_never_cleans_or_reuses_its_epoch() {
     let first = write_named(
         &dir,
         "first.yaml",
-        &passthrough_yaml(
+        &http_controller_yaml(
             port,
             &format!(
                 "x-setting: old\nx-fake-core:\n  launch-count-file: '{counter_path}'\n  fail-after-launches: 99\n"
@@ -709,7 +710,7 @@ async fn unconfirmed_replacement_stop_never_cleans_or_reuses_its_epoch() {
     let desired = write_named(
         &dir,
         "desired.yaml",
-        &passthrough_yaml(
+        &http_controller_yaml(
             port,
             &format!(
                 "x-setting: desired\nx-fake-core:\n  launch-count-file: '{counter_path}'\n  fail-after-launches: 99\n  never-ready: true\n  crash-after-ms: 3000\n  crash-times: 1\n  state-file: '{rejected_state_path}'\n"
@@ -829,7 +830,7 @@ async fn readiness_timeout_with_unconfirmed_stop_preserves_and_quarantines_epoch
     let first = write_named(
         &dir,
         "readiness-timeout-first.yaml",
-        &passthrough_yaml(
+        &http_controller_yaml(
             port,
             &format!(
                 "x-setting: old\nx-fake-core:\n  launch-count-file: '{counter_path}'\n  fail-after-launches: 99\n"
@@ -839,7 +840,7 @@ async fn readiness_timeout_with_unconfirmed_stop_preserves_and_quarantines_epoch
     let desired = write_named(
         &dir,
         "readiness-timeout-desired.yaml",
-        &passthrough_yaml(
+        &http_controller_yaml(
             port,
             &format!(
                 "x-setting: desired\nx-fake-core:\n  launch-count-file: '{counter_path}'\n  fail-after-launches: 99\n  never-ready: true\n"
@@ -956,12 +957,12 @@ async fn compensation_publishes_restart_before_replacement_is_ready() {
     let first = write_named(
         &dir,
         "first.yaml",
-        &passthrough_yaml(port, &format!("allow-lan: false\n{behavior}")),
+        &http_controller_yaml(port, &format!("allow-lan: false\n{behavior}")),
     );
     let desired = write_named(
         &dir,
         "desired.yaml",
-        &passthrough_yaml(port, &format!("allow-lan: true\n{behavior}")),
+        &http_controller_yaml(port, &format!("allow-lan: true\n{behavior}")),
     );
     let manager = std::sync::Arc::new(manager(&dir, Duration::from_secs(1)).await);
     manager.start(spec(&dir, first)).await.expect("start");

--- a/crates/nyanpasu-core-manager/tests/graceful_switch.rs
+++ b/crates/nyanpasu-core-manager/tests/graceful_switch.rs
@@ -3,8 +3,8 @@ mod common;
 use std::time::Duration;
 
 use nyanpasu_core_manager::{
-    ControllerMode, ControllerVersionProbe, CoreState, DegradeReason, Error, HealthProbe,
-    LocalIpcPolicy, ManagerOptions, ProbeHandle, ProbeResult, StopReason, manager::CoreManager,
+    ControllerVersionProbe, CoreState, DegradeReason, Error, HealthProbe, LocalIpcPolicy,
+    ManagerOptions, ProbeHandle, ProbeResult, StopReason, manager::CoreManager,
 };
 
 fn unique_template() -> Option<String> {
@@ -20,17 +20,15 @@ fn unique_template() -> Option<String> {
     }
     #[cfg(not(windows))]
     {
-        None // unix default derives the socket under derived_dir (already unique)
+        None // unix default derives the socket under the runtime dir (already unique)
     }
 }
 
-async fn managed_manager(derived_dir: camino::Utf8PathBuf) -> CoreManager {
+async fn local_ipc_manager(runtime_dir: camino::Utf8PathBuf) -> CoreManager {
     CoreManager::new(ManagerOptions {
-        controller_mode: ControllerMode::Managed {
-            derived_dir,
-            controller_template: unique_template(),
-            local_ipc_policy: LocalIpcPolicy::Force,
-        },
+        runtime_dir: Some(runtime_dir),
+        local_ipc_policy: LocalIpcPolicy::Force,
+        controller_template: unique_template(),
         ..Default::default()
     })
     .await
@@ -38,19 +36,20 @@ async fn managed_manager(derived_dir: camino::Utf8PathBuf) -> CoreManager {
 }
 
 #[tokio::test]
-async fn managed_start_injects_the_epoch_endpoint_and_advertises_it() {
+async fn local_ipc_start_injects_the_epoch_endpoint_and_advertises_it() {
     let (_guard, dir) = common::utf8_tempdir();
-    let derived_dir = dir.join("derived");
+    let runtime_dir = dir.join("runtime");
     // Stale artifacts from a "previous run" must be swept by CoreManager::new.
-    std::fs::create_dir_all(&derived_dir).unwrap();
-    std::fs::write(derived_dir.join("config-99.yaml"), "stale").unwrap();
+    std::fs::create_dir_all(&runtime_dir).unwrap();
+    std::fs::write(runtime_dir.join("config-99.yaml"), "stale").unwrap();
 
-    // No external-controller in the user config — Managed mode injects one.
+    // No external-controller in the user config — Force resolves to local IPC, so the manager
+    // injects the epoch-scoped endpoint.
     let config = common::write_config(&dir, "mixed-port: 0\n");
-    let manager = managed_manager(derived_dir.clone()).await;
+    let manager = local_ipc_manager(runtime_dir.clone()).await;
     assert!(
-        !derived_dir.join("config-99.yaml").exists(),
-        "stale derived config swept on construction"
+        !runtime_dir.join("config-99.yaml").exists(),
+        "stale runtime config swept on construction"
     );
 
     manager
@@ -65,25 +64,25 @@ async fn managed_start_injects_the_epoch_endpoint_and_advertises_it() {
         endpoint.contains('1'),
         "endpoint should embed the epoch: {endpoint}"
     );
-    assert!(derived_dir.join("config-100.yaml").exists());
+    assert!(runtime_dir.join("config-100.yaml").exists());
 
     manager.shutdown().await.expect("shutdown");
     assert!(
-        !derived_dir.join("config-100.yaml").exists(),
-        "derived config removed after shutdown"
+        !runtime_dir.join("config-100.yaml").exists(),
+        "runtime config removed after shutdown"
     );
     let _ = Duration::ZERO;
 }
 
 #[tokio::test]
-async fn managed_spawn_error_removes_secret_derived_config() {
+async fn spawn_error_removes_the_secret_runtime_config() {
     let (_guard, dir) = common::utf8_tempdir();
-    let derived_dir = dir.join("derived");
+    let runtime_dir = dir.join("runtime");
     let config = common::write_config(
         &dir,
         "mixed-port: 0\nsecret: test-secret\nx-fake-core:\n  check-fail: boom\n",
     );
-    let manager = managed_manager(derived_dir.clone()).await;
+    let manager = local_ipc_manager(runtime_dir.clone()).await;
 
     let error = manager
         .start(common::mihomo_spec(&dir, config))
@@ -97,15 +96,15 @@ async fn managed_spawn_error_removes_secret_derived_config() {
         }
     ));
     assert!(
-        !derived_dir.join("config-1.yaml").exists(),
-        "secret-bearing derived config must be removed"
+        !runtime_dir.join("config-1.yaml").exists(),
+        "secret-bearing runtime config must be removed"
     );
 }
 
 #[tokio::test]
-async fn stop_cleans_derived_config_for_terminal_instance() {
+async fn stop_cleans_the_runtime_config_for_terminal_instance() {
     let (_guard, dir) = common::utf8_tempdir();
-    let derived_dir = dir.join("derived");
+    let runtime_dir = dir.join("runtime");
     let state_file = dir.join("crash-state");
     let config = common::write_config(
         &dir,
@@ -113,7 +112,7 @@ async fn stop_cleans_derived_config_for_terminal_instance() {
             "mixed-port: 0\nx-fake-core:\n  crash-after-ms: 500\n  crash-times: 99\n  state-file: {state_file}\n"
         ),
     );
-    let manager = managed_manager(derived_dir.clone()).await;
+    let manager = local_ipc_manager(runtime_dir.clone()).await;
     let mut rx = manager.subscribe();
 
     manager
@@ -138,13 +137,13 @@ async fn stop_cleans_derived_config_for_terminal_instance() {
     .expect("core never exhausted its restart budget");
 
     assert!(
-        derived_dir.join("config-1.yaml").exists(),
-        "derived config must exist before terminal stop cleanup"
+        runtime_dir.join("config-1.yaml").exists(),
+        "runtime config must exist before terminal stop cleanup"
     );
     assert!(matches!(manager.stop().await, Err(Error::NotStarted)));
     assert!(
-        !derived_dir.join("config-1.yaml").exists(),
-        "derived config must be removed after terminal stop"
+        !runtime_dir.join("config-1.yaml").exists(),
+        "runtime config must be removed after terminal stop"
     );
     manager.shutdown().await.expect("shutdown");
 }
@@ -156,7 +155,7 @@ use std::sync::Arc;
 #[tokio::test]
 async fn graceful_switch_overlaps_and_restores_listeners() {
     let (_guard, dir) = common::utf8_tempdir();
-    let derived_dir = dir.join("derived");
+    let runtime_dir = dir.join("runtime");
     let mixed = common::free_port();
     let patch_log_b = dir.join("patch-b.log");
 
@@ -168,12 +167,12 @@ async fn graceful_switch_overlaps_and_restores_listeners() {
     )
     .unwrap();
 
-    let manager = managed_manager(derived_dir.clone()).await;
+    let manager = local_ipc_manager(runtime_dir.clone()).await;
     manager
         .start(common::mihomo_spec(&dir, config_a))
         .await
         .expect("start A");
-    assert!(derived_dir.join("config-1.yaml").exists());
+    assert!(runtime_dir.join("config-1.yaml").exists());
     tokio::net::TcpStream::connect(("127.0.0.1", mixed))
         .await
         .expect("A holds the mixed port");
@@ -240,12 +239,12 @@ async fn graceful_switch_overlaps_and_restores_listeners() {
     );
     assert!(status.controller.is_some());
     assert!(
-        !derived_dir.join("config-1.yaml").exists(),
-        "old derived config must be removed after switch"
+        !runtime_dir.join("config-1.yaml").exists(),
+        "old runtime config must be removed after switch"
     );
     assert!(
-        derived_dir.join("config-2.yaml").exists(),
-        "new derived config must remain active"
+        runtime_dir.join("config-2.yaml").exists(),
+        "new runtime config must remain active"
     );
     manager.shutdown().await.expect("shutdown");
 }
@@ -253,12 +252,12 @@ async fn graceful_switch_overlaps_and_restores_listeners() {
 #[tokio::test]
 async fn graceful_switch_surfaces_installed_but_uncertain_durability() {
     let (_guard, dir) = common::utf8_tempdir();
-    let derived_dir = dir.join("derived");
+    let runtime_dir = dir.join("runtime");
     let mixed = common::free_port();
     let config_a = common::write_config(&dir, &format!("mixed-port: {mixed}\n"));
     let config_b = dir.join("config-b.yaml");
     std::fs::write(&config_b, format!("mixed-port: {mixed}\n")).unwrap();
-    let manager = managed_manager(derived_dir).await;
+    let manager = local_ipc_manager(runtime_dir).await;
     manager
         .start(common::mihomo_spec(&dir, config_a))
         .await
@@ -281,7 +280,7 @@ async fn graceful_switch_surfaces_installed_but_uncertain_durability() {
 #[tokio::test]
 async fn graceful_respawn_loads_the_full_committed_runtime_config() {
     let (_guard, dir) = common::utf8_tempdir();
-    let derived_dir = dir.join("derived");
+    let runtime_dir = dir.join("runtime");
     let ports = std::array::from_fn::<_, 5, _>(|_| common::free_port());
     let [port, socks, redir, tproxy, mixed] = ports;
     let config_a = common::write_config(&dir, &format!("mixed-port: {mixed}\n"));
@@ -294,7 +293,7 @@ async fn graceful_respawn_loads_the_full_committed_runtime_config() {
     )
     .unwrap();
 
-    let manager = managed_manager(derived_dir.clone()).await;
+    let manager = local_ipc_manager(runtime_dir.clone()).await;
     manager
         .start(common::mihomo_spec(&dir, config_a))
         .await
@@ -347,7 +346,7 @@ async fn graceful_respawn_loads_the_full_committed_runtime_config() {
     assert_eq!(runtime.mixed_port, i64::from(mixed));
     assert!(runtime.tun.enable, "respawn must restore TUN enablement");
 
-    let runtime_file = std::fs::read_to_string(derived_dir.join("config-2.yaml")).unwrap();
+    let runtime_file = std::fs::read_to_string(runtime_dir.join("config-2.yaml")).unwrap();
     assert!(runtime_file.contains(&format!("port: {port}")));
     assert!(runtime_file.contains(&format!("socks-port: {socks}")));
     assert!(runtime_file.contains(&format!("redir-port: {redir}")));
@@ -360,12 +359,12 @@ async fn graceful_respawn_loads_the_full_committed_runtime_config() {
 #[tokio::test]
 async fn graceful_success_publishes_only_the_new_epoch_context() {
     let (_guard, dir) = common::utf8_tempdir();
-    let derived_dir = dir.join("derived");
+    let runtime_dir = dir.join("runtime");
     let mixed = common::free_port();
     let config_a = common::write_config(&dir, &format!("mixed-port: {mixed}\n"));
     let config_b = dir.join("config-b.yaml");
     std::fs::write(&config_b, format!("mixed-port: {mixed}\n")).unwrap();
-    let manager = managed_manager(derived_dir).await;
+    let manager = local_ipc_manager(runtime_dir).await;
     manager
         .start(common::mihomo_spec(&dir, config_a))
         .await
@@ -424,7 +423,7 @@ async fn graceful_success_publishes_only_the_new_epoch_context() {
 #[tokio::test]
 async fn graceful_patch_timeout_with_matching_get_is_success() {
     let (_guard, dir) = common::utf8_tempdir();
-    let derived_dir = dir.join("derived");
+    let runtime_dir = dir.join("runtime");
     let mixed = common::free_port();
     let config_a = common::write_config(&dir, &format!("mixed-port: {mixed}\n"));
     let config_b = dir.join("config-b.yaml");
@@ -434,11 +433,9 @@ async fn graceful_patch_timeout_with_matching_get_is_success() {
     )
     .unwrap();
     let manager = CoreManager::new(ManagerOptions {
-        controller_mode: ControllerMode::Managed {
-            derived_dir,
-            controller_template: unique_template(),
-            local_ipc_policy: LocalIpcPolicy::Force,
-        },
+        runtime_dir: Some(runtime_dir),
+        local_ipc_policy: LocalIpcPolicy::Force,
+        controller_template: unique_template(),
         control_timeout: Duration::from_millis(50),
         reconcile_timeout: Duration::from_secs(3),
         ..Default::default()
@@ -476,7 +473,7 @@ async fn graceful_patch_timeout_with_matching_get_is_success() {
 #[tokio::test]
 async fn graceful_overlap_keeps_both_epoch_pid_records_without_miskilling_old() {
     let (_guard, dir) = common::utf8_tempdir();
-    let derived_dir = dir.join("derived");
+    let runtime_dir = dir.join("runtime");
     let mixed = common::free_port();
     let config_a = common::write_config(&dir, &format!("mixed-port: {mixed}\n"));
     let config_b = dir.join("config-b.yaml");
@@ -485,7 +482,7 @@ async fn graceful_overlap_keeps_both_epoch_pid_records_without_miskilling_old() 
         format!("mixed-port: {mixed}\nx-fake-core:\n  ready-delay-ms: 5000\n"),
     )
     .unwrap();
-    let manager = Arc::new(managed_manager(derived_dir.clone()).await);
+    let manager = Arc::new(local_ipc_manager(runtime_dir.clone()).await);
     manager
         .start(common::mihomo_spec(&dir, config_a))
         .await
@@ -503,13 +500,13 @@ async fn graceful_overlap_keeps_both_epoch_pid_records_without_miskilling_old() 
     let (old_record, new_record) = tokio::time::timeout(Duration::from_secs(15), async {
         loop {
             let old = nyanpasu_utils::process::read_epoch_pid_file(
-                derived_dir.join("core-1.pid").as_std_path(),
+                runtime_dir.join("core-1.pid").as_std_path(),
             )
             .await
             .ok()
             .flatten();
             let new = nyanpasu_utils::process::read_epoch_pid_file(
-                derived_dir.join("core-2.pid").as_std_path(),
+                runtime_dir.join("core-2.pid").as_std_path(),
             )
             .await
             .ok()
@@ -535,7 +532,7 @@ async fn graceful_overlap_keeps_both_epoch_pid_records_without_miskilling_old() 
 #[tokio::test]
 async fn graceful_overlap_removes_shared_http_controller_from_both_epochs() {
     let (_guard, dir) = common::utf8_tempdir();
-    let derived_dir = dir.join("derived");
+    let runtime_dir = dir.join("runtime");
     let mixed = common::free_port();
     let controller = common::free_port();
     let shared_controller = format!("127.0.0.1:{controller}");
@@ -551,7 +548,7 @@ async fn graceful_overlap_removes_shared_http_controller_from_both_epochs() {
         ),
     )
     .unwrap();
-    let manager = Arc::new(managed_manager(derived_dir.clone()).await);
+    let manager = Arc::new(local_ipc_manager(runtime_dir.clone()).await);
     manager
         .start(common::mihomo_spec(&dir, config_a))
         .await
@@ -566,13 +563,13 @@ async fn graceful_overlap_removes_shared_http_controller_from_both_epochs() {
     let (old_record, new_record) = tokio::time::timeout(Duration::from_secs(15), async {
         loop {
             let old = nyanpasu_utils::process::read_epoch_pid_file(
-                derived_dir.join("core-1.pid").as_std_path(),
+                runtime_dir.join("core-1.pid").as_std_path(),
             )
             .await
             .ok()
             .flatten();
             let new = nyanpasu_utils::process::read_epoch_pid_file(
-                derived_dir.join("core-2.pid").as_std_path(),
+                runtime_dir.join("core-2.pid").as_std_path(),
             )
             .await
             .ok()
@@ -588,7 +585,7 @@ async fn graceful_overlap_removes_shared_http_controller_from_both_epochs() {
     assert_ne!(old_record.pid, new_record.pid);
 
     for epoch in [1, 2] {
-        let runtime = std::fs::read_to_string(derived_dir.join(format!("config-{epoch}.yaml")))
+        let runtime = std::fs::read_to_string(runtime_dir.join(format!("config-{epoch}.yaml")))
             .expect("read overlapping effective config");
         let document: serde_yaml_ng::Mapping =
             serde_yaml_ng::from_str(&runtime).expect("parse effective config");
@@ -612,7 +609,7 @@ async fn graceful_overlap_removes_shared_http_controller_from_both_epochs() {
 #[tokio::test]
 async fn quarantine_recovery_continues_after_an_independent_epoch_failure() {
     let (_guard, dir) = common::utf8_tempdir();
-    let derived_dir = dir.join("derived");
+    let runtime_dir = dir.join("runtime");
     let config_a = common::write_config(&dir, "mixed-port: 0\n");
     let config_b = dir.join("config-b.yaml");
     std::fs::write(
@@ -622,11 +619,9 @@ async fn quarantine_recovery_continues_after_an_independent_epoch_failure() {
     .unwrap();
     let manager = Arc::new(
         CoreManager::new(ManagerOptions {
-            controller_mode: ControllerMode::Managed {
-                derived_dir: derived_dir.clone(),
-                controller_template: unique_template(),
-                local_ipc_policy: LocalIpcPolicy::Force,
-            },
+            runtime_dir: Some(runtime_dir.clone()),
+            local_ipc_policy: LocalIpcPolicy::Force,
+            controller_template: unique_template(),
             stop_timeout: Duration::from_secs(1),
             ..Default::default()
         })
@@ -644,8 +639,8 @@ async fn quarantine_recovery_continues_after_an_independent_epoch_failure() {
         let manager = manager.clone();
         tokio::spawn(async move { manager.switch(spec_b).await })
     };
-    let first_pid = derived_dir.join("core-1.pid");
-    let second_pid = derived_dir.join("core-2.pid");
+    let first_pid = runtime_dir.join("core-1.pid");
+    let second_pid = runtime_dir.join("core-2.pid");
     tokio::time::timeout(Duration::from_secs(15), async {
         while !second_pid.exists() {
             tokio::time::sleep(Duration::from_millis(5)).await;
@@ -668,31 +663,31 @@ async fn quarantine_recovery_continues_after_an_independent_epoch_failure() {
         .await
         .expect_err("first epoch must remain uncertain");
     assert!(
-        !derived_dir.join("config-2.yaml").exists(),
+        !runtime_dir.join("config-2.yaml").exists(),
         "a later independent quarantine was not recovered"
     );
     assert!(!second_pid.exists());
-    assert!(derived_dir.join("config-1.yaml").exists());
+    assert!(runtime_dir.join("config-1.yaml").exists());
 
     std::fs::write(&first_pid, first_record).unwrap();
     manager.recover_quarantine().await.unwrap();
-    assert!(!derived_dir.join("config-1.yaml").exists());
+    assert!(!runtime_dir.join("config-1.yaml").exists());
 }
 
 #[tokio::test]
-async fn managed_hard_switch_removes_old_derived_config() {
+async fn hard_switch_removes_the_old_runtime_config() {
     let (_guard, dir) = common::utf8_tempdir();
-    let derived_dir = dir.join("derived");
+    let runtime_dir = dir.join("runtime");
     let config_a = common::write_config(&dir, "mixed-port: 0\n");
     let config_b_path = dir.join("config-b.yaml");
     std::fs::write(&config_b_path, "dns:\n  listen: 127.0.0.1:0\n").unwrap();
-    let manager = managed_manager(derived_dir.clone()).await;
+    let manager = local_ipc_manager(runtime_dir.clone()).await;
 
     manager
         .start(common::mihomo_spec(&dir, config_a))
         .await
         .expect("start A");
-    assert!(derived_dir.join("config-1.yaml").exists());
+    assert!(runtime_dir.join("config-1.yaml").exists());
 
     let outcome = manager
         .switch(common::mihomo_spec(&dir, config_b_path))
@@ -705,10 +700,10 @@ async fn managed_hard_switch_removes_old_derived_config() {
         }
     );
     assert!(
-        !derived_dir.join("config-1.yaml").exists(),
-        "old derived config must be removed after hard switch"
+        !runtime_dir.join("config-1.yaml").exists(),
+        "old runtime config must be removed after hard switch"
     );
-    assert!(derived_dir.join("config-2.yaml").exists());
+    assert!(runtime_dir.join("config-2.yaml").exists());
     assert!(matches!(
         manager.status().state,
         CoreState::Running { epoch: 2, .. }
@@ -719,7 +714,7 @@ async fn managed_hard_switch_removes_old_derived_config() {
 #[tokio::test]
 async fn prefer_http_fallback_degrades_switch_to_hard() {
     let (_guard, dir) = common::utf8_tempdir();
-    let derived_dir = dir.join("derived");
+    let runtime_dir = dir.join("runtime");
     let port = common::free_port();
     let config_a = common::write_config(&dir, &format!("external-controller: 127.0.0.1:{port}\n"));
     let config_b = dir.join("config-b.yaml");
@@ -729,11 +724,9 @@ async fn prefer_http_fallback_degrades_switch_to_hard() {
     )
     .unwrap();
     let manager = CoreManager::new(ManagerOptions {
-        controller_mode: ControllerMode::Managed {
-            derived_dir,
-            controller_template: unique_template(),
-            local_ipc_policy: LocalIpcPolicy::Prefer,
-        },
+        runtime_dir: Some(runtime_dir),
+        local_ipc_policy: LocalIpcPolicy::Prefer,
+        controller_template: unique_template(),
         ..ManagerOptions::default()
     })
     .await
@@ -770,12 +763,12 @@ async fn prefer_http_fallback_degrades_switch_to_hard() {
 #[tokio::test]
 async fn derive_failure_republishes_old_running_state() {
     let (_guard, dir) = common::utf8_tempdir();
-    let derived_dir = dir.join("derived");
+    let runtime_dir = dir.join("runtime");
     let mixed = common::free_port();
     let config_a = common::write_config(&dir, &format!("mixed-port: {mixed}\n"));
     let config_b_path = dir.join("config-b.yaml");
     std::fs::write(&config_b_path, format!("mixed-port: {mixed}\n1: invalid\n")).unwrap();
-    let manager = managed_manager(derived_dir.clone()).await;
+    let manager = local_ipc_manager(runtime_dir.clone()).await;
 
     manager
         .start(common::mihomo_spec(&dir, config_a))
@@ -810,7 +803,7 @@ async fn derive_failure_republishes_old_running_state() {
 #[tokio::test]
 async fn failed_new_core_while_old_restarting_republishes_actual_state() {
     let (_guard, dir) = common::utf8_tempdir();
-    let derived_dir = dir.join("derived");
+    let runtime_dir = dir.join("runtime");
     let state_file = dir.join("crash-state");
     let config_a = common::write_config(
         &dir,
@@ -822,11 +815,9 @@ async fn failed_new_core_while_old_restarting_republishes_actual_state() {
     std::fs::write(&config_b_path, "mixed-port: 0\n").unwrap();
     let cancel_token = tokio_util::sync::CancellationToken::new();
     let manager = CoreManager::new(ManagerOptions {
-        controller_mode: ControllerMode::Managed {
-            derived_dir,
-            controller_template: unique_template(),
-            local_ipc_policy: LocalIpcPolicy::Force,
-        },
+        runtime_dir: Some(runtime_dir),
+        local_ipc_policy: LocalIpcPolicy::Force,
+        controller_template: unique_template(),
         cancel_token: cancel_token.clone(),
         ..Default::default()
     })
@@ -894,7 +885,7 @@ async fn failed_new_core_rolls_back_without_touching_the_old_one() {
     let config_b_path = dir.join("config-b.yaml");
     std::fs::write(&config_b_path, "x-fake-core:\n  never-ready: true\n").unwrap();
 
-    let manager = managed_manager(dir.join("derived")).await;
+    let manager = local_ipc_manager(dir.join("runtime")).await;
     manager
         .start(common::mihomo_spec(&dir, config_a))
         .await
@@ -953,11 +944,9 @@ async fn rejected_patch_falls_back_to_a_hard_restart() {
         }
     });
     let manager = CoreManager::builder(ManagerOptions {
-        controller_mode: ControllerMode::Managed {
-            derived_dir: dir.join("derived"),
-            controller_template: unique_template(),
-            local_ipc_policy: LocalIpcPolicy::Force,
-        },
+        runtime_dir: Some(dir.join("runtime")),
+        local_ipc_policy: LocalIpcPolicy::Force,
+        controller_template: unique_template(),
         ..ManagerOptions::default()
     })
     .readiness_probe(readiness)

--- a/crates/nyanpasu-core-manager/tests/manager_orchestration.rs
+++ b/crates/nyanpasu-core-manager/tests/manager_orchestration.rs
@@ -10,8 +10,8 @@ use std::{
 };
 
 use nyanpasu_core_manager::{
-    ControllerMode, CoreState, Error, HealthPolicy, HealthState, LocalIpcPolicy, LogLevel,
-    LogStream, ManagerOptions, ProbeHandle, ProbeResult, StopReason, manager::CoreManager,
+    CoreState, Error, HealthPolicy, HealthState, LocalIpcPolicy, LogLevel, LogStream,
+    ManagerOptions, ProbeHandle, ProbeResult, StopReason, manager::CoreManager,
 };
 
 async fn manager(runtime_dir: &camino::Utf8Path) -> CoreManager {
@@ -110,18 +110,29 @@ async fn manager_builder_forwards_atomic_runtime_health_without_bumping_lifecycl
 }
 
 #[tokio::test]
-async fn managed_controller_template_without_epoch_is_rejected_at_construction() {
+async fn a_controller_template_without_epoch_is_rejected_at_construction() {
     let (_guard, dir) = common::utf8_tempdir();
     let options = ManagerOptions {
-        controller_mode: ControllerMode::Managed {
-            derived_dir: dir,
-            controller_template: Some(r"\\.\pipe\nyanpasu\fixed".to_owned()),
-            local_ipc_policy: LocalIpcPolicy::Force,
-        },
+        runtime_dir: Some(dir),
+        local_ipc_policy: LocalIpcPolicy::Force,
+        controller_template: Some(r"\\.\pipe\nyanpasu\fixed".to_owned()),
         ..ManagerOptions::default()
     };
 
     assert!(CoreManager::new(options).await.is_err());
+}
+
+/// `runtime_dir` is the manager's only runtime artifact directory.
+#[tokio::test]
+async fn a_missing_runtime_dir_is_rejected_at_construction() {
+    let error = CoreManager::new(ManagerOptions::default())
+        .await
+        .err()
+        .expect("a manager without a runtime dir was accepted");
+    assert!(
+        matches!(error, Error::InvalidManagerOptions(ref detail) if detail.contains("runtime_dir")),
+        "unexpected error: {error}"
+    );
 }
 
 #[cfg(unix)]
@@ -131,12 +142,9 @@ async fn managed_unix_controller_template_cannot_escape_runtime_directory() {
     let runtime = dir.join("runtime");
     let escaped = dir.join("escaped-{epoch}.sock").to_string();
     let result = CoreManager::new(ManagerOptions {
-        runtime_dir: Some(runtime.clone()),
-        controller_mode: ControllerMode::Managed {
-            derived_dir: runtime,
-            controller_template: Some(escaped),
-            local_ipc_policy: LocalIpcPolicy::Force,
-        },
+        runtime_dir: Some(runtime),
+        local_ipc_policy: LocalIpcPolicy::Force,
+        controller_template: Some(escaped),
         ..ManagerOptions::default()
     })
     .await;
@@ -321,7 +329,7 @@ async fn hard_switch_replaces_the_core_and_bumps_the_epoch() {
 }
 
 #[tokio::test]
-async fn passthrough_prepare_failure_never_leaves_switching() {
+async fn prepare_failure_never_leaves_switching() {
     let (_guard, dir) = common::utf8_tempdir();
     let port = common::free_port();
     let config_a = common::write_config(&dir, &format!("external-controller: 127.0.0.1:{port}\n"));

--- a/crates/nyanpasu-core-manager/tests/real_cores.rs
+++ b/crates/nyanpasu-core-manager/tests/real_cores.rs
@@ -59,7 +59,7 @@ fn write_proxy_config(bed: &TestBed, extra: &str) -> Utf8PathBuf {
 async fn start_bed(core: &RealCore, policy: LocalIpcPolicy) -> (TestBed, CoreManager) {
     let bed = bed().await;
     let config = write_proxy_config(&bed, "");
-    let manager = real::managed_manager(&bed.dir, policy).await;
+    let manager = real::manager_with_policy(&bed.dir, policy).await;
     manager
         .start(real::real_spec(core, &bed.dir, config))
         .await
@@ -225,8 +225,8 @@ async fn config_update(core: RealCore) {
             "mihomo log-level change should patch in place, got {outcome:?}"
         ),
         _ => assert!(
-            matches!(outcome, ApplyOutcome::Restarted { .. }),
-            "{} log-level change should restart, got {outcome:?}",
+            matches!(outcome, ApplyOutcome::Switched { .. }),
+            "{} log-level change should switch, got {outcome:?}",
             core.name
         ),
     }
@@ -265,8 +265,8 @@ async fn config_update(core: RealCore) {
             "mihomo mixed-port change should patch in place, got {outcome:?}"
         ),
         _ => assert!(
-            matches!(outcome, ApplyOutcome::Restarted { .. }),
-            "{} mixed-port change should restart, got {outcome:?}",
+            matches!(outcome, ApplyOutcome::Switched { .. }),
+            "{} mixed-port change should switch, got {outcome:?}",
             core.name
         ),
     }
@@ -326,7 +326,7 @@ async fn ipc_mode_start(core: RealCore, policy: LocalIpcPolicy, expect_local: bo
             "got {outcome:?}"
         ),
         _ => assert!(
-            matches!(outcome, ApplyOutcome::Restarted { .. }),
+            matches!(outcome, ApplyOutcome::Switched { .. }),
             "got {outcome:?}"
         ),
     }
@@ -339,7 +339,7 @@ async fn ipc_mode_force_rejected(core: RealCore) {
     let _serial = real::serial_lock().await;
     let bed = bed().await;
     let config = write_proxy_config(&bed, "");
-    let manager = real::managed_manager(&bed.dir, LocalIpcPolicy::Force).await;
+    let manager = real::manager_with_policy(&bed.dir, LocalIpcPolicy::Force).await;
     let error = manager
         .start(real::real_spec(&core, &bed.dir, config))
         .await

--- a/crates/nyanpasu-service-runtime/src/cmds/install.rs
+++ b/crates/nyanpasu-service-runtime/src/cmds/install.rs
@@ -6,7 +6,7 @@ use service_manager::{
 
 use crate::consts::{APP_NAME, SERVICE_LABEL};
 
-use super::CommandError;
+use super::{CommandError, LocalIpcPolicyArg};
 
 /// Every argument may come from its `NYANPASU_*` variable instead; an explicit
 /// flag always wins. Note for callers: `sudo` resets the environment by
@@ -26,6 +26,14 @@ pub struct InstallCommand {
     /// The nyanpasu install directory, allowing to search the sidecar binary
     #[clap(long, env = "NYANPASU_APP_DIR")]
     nyanpasu_app_dir: PathBuf,
+    /// How the installed service reaches the core's control plane
+    #[clap(
+        long,
+        value_enum,
+        default_value = "disable",
+        env = "NYANPASU_LOCAL_IPC_POLICY"
+    )]
+    local_ipc_policy: LocalIpcPolicyArg,
 }
 
 pub fn install(ctx: InstallCommand) -> Result<(), CommandError> {
@@ -123,6 +131,19 @@ pub fn install_with(manager: &dyn ServiceManager, ctx: InstallCommand) -> Result
     Ok(())
 }
 
+/// The kebab-case CLI value the server side parses back.
+///
+/// Spelled out rather than read off `ValueEnum`: this string is written into the
+/// persisted service definition, so it must not change as a side effect of a
+/// derive-macro upgrade. `cmds::tests` pins the round trip.
+pub(super) fn policy_value(policy: LocalIpcPolicyArg) -> &'static str {
+    match policy {
+        LocalIpcPolicyArg::Force => "force",
+        LocalIpcPolicyArg::Prefer => "prefer",
+        LocalIpcPolicyArg::Disable => "disable",
+    }
+}
+
 fn build_install_ctx(
     label: ServiceLabel,
     program: PathBuf,
@@ -141,6 +162,8 @@ fn build_install_ctx(
             ctx.nyanpasu_config_dir.clone().into(),
             OsString::from("--nyanpasu-app-dir"),
             ctx.nyanpasu_app_dir.clone().into(),
+            OsString::from("--local-ipc-policy"),
+            OsString::from(policy_value(ctx.local_ipc_policy)),
             OsString::from("--service"),
         ],
         contents: None,
@@ -167,6 +190,7 @@ mod tests {
                 nyanpasu_data_dir: "data".into(),
                 nyanpasu_config_dir: "config".into(),
                 nyanpasu_app_dir: "app".into(),
+                local_ipc_policy: LocalIpcPolicyArg::Disable,
             },
         );
 
@@ -184,6 +208,7 @@ mod tests {
                 nyanpasu_data_dir: "data".into(),
                 nyanpasu_config_dir: "config".into(),
                 nyanpasu_app_dir: "app".into(),
+                local_ipc_policy: LocalIpcPolicyArg::Disable,
             },
         );
 
@@ -198,6 +223,7 @@ mod tests {
             nyanpasu_data_dir: "data".into(),
             nyanpasu_config_dir: "config".into(),
             nyanpasu_app_dir: "app".into(),
+            local_ipc_policy: LocalIpcPolicyArg::Disable,
         };
         let environment = vec![("HOME".into(), "home".into())];
         let install_ctx = build_install_ctx(
@@ -220,6 +246,8 @@ mod tests {
                 "config",
                 "--nyanpasu-app-dir",
                 "app",
+                "--local-ipc-policy",
+                "disable",
                 "--service",
             ]
             .map(OsString::from)

--- a/crates/nyanpasu-service-runtime/src/cmds/mod.rs
+++ b/crates/nyanpasu-service-runtime/src/cmds/mod.rs
@@ -19,6 +19,34 @@ mod test_support;
 
 pub use server::SHUTDOWN_TOKEN as SERVER_SHUTDOWN_TOKEN;
 
+/// The CLI spelling of [`nyanpasu_core_manager::LocalIpcPolicy`].
+///
+/// A mirror rather than a `ValueEnum` derive on the manager type: core-manager
+/// is a library the GUI also links, and it must not take a `clap` dependency.
+/// These value names are protocol — `install` writes the chosen one into the
+/// persisted service definition.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+#[value(rename_all = "kebab-case")]
+pub enum LocalIpcPolicyArg {
+    /// Require the platform-local transport; refuse to start a core without it.
+    Force,
+    /// Use the platform-local transport when the core supports it, otherwise
+    /// the config's HTTP `external-controller`.
+    Prefer,
+    /// Always use the config's HTTP `external-controller`.
+    Disable,
+}
+
+impl From<LocalIpcPolicyArg> for nyanpasu_core_manager::LocalIpcPolicy {
+    fn from(value: LocalIpcPolicyArg) -> Self {
+        match value {
+            LocalIpcPolicyArg::Force => Self::Force,
+            LocalIpcPolicyArg::Prefer => Self::Prefer,
+            LocalIpcPolicyArg::Disable => Self::Disable,
+        }
+    }
+}
+
 /// Nyanpasu Service, a privileged service for managing the core service.
 ///
 /// The main entry point for the service, Other commands are the control plane for the service.
@@ -266,7 +294,10 @@ mod tests {
             "--nyanpasu-app-dir",
             "app",
         ],
-        // The exact argv `install` writes into the service definition.
+        // The exact argv `install` wrote before S10. It has no
+        // `--local-ipc-policy`, and an upgraded binary must still start from a
+        // service definition containing it — which is what
+        // `the_server_local_ipc_policy_defaults_to_disable` pins.
         &[
             "nyanpasu-service",
             "server",
@@ -357,6 +388,34 @@ mod tests {
             "config.yaml",
         ],
         &["nyanpasu-service", "rpc", "recover-core"],
+        // The exact argv `install` writes after S10.
+        &[
+            "nyanpasu-service",
+            "server",
+            "--nyanpasu-data-dir",
+            "data",
+            "--nyanpasu-config-dir",
+            "config",
+            "--nyanpasu-app-dir",
+            "app",
+            "--local-ipc-policy",
+            "disable",
+            "--service",
+        ],
+        &[
+            "nyanpasu-service",
+            "install",
+            "--user",
+            "alice",
+            "--nyanpasu-data-dir",
+            "data",
+            "--nyanpasu-config-dir",
+            "config",
+            "--nyanpasu-app-dir",
+            "app",
+            "--local-ipc-policy",
+            "force",
+        ],
     ];
 
     #[test]
@@ -438,6 +497,7 @@ mod tests {
                 ("nyanpasu_data_dir", "NYANPASU_DATA_DIR"),
                 ("nyanpasu_config_dir", "NYANPASU_CONFIG_DIR"),
                 ("nyanpasu_app_dir", "NYANPASU_APP_DIR"),
+                ("local_ipc_policy", "NYANPASU_LOCAL_IPC_POLICY"),
             ]
         );
     }
@@ -502,5 +562,117 @@ mod tests {
             "--nyanpasu-app-dir",
             "app",
         ]));
+    }
+
+    fn server_policy(argv: &[&str]) -> LocalIpcPolicyArg {
+        let cli = Cli::try_parse_from(argv)
+            .unwrap_or_else(|err| panic!("{argv:?} does not parse:\n{err}"));
+        let Some(Commands::Server(ctx)) = cli.command else {
+            panic!("{argv:?} is not a server invocation")
+        };
+        ctx.local_ipc_policy
+    }
+
+    /// The transition default (report §4 P2). Two things ride on it: a service
+    /// definition written before the argument existed keeps starting, and the
+    /// resulting behaviour matches the removed passthrough behavior — the
+    /// config's HTTP controller, never rewritten.
+    #[test]
+    fn the_server_local_ipc_policy_defaults_to_disable() {
+        assert_eq!(
+            server_policy(&[
+                "nyanpasu-service",
+                "server",
+                "--nyanpasu-data-dir",
+                "data",
+                "--nyanpasu-config-dir",
+                "config",
+                "--nyanpasu-app-dir",
+                "app",
+                "--service",
+            ]),
+            LocalIpcPolicyArg::Disable
+        );
+        assert_eq!(
+            nyanpasu_core_manager::LocalIpcPolicy::from(LocalIpcPolicyArg::Disable),
+            nyanpasu_core_manager::LocalIpcPolicy::Disable
+        );
+    }
+
+    /// The CLI value names are kebab-case per the S5 conventions, and each maps
+    /// onto the manager variant of the same name.
+    #[test]
+    fn every_local_ipc_policy_value_parses_and_maps() {
+        use nyanpasu_core_manager::LocalIpcPolicy;
+
+        let cases = [
+            ("force", LocalIpcPolicyArg::Force, LocalIpcPolicy::Force),
+            ("prefer", LocalIpcPolicyArg::Prefer, LocalIpcPolicy::Prefer),
+            (
+                "disable",
+                LocalIpcPolicyArg::Disable,
+                LocalIpcPolicy::Disable,
+            ),
+        ];
+        for (value, arg, manager) in cases {
+            let argv = [
+                "nyanpasu-service",
+                "server",
+                "--nyanpasu-data-dir",
+                "data",
+                "--nyanpasu-config-dir",
+                "config",
+                "--nyanpasu-app-dir",
+                "app",
+                "--local-ipc-policy",
+                value,
+            ];
+            assert_eq!(server_policy(&argv), arg, "{value}");
+            assert_eq!(LocalIpcPolicy::from(arg), manager, "{value}");
+        }
+        assert!(
+            Cli::try_parse_from([
+                "nyanpasu-service",
+                "server",
+                "--nyanpasu-data-dir",
+                "data",
+                "--nyanpasu-config-dir",
+                "config",
+                "--nyanpasu-app-dir",
+                "app",
+                "--local-ipc-policy",
+                "passthrough",
+            ])
+            .is_err(),
+            "an unknown policy must not parse"
+        );
+    }
+
+    /// The string `install` persists into the service definition must be the
+    /// one the server parses back — the two are written out independently on
+    /// purpose (`install::policy_value`).
+    #[test]
+    fn the_persisted_policy_value_is_what_the_server_parses() {
+        for arg in [
+            LocalIpcPolicyArg::Force,
+            LocalIpcPolicyArg::Prefer,
+            LocalIpcPolicyArg::Disable,
+        ] {
+            let value = super::install::policy_value(arg);
+            let argv = [
+                "nyanpasu-service",
+                "server",
+                "--nyanpasu-data-dir",
+                "data",
+                "--nyanpasu-config-dir",
+                "config",
+                "--nyanpasu-app-dir",
+                "app",
+                "--local-ipc-policy",
+                value,
+                "--service",
+            ];
+            assert_eq!(server_policy(&argv), arg, "{value}");
+        }
     }
 }

--- a/crates/nyanpasu-service-runtime/src/cmds/mod.rs
+++ b/crates/nyanpasu-service-runtime/src/cmds/mod.rs
@@ -327,6 +327,36 @@ mod tests {
             "--config-file",
             "config.yaml",
         ],
+        &[
+            "nyanpasu-service",
+            "rpc",
+            "apply-config",
+            "--core-type",
+            "mihomo",
+            "--config-file",
+            "config.yaml",
+        ],
+        &[
+            "nyanpasu-service",
+            "rpc",
+            "apply-config",
+            "--core-type",
+            "mihomo",
+            "--config-file",
+            "config.yaml",
+            "--expected-revision",
+            "3:7:fedcba9876543210",
+        ],
+        &[
+            "nyanpasu-service",
+            "rpc",
+            "check-config",
+            "--core-type",
+            "mihomo",
+            "--config-file",
+            "config.yaml",
+        ],
+        &["nyanpasu-service", "rpc", "recover-core"],
     ];
 
     #[test]

--- a/crates/nyanpasu-service-runtime/src/cmds/rpc/mod.rs
+++ b/crates/nyanpasu-service-runtime/src/cmds/rpc/mod.rs
@@ -6,7 +6,10 @@ use clap::{
     Subcommand, ValueEnum,
     builder::{PossibleValue, TypedValueParser},
 };
-use nyanpasu_ipc::{api::network::set_dns::NetworkSetDnsReq, client::shortcuts::Client};
+use nyanpasu_ipc::{
+    api::{network::set_dns::NetworkSetDnsReq, status::RevisionIdInfo},
+    client::shortcuts::Client,
+};
 use nyanpasu_utils::core::{ClashCoreType, CoreType};
 
 /// The core names `--core-type` accepts, spelled exactly as they are on the
@@ -79,6 +82,27 @@ fn legacy_json_core_type(value: &str) -> Option<CoreType> {
     simd_json::serde::from_slice(&mut bytes).ok()
 }
 
+/// `--expected-revision 3:7:fedcba9876543210`, i.e. the three fields the
+/// manager's compare-and-swap actually compares, in the order `/status` prints
+/// them.
+fn parse_revision_id(value: &str) -> Result<RevisionIdInfo, String> {
+    let parts: Vec<&str> = value.split(':').collect();
+    let [epoch, generation, effective_hash] = parts.as_slice() else {
+        return Err(format!(
+            "`{value}` is not <epoch>:<generation>:<effective-hash>"
+        ));
+    };
+    Ok(RevisionIdInfo {
+        epoch: epoch
+            .parse()
+            .map_err(|_| format!("`{epoch}` is not an epoch"))?,
+        generation: generation
+            .parse()
+            .map_err(|_| format!("`{generation}` is not a generation"))?,
+        effective_hash: (*effective_hash).to_owned(),
+    })
+}
+
 #[derive(Debug, Subcommand)]
 pub enum RpcCommand {
     /// Start specific core with the given config file
@@ -96,6 +120,38 @@ pub enum RpcCommand {
     StopCore,
     /// Restart the running core
     RestartCore,
+    /// Apply a config to the running core (patch/reload/restart/switch, as the
+    /// manager classifies it)
+    ApplyConfig {
+        /// The core type to run the config with. A different core than the
+        /// running one switches cores.
+        #[clap(long)]
+        #[arg(value_parser = CoreTypeParser)]
+        core_type: nyanpasu_utils::core::CoreType,
+
+        /// The path to the core config file
+        #[clap(long)]
+        config_file: std::path::PathBuf,
+
+        /// Only apply if the running revision still matches, as
+        /// `<epoch>:<generation>:<effective-hash>`
+        #[clap(long)]
+        #[arg(value_parser = parse_revision_id)]
+        expected_revision: Option<RevisionIdInfo>,
+    },
+    /// Dry-run a config against a core binary without touching the running core
+    CheckConfig {
+        /// The core type to check the config against
+        #[clap(long)]
+        #[arg(value_parser = CoreTypeParser)]
+        core_type: nyanpasu_utils::core::CoreType,
+
+        /// The path to the core config file
+        #[clap(long)]
+        config_file: std::path::PathBuf,
+    },
+    /// Clear the manager's quarantine latch
+    RecoverCore,
     /// Get the logs of the service
     InspectLogs,
     /// Set the dns servers
@@ -131,6 +187,50 @@ pub async fn rpc(commands: RpcCommand) -> Result<(), crate::cmds::CommandError> 
             let client = Client::service_default();
             client
                 .restart_core()
+                .await
+                .map_err(|e| crate::cmds::CommandError::Other(e.into()))?;
+        }
+        RpcCommand::ApplyConfig {
+            core_type,
+            config_file,
+            expected_revision,
+        } => {
+            let client = Client::service_default();
+            let payload = nyanpasu_ipc::api::core::apply::CoreApplyReq {
+                core_type: Cow::Borrowed(&core_type),
+                config_file: Cow::Borrowed(&config_file),
+                expected_revision,
+            };
+            let data = client
+                .apply_config(&payload)
+                .await
+                .map_err(|e| crate::cmds::CommandError::Other(e.into()))?;
+            // The response is the point of the operation — a rolled-back apply
+            // is a success at the transport level and must be visible.
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&data)
+                    .map_err(|e| crate::cmds::CommandError::Other(e.into()))?
+            );
+        }
+        RpcCommand::CheckConfig {
+            core_type,
+            config_file,
+        } => {
+            let client = Client::service_default();
+            let payload = nyanpasu_ipc::api::core::check::CoreCheckReq {
+                core_type: Cow::Borrowed(&core_type),
+                config_file: Cow::Borrowed(&config_file),
+            };
+            client
+                .check_config(&payload)
+                .await
+                .map_err(|e| crate::cmds::CommandError::Other(e.into()))?;
+        }
+        RpcCommand::RecoverCore => {
+            let client = Client::service_default();
+            client
+                .recover_core()
                 .await
                 .map_err(|e| crate::cmds::CommandError::Other(e.into()))?;
         }
@@ -231,5 +331,24 @@ mod tests {
                 "meow"
             ]
         );
+    }
+
+    #[test]
+    fn the_revision_parser_accepts_the_status_triple() {
+        assert_eq!(
+            parse_revision_id("3:7:fedcba9876543210").unwrap(),
+            RevisionIdInfo {
+                epoch: 3,
+                generation: 7,
+                effective_hash: "fedcba9876543210".to_owned(),
+            }
+        );
+    }
+
+    #[test]
+    fn the_revision_parser_rejects_anything_else() {
+        for value in ["", "3", "3:7", "3:7:hash:extra", "x:7:hash", "3:y:hash"] {
+            assert!(parse_revision_id(value).is_err(), "{value}");
+        }
     }
 }

--- a/crates/nyanpasu-service-runtime/src/cmds/server.rs
+++ b/crates/nyanpasu-service-runtime/src/cmds/server.rs
@@ -24,6 +24,18 @@ pub struct ServerContext {
     /// run as service
     #[clap(long, default_value = "false")]
     pub service: bool,
+    /// How the core's control plane is reached.
+    ///
+    /// `default_value` is mandatory, not cosmetic: a service definition written
+    /// before this argument existed has no `--local-ipc-policy` in its argv and
+    /// must keep starting an upgraded binary.
+    #[clap(
+        long,
+        value_enum,
+        default_value = "disable",
+        env = "NYANPASU_LOCAL_IPC_POLICY"
+    )]
+    pub local_ipc_policy: super::LocalIpcPolicyArg,
 }
 
 pub static SHUTDOWN_TOKEN: OnceLock<CancellationToken> = OnceLock::new();
@@ -40,6 +52,7 @@ pub async fn server_inner(
     .await?;
     tracing::info!("nyanpasu config dir: {:?}", ctx.nyanpasu_config_dir);
     tracing::info!("nyanpasu data dir: {:?}", ctx.nyanpasu_data_dir);
+    tracing::info!("local ipc policy: {:?}", ctx.local_ipc_policy);
 
     // Print current envs
     let envs: BTreeMap<String, String> = std::env::vars().collect();
@@ -92,7 +105,7 @@ pub async fn server_inner(
     #[cfg(windows)]
     tracing::info!(sids = ?sids_str, "Loaded acl file");
 
-    crate::server::run(runtime_infos, token, sids_str).await?;
+    crate::server::run(runtime_infos, ctx.local_ipc_policy.into(), token, sids_str).await?;
     Ok(())
 }
 

--- a/crates/nyanpasu-service-runtime/src/cmds/server.rs
+++ b/crates/nyanpasu-service-runtime/src/cmds/server.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, path::PathBuf, sync::OnceLock};
+use std::{collections::BTreeSet, path::PathBuf, sync::OnceLock};
 
 #[cfg(windows)]
 use anyhow::Context;
@@ -54,9 +54,14 @@ pub async fn server_inner(
     tracing::info!("nyanpasu data dir: {:?}", ctx.nyanpasu_data_dir);
     tracing::info!("local ipc policy: {:?}", ctx.local_ipc_policy);
 
-    // Print current envs
-    let envs: BTreeMap<String, String> = std::env::vars().collect();
-    tracing::info!(environments = ?envs, "collected current envs.");
+    // Names only, never values: this buffer is served by /logs and
+    // /logs/inspect to every socket-ACL user, and the environment routinely
+    // carries proxy credentials and tokens. The names are what the log was ever
+    // for — confirming what a service manager handed the process.
+    let env_names: BTreeSet<String> = std::env::vars_os()
+        .map(|(name, _)| name.to_string_lossy().into_owned())
+        .collect();
+    tracing::info!(environment_names = ?env_names, "collected current env names.");
 
     // check dirs accessibility
     let nyanpasu_config_dir = dunce::canonicalize(&ctx.nyanpasu_config_dir)?;

--- a/crates/nyanpasu-service-runtime/src/server/events.rs
+++ b/crates/nyanpasu-service-runtime/src/server/events.rs
@@ -150,9 +150,10 @@ mod tests {
         );
     }
 
-    /// The v2 frame as `simd_json` writes it. Pinned separately from the ipc
-    /// crate's golden because this is the serializer that actually feeds the
-    /// socket, and the client decodes with `serde_json`: the two must agree.
+    /// The status snapshot frame as `simd_json` writes it. Pinned separately
+    /// from the ipc crate's golden because this is the serializer that actually
+    /// feeds the socket, and the client decodes with `serde_json`: the two must
+    /// agree.
     #[test]
     fn ws_status_frames_are_pinned() {
         let event = Event::new_core_status_changed(CoreInfos {

--- a/crates/nyanpasu-service-runtime/src/server/events.rs
+++ b/crates/nyanpasu-service-runtime/src/server/events.rs
@@ -57,7 +57,7 @@ impl EventHub {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use nyanpasu_ipc::api::status::CoreState;
+    use nyanpasu_ipc::api::status::{CoreInfos, CoreState, CoreStateDetail};
     use tokio::sync::broadcast::error::TryRecvError;
 
     fn state_event(state: CoreState) -> Event {
@@ -147,6 +147,32 @@ mod tests {
         assert_eq!(
             String::from_utf8(frame).unwrap(),
             r#"{"CoreStateChanged":"Running"}"#
+        );
+    }
+
+    /// The v2 frame as `simd_json` writes it. Pinned separately from the ipc
+    /// crate's golden because this is the serializer that actually feeds the
+    /// socket, and the client decodes with `serde_json`: the two must agree.
+    #[test]
+    fn ws_status_frames_are_pinned() {
+        let event = Event::new_core_status_changed(CoreInfos {
+            r#type: None,
+            state: CoreState::Stopped(None),
+            state_changed_at: 42,
+            config_path: None,
+            controller: None,
+            health: None,
+            revision: None,
+            detail: Some(CoreStateDetail::Stopped { reason: None }),
+        });
+        let frame = simd_json::to_vec(&event).unwrap();
+        assert_eq!(
+            String::from_utf8(frame).unwrap(),
+            concat!(
+                r#"{"CoreStatusChanged":{"type":null,"state":{"Stopped":null},"#,
+                r#""state_changed_at":42,"config_path":null,"#,
+                r#""detail":{"Stopped":{"reason":null}}}}"#
+            )
         );
     }
 }

--- a/crates/nyanpasu-service-runtime/src/server/manager_bridge.rs
+++ b/crates/nyanpasu-service-runtime/src/server/manager_bridge.rs
@@ -7,8 +7,8 @@ use std::{
 use camino::{Utf8Path, Utf8PathBuf};
 use nyanpasu_core_manager::{
     ApplyOutcome, ConfigRevision, ControllerMode, CoreKind, CoreManager as Manager, CoreSpec,
-    CoreState as ManagerCoreState, Error as ManagerError, HealthState, HealthStatus, Host,
-    InstanceOptions, InstanceSpec, LogFrame, LogStream, ManagerOptions, RevisionId,
+    CoreState as ManagerCoreState, CoreStatus, Error as ManagerError, HealthState, HealthStatus,
+    Host, InstanceOptions, InstanceSpec, LogFrame, LogStream, ManagerOptions, RevisionId,
 };
 use nyanpasu_ipc::api::{
     R, RBuilder,
@@ -90,7 +90,11 @@ impl From<anyhow::Error> for OpError {
 struct Inner {
     manager: Manager,
     /// Wire-type echo: the manager knows nothing about the alpha variants.
-    requested_core: RwLock<Option<CoreType>>,
+    /// Behind an `Arc` so the state bridge can read it without capturing the
+    /// whole adapter — an `Arc<Inner>` inside that task would keep the manager
+    /// alive, so its watch channel would never close and the task would never
+    /// exit.
+    requested_core: Arc<RwLock<Option<CoreType>>>,
     /// Serializes adapter-level control ops and carries the closing latch.
     control: tokio::sync::Mutex<ControlState>,
 }
@@ -115,7 +119,7 @@ impl CoreManagerService {
         Ok(Self {
             inner: Arc::new(Inner {
                 manager,
-                requested_core: RwLock::new(None),
+                requested_core: Arc::new(RwLock::new(None)),
                 control: tokio::sync::Mutex::new(ControlState { closing: false }),
             }),
         })
@@ -124,12 +128,25 @@ impl CoreManagerService {
     /// State → ws events and core logs → tracing.
     pub fn spawn_bridges(&self, hub: EventHub) {
         let mut states = self.inner.manager.subscribe();
+        // Only the echo is cloned in, never the whole adapter: see `Inner`.
+        let requested_core = self.inner.requested_core.clone();
         tokio::spawn(async move {
             let raw = states.borrow_and_update().clone();
             let mut last = map_core_state(&raw.state);
             while states.changed().await.is_ok() {
                 let raw = states.borrow_and_update().clone();
                 let next = map_core_state(&raw.state);
+                // v2 leads and is never suppressed: it carries every manager
+                // transition, including the ones the two-valued v1 state cannot
+                // express (Starting, Restarting, and the Stopping/Switching
+                // arrivals the guards below drop). Emitting it here rather than
+                // after the guards is what keeps the v1 path below untouched.
+                // Deliberately no `tracing::info!` for it — that would re-enter
+                // the hub as an `Event::Log` and change what v1 streams carry.
+                let requested = requested_core.read().clone();
+                hub.send(WsEvent::new_core_status_changed(project_core_infos(
+                    &raw, requested,
+                )));
                 if matches!(
                     raw.state,
                     ManagerCoreState::Stopping { .. } | ManagerCoreState::Switching { .. }
@@ -309,17 +326,10 @@ impl CoreManagerService {
     }
 
     pub async fn status(&self) -> CoreInfos {
-        let status = self.inner.manager.status();
-        CoreInfos {
-            r#type: self.inner.requested_core.read().clone(),
-            state: map_core_state(&status.state),
-            state_changed_at: status.changed_at,
-            config_path: status.spec.map(|spec| spec.config_path.into_std_path_buf()),
-            controller: status.controller.as_ref().and_then(map_controller),
-            health: status.health.as_ref().map(map_health),
-            revision: status.revision.as_ref().map(map_revision),
-            detail: map_state_detail(&status.state),
-        }
+        project_core_infos(
+            &self.inner.manager.status(),
+            self.inner.requested_core.read().clone(),
+        )
     }
 
     fn instance_spec(
@@ -542,6 +552,28 @@ fn same_ipc_state(previous: &CoreState, next: &CoreState) -> bool {
         (CoreState::Running, CoreState::Running) => true,
         (CoreState::Stopped(previous), CoreState::Stopped(next)) => previous == next,
         _ => false,
+    }
+}
+
+/// The wire projection of a manager snapshot.
+///
+/// One function so `/status` and the v2 `CoreStatusChanged` frame cannot drift:
+/// the event *is* the snapshot (report §4 P1-A). `state` stays the lossy
+/// two-valued field v1 clients depend on; `detail` is the faithful six-state
+/// view beside it.
+fn project_core_infos(status: &CoreStatus, requested_core: Option<CoreType>) -> CoreInfos {
+    CoreInfos {
+        r#type: requested_core,
+        state: map_core_state(&status.state),
+        state_changed_at: status.changed_at,
+        config_path: status
+            .spec
+            .as_ref()
+            .map(|spec| spec.config_path.as_std_path().to_path_buf()),
+        controller: status.controller.as_ref().and_then(map_controller),
+        health: status.health.as_ref().map(map_health),
+        revision: status.revision.as_ref().map(map_revision),
+        detail: map_state_detail(&status.state),
     }
 }
 
@@ -1095,6 +1127,128 @@ mod tests {
                 effective_hash: "fedcba9876543210".to_owned(),
             }
         );
+    }
+
+    fn status_of(state: ManagerCoreState) -> CoreStatus {
+        CoreStatus {
+            state,
+            changed_at: 42,
+            health: None,
+            spec: None,
+            controller: None,
+            revision: None,
+        }
+    }
+
+    /// Mirrors the restructured bridge loop: what a v1 connection receives
+    /// (after the unchanged suppression rules) and what a v2 connection
+    /// receives (one snapshot per manager transition, none suppressed).
+    fn simulate_both(statuses: &[CoreStatus]) -> (Vec<String>, Vec<Option<CoreStateDetail>>) {
+        let mut last = CoreState::Stopped(None);
+        let mut v1 = Vec::new();
+        let mut v2 = Vec::new();
+        for raw in statuses {
+            let next = map_core_state(&raw.state);
+            v2.push(project_core_infos(raw, None).detail);
+            if matches!(
+                raw.state,
+                ManagerCoreState::Stopping { .. } | ManagerCoreState::Switching { .. }
+            ) && matches!(last, CoreState::Stopped(_))
+            {
+                continue;
+            }
+            if same_ipc_state(&last, &next) {
+                continue;
+            }
+            v1.push(format!("{next:?}"));
+            last = next;
+        }
+        (v1, v2)
+    }
+
+    /// The point of S9: the v1 stream keeps suppressing exactly what it always
+    /// suppressed, while the v2 stream carries every transition — including the
+    /// crash-loop and start-up ones the two-valued v1 state cannot express
+    /// (report §1.2).
+    #[test]
+    fn the_v2_stream_carries_every_transition_the_v1_stream_suppresses() {
+        let states = [
+            ManagerCoreState::Starting { epoch: 1 },
+            ManagerCoreState::Running { epoch: 1, pid: 42 },
+            ManagerCoreState::Restarting {
+                epoch: 1,
+                attempt: 2,
+            },
+            ManagerCoreState::Running { epoch: 1, pid: 43 },
+            ManagerCoreState::Stopping { epoch: 1 },
+            ManagerCoreState::Stopped {
+                reason: Some(StopReason::User),
+            },
+        ];
+        let statuses: Vec<CoreStatus> = states.iter().cloned().map(status_of).collect();
+        let (v1, v2) = simulate_both(&statuses);
+
+        // The lossy v1 stream, defect included: the restart in the middle is
+        // reported as a stop, which is why S9 exists.
+        assert_eq!(
+            v1,
+            [
+                "Running",
+                "Stopped(None)",
+                "Running",
+                r#"Stopped(Some("stopped by user"))"#,
+            ]
+        );
+        // …and the mirror above agrees with the untouched v1 helper.
+        assert_eq!(v1, simulate(&states));
+        // One faithful frame per manager transition, none dropped.
+        assert_eq!(
+            v2,
+            [
+                Some(CoreStateDetail::Starting { epoch: 1 }),
+                Some(CoreStateDetail::Running { epoch: 1, pid: 42 }),
+                Some(CoreStateDetail::Restarting {
+                    epoch: 1,
+                    attempt: 2,
+                }),
+                Some(CoreStateDetail::Running { epoch: 1, pid: 43 }),
+                Some(CoreStateDetail::Stopping { epoch: 1 }),
+                Some(CoreStateDetail::Stopped {
+                    reason: Some("stopped by user".to_owned()),
+                }),
+            ]
+        );
+    }
+
+    /// The v2 payload is the S7 projection unchanged: `state` stays the lossy
+    /// field the v1 wire has always carried, `detail` is the faithful one, and
+    /// the type echo comes from the adapter rather than the manager.
+    #[test]
+    fn the_v2_payload_keeps_the_lossy_state_and_adds_the_faithful_detail() {
+        let infos = project_core_infos(
+            &status_of(ManagerCoreState::Restarting {
+                epoch: 3,
+                attempt: 2,
+            }),
+            Some(CoreType::Clash(ClashCoreType::MihomoAlpha)),
+        );
+        assert!(matches!(infos.state, CoreState::Stopped(None)));
+        assert_eq!(
+            infos.detail,
+            Some(CoreStateDetail::Restarting {
+                epoch: 3,
+                attempt: 2
+            })
+        );
+        assert_eq!(
+            infos.r#type,
+            Some(CoreType::Clash(ClashCoreType::MihomoAlpha))
+        );
+        assert_eq!(infos.state_changed_at, 42);
+        assert!(infos.controller.is_none());
+        assert!(infos.health.is_none());
+        assert!(infos.revision.is_none());
+        assert!(infos.config_path.is_none());
     }
 }
 

--- a/crates/nyanpasu-service-runtime/src/server/manager_bridge.rs
+++ b/crates/nyanpasu-service-runtime/src/server/manager_bridge.rs
@@ -1,20 +1,28 @@
-use std::{path::PathBuf, sync::Arc};
+use std::{
+    borrow::Cow,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 use camino::{Utf8Path, Utf8PathBuf};
 use nyanpasu_core_manager::{
-    ConfigRevision, ControllerMode, CoreKind, CoreManager as Manager, CoreSpec,
+    ApplyOutcome, ConfigRevision, ControllerMode, CoreKind, CoreManager as Manager, CoreSpec,
     CoreState as ManagerCoreState, Error as ManagerError, HealthState, HealthStatus, Host,
-    InstanceOptions, InstanceSpec, LogFrame, LogStream, ManagerOptions,
+    InstanceOptions, InstanceSpec, LogFrame, LogStream, ManagerOptions, RevisionId,
 };
 use nyanpasu_ipc::api::{
+    R, RBuilder,
+    core::apply::{ApplyOutcomeKind, CoreApplyData},
+    error_kind,
     status::{
         ConfigRevisionInfo, CoreControllerInfo, CoreHealthInfo, CoreHealthState, CoreInfos,
-        CoreState, CoreStateDetail,
+        CoreState, CoreStateDetail, RevisionIdInfo,
     },
     ws::events::Event as WsEvent,
 };
 use nyanpasu_utils::core::{ClashCoreType, CoreType};
 use parking_lot::RwLock;
+use serde::{Serialize, de::DeserializeOwned};
 use tokio::sync::broadcast::error::RecvError;
 use tracing::instrument;
 
@@ -27,6 +35,57 @@ const CORE_LOG_TARGET: &str = "nyanpasu_service::core";
 pub(crate) const MSG_CORE_ALREADY_RUNNING: &str = "core is already running";
 pub(crate) const MSG_CORE_ALREADY_STOPPED: &str = "core is already stopped";
 pub(crate) const MSG_CORE_NOT_STARTED: &str = "core have not been started yet";
+
+/// A failed operation, carrying its wire `error_kind` next to its message.
+///
+/// `start`/`stop`/`restart` predate `error_kind` and keep returning
+/// `anyhow::Error`; the S8 operations need the classification, and the only
+/// place it can be derived without downcasting is where the `ManagerError` is
+/// still typed.
+pub(crate) struct OpError {
+    kind: Option<&'static str>,
+    message: String,
+}
+
+impl OpError {
+    /// A failure the service cannot classify. Omitting the kind is correct
+    /// here: a guessed one is worse than none.
+    fn plain(message: impl Into<String>) -> Self {
+        Self {
+            kind: None,
+            message: message.into(),
+        }
+    }
+
+    /// The error envelope for this failure, `error_kind` included.
+    pub(crate) fn into_envelope<T>(self) -> R<'static, T>
+    where
+        T: Serialize + DeserializeOwned + std::fmt::Debug,
+    {
+        RBuilder::other_error_with_kind(Cow::Owned(self.message), self.kind.map(Cow::Borrowed))
+    }
+}
+
+impl From<ManagerError> for OpError {
+    fn from(error: ManagerError) -> Self {
+        Self {
+            kind: map_error_kind(&error),
+            message: match &error {
+                // The legacy wire string the GUI already branches on, so
+                // `apply` on a stopped core reads exactly like `restart` on
+                // one instead of inventing a second phrasing.
+                ManagerError::NotStarted => MSG_CORE_NOT_STARTED.to_owned(),
+                _ => error.to_string(),
+            },
+        }
+    }
+}
+
+impl From<anyhow::Error> for OpError {
+    fn from(error: anyhow::Error) -> Self {
+        Self::plain(error.to_string())
+    }
+}
 
 struct Inner {
     manager: Manager,
@@ -137,6 +196,14 @@ impl CoreManagerService {
             anyhow::bail!(MSG_CORE_ALREADY_RUNNING);
         }
         let spec = self.instance_spec(infos, core_type, config_path)?;
+        tracing::info!(
+            core_type = %core_type,
+            kind = %spec.core.kind,
+            working_dir = %spec.working_dir,
+            binary_path = %spec.core.binary_path,
+            config_path = %spec.config_path,
+            "Starting Core"
+        );
         self.inner.manager.start(spec).await?;
         *self.inner.requested_core.write() = Some(core_type.clone());
         Ok(())
@@ -166,6 +233,81 @@ impl CoreManagerService {
         }
     }
 
+    /// Apply `config_file` to the running core.
+    ///
+    /// The manager classifies the change and routes it: in-place patch, reload,
+    /// same-epoch restart with rollback, or a full core switch when the process
+    /// spec changed (which is what a different `core_type` produces). A stopped
+    /// core is an error, never an implicit start (report §7 R2).
+    #[instrument(skip(self, infos))]
+    pub async fn apply(
+        &self,
+        infos: &RuntimeInfos,
+        core_type: &CoreType,
+        config_file: &Path,
+        expected_revision: Option<&RevisionIdInfo>,
+    ) -> Result<CoreApplyData, OpError> {
+        let control = self.inner.control.lock().await;
+        if control.closing {
+            return Err(OpError::plain("service is shutting down"));
+        }
+        let config_path = canonical_config_path(config_file)?;
+        let spec = self.instance_spec(infos, core_type, config_path)?;
+        let outcome = self
+            .inner
+            .manager
+            .apply_config(spec, expected_revision.map(map_revision_id))
+            .await?;
+        let data = map_apply_outcome(&outcome);
+        tracing::info!(
+            outcome = ?data.outcome,
+            epoch = data.revision.epoch,
+            generation = data.revision.generation,
+            "Applied config"
+        );
+        // A rollback put the *old* spec back, so the wire echo must not claim
+        // the core type that was asked for.
+        if data.outcome != ApplyOutcomeKind::RolledBack {
+            *self.inner.requested_core.write() = Some(core_type.clone());
+        }
+        Ok(data)
+    }
+
+    /// Dry-run a config against a core binary. Never touches the running core.
+    #[instrument(skip(self, infos))]
+    pub async fn check(
+        &self,
+        infos: &RuntimeInfos,
+        core_type: &CoreType,
+        config_file: &Path,
+    ) -> Result<(), OpError> {
+        {
+            // Released before the check runs: it spawns the core binary, and
+            // holding the adapter latch across an external process would block
+            // start/stop/restart for as long as that takes.
+            let control = self.inner.control.lock().await;
+            if control.closing {
+                return Err(OpError::plain("service is shutting down"));
+            }
+        }
+        let config_path = canonical_config_path(config_file)?;
+        let spec = self.instance_spec(infos, core_type, config_path)?;
+        self.inner.manager.check_config(&spec).await?;
+        Ok(())
+    }
+
+    /// Clear the quarantine latch left by an epoch whose death could not be
+    /// confirmed. Idempotent: succeeds when nothing was quarantined.
+    #[instrument(skip(self))]
+    pub async fn recover(&self) -> Result<(), OpError> {
+        let control = self.inner.control.lock().await;
+        if control.closing {
+            return Err(OpError::plain("service is shutting down"));
+        }
+        self.inner.manager.recover_quarantine().await?;
+        Ok(())
+    }
+
     pub async fn status(&self) -> CoreInfos {
         let status = self.inner.manager.status();
         CoreInfos {
@@ -193,14 +335,6 @@ impl CoreManagerService {
         let binary_path = Utf8PathBuf::from_path_buf(find_binary_path(infos, core_type)?)
             .map_err(|path| anyhow::anyhow!("core binary path is not UTF-8: {}", path.display()))?;
         let kind = core_kind(core_type)?;
-        tracing::info!(
-            core_type = %core_type,
-            kind = %kind,
-            working_dir = %working_dir,
-            binary_path = %binary_path,
-            config_path = %config_path,
-            "Starting Core"
-        );
         Ok(InstanceSpec {
             core: CoreSpec {
                 kind,
@@ -297,6 +431,85 @@ fn map_revision(revision: &ConfigRevision) -> ConfigRevisionInfo {
     }
 }
 
+/// The wire CAS token, as the manager compares it.
+fn map_revision_id(info: &RevisionIdInfo) -> RevisionId {
+    RevisionId {
+        epoch: info.epoch,
+        generation: info.generation,
+        effective_hash: info.effective_hash.clone(),
+    }
+}
+
+/// Project an apply result onto the wire.
+///
+/// `DurabilityUncertain` is a wrapper, not an outcome, and the apply path can
+/// wrap twice — a commit warning around a restore warning
+/// (`manager/apply.rs:148` around `:445`) — so unwrap to the real outcome and
+/// keep every warning. `ApplyOutcome` is not `#[non_exhaustive]`: if the
+/// manager grows a variant, this match must fail to compile rather than
+/// silently mislabel it.
+fn map_apply_outcome(outcome: &ApplyOutcome) -> CoreApplyData {
+    let mut warnings = Vec::new();
+    let mut current = outcome;
+    while let ApplyOutcome::DurabilityUncertain { outcome, warning } = current {
+        warnings.push(warning.clone());
+        current = &**outcome;
+    }
+    let (kind, revision, failed_apply) = match current {
+        ApplyOutcome::Noop { revision } => (ApplyOutcomeKind::Noop, revision, None),
+        ApplyOutcome::Patched { revision } => (ApplyOutcomeKind::Patched, revision, None),
+        ApplyOutcome::Reloaded { revision } => (ApplyOutcomeKind::Reloaded, revision, None),
+        // The core-switch path reports `Restarted` too (`manager/apply.rs:531`),
+        // so `ApplyOutcomeKind::Switched` is never produced here. Do not try to
+        // infer it from an epoch change: the pre-call epoch can only be read
+        // outside the manager's control lock.
+        ApplyOutcome::Restarted { revision } => (ApplyOutcomeKind::Restarted, revision, None),
+        ApplyOutcome::RolledBack {
+            revision,
+            failed_apply,
+        } => (
+            ApplyOutcomeKind::RolledBack,
+            revision,
+            Some(failed_apply.clone()),
+        ),
+        ApplyOutcome::DurabilityUncertain { .. } => {
+            unreachable!("unwrapped by the loop above")
+        }
+    };
+    CoreApplyData {
+        outcome: kind,
+        revision: map_revision(revision),
+        warning: (!warnings.is_empty()).then(|| warnings.join("; ")),
+        failed_apply,
+    }
+}
+
+/// The wire classification for a manager error, or `None` when this change does
+/// not classify it yet (report P3 maps the rest).
+///
+/// `Error` is `#[non_exhaustive]`, so the wildcard arm is mandatory; it must
+/// stay "no kind", never a guess.
+fn map_error_kind(error: &ManagerError) -> Option<&'static str> {
+    match error {
+        ManagerError::NotStarted => Some(error_kind::NOT_STARTED),
+        ManagerError::AlreadyRunning => Some(error_kind::ALREADY_RUNNING),
+        ManagerError::RevisionConflict { .. } => Some(error_kind::REVISION_CONFLICT),
+        ManagerError::ManagerQuarantined { .. } => Some(error_kind::QUARANTINED),
+        ManagerError::ConfigCheckFailed(_) => Some(error_kind::CONFIG_CHECK_FAILED),
+        ManagerError::ConfigNotFound(_) => Some(error_kind::CONFIG_NOT_FOUND),
+        ManagerError::BinaryNotFound(_) => Some(error_kind::BINARY_NOT_FOUND),
+        ManagerError::InvalidConfig(_) | ManagerError::Yaml(_) => Some(error_kind::INVALID_CONFIG),
+        ManagerError::ControllerMissing => Some(error_kind::CONTROLLER_MISSING),
+        ManagerError::ApplyFailed(_) => Some(error_kind::APPLY_FAILED),
+        ManagerError::ApplyRollbackFailed { .. } => Some(error_kind::APPLY_ROLLBACK_FAILED),
+        ManagerError::StopUnconfirmed(_) => Some(error_kind::STOP_UNCONFIRMED),
+        // The durability wrapper is a warning around a real failure; report the
+        // failure's kind so a caller can still branch on it.
+        ManagerError::DurabilityUncertain { source, .. } => map_error_kind(source),
+        _ => None,
+    }
+}
+
 /// The lossless counterpart to `map_core_state`.
 fn map_state_detail(state: &ManagerCoreState) -> Option<CoreStateDetail> {
     match state {
@@ -364,6 +577,23 @@ fn find_binary_path(infos: &RuntimeInfos, core_type: &CoreType) -> std::io::Resu
         std::io::ErrorKind::NotFound,
         format!("{} not found", core_type.get_executable_name()),
     ))
+}
+
+/// The absolute, non-verbatim, UTF-8 path the manager is handed for a config.
+///
+/// Same shape as `start`'s inline version: canonicalizing makes the source path
+/// a stable identity, and `dunce::simplified` strips the Windows `\\?\` prefix
+/// the core's own command line cannot use. Canonicalization is also the
+/// existence check.
+fn canonical_config_path(config_file: &Path) -> Result<Utf8PathBuf, OpError> {
+    let canonical = config_file.canonicalize().map_err(|error| {
+        OpError::plain(format!(
+            "failed to resolve config path {}: {error}",
+            config_file.display()
+        ))
+    })?;
+    Utf8PathBuf::from_path_buf(dunce::simplified(&canonical).to_path_buf())
+        .map_err(|path| OpError::plain(format!("config path is not UTF-8: {}", path.display())))
 }
 
 #[cfg(test)]
@@ -695,6 +925,176 @@ mod tests {
         assert_eq!(mapped.consecutive_failures, 4);
         assert_eq!(mapped.last_error.as_deref(), Some("probe timed out"));
         assert_eq!(mapped.last_success_at, Some(1_700_000_000_000));
+    }
+
+    fn revision(generation: u64) -> ConfigRevision {
+        ConfigRevision {
+            epoch: 3,
+            generation,
+            source_hash: "0123456789abcdef".to_owned(),
+            effective_hash: "fedcba9876543210".to_owned(),
+            runtime_path: "/srv/data/core-runtime/config-3.yaml".into(),
+        }
+    }
+
+    #[test]
+    fn apply_outcomes_map_onto_the_wire_kinds() {
+        let cases = [
+            (
+                ApplyOutcome::Noop {
+                    revision: revision(7),
+                },
+                ApplyOutcomeKind::Noop,
+            ),
+            (
+                ApplyOutcome::Patched {
+                    revision: revision(8),
+                },
+                ApplyOutcomeKind::Patched,
+            ),
+            (
+                ApplyOutcome::Reloaded {
+                    revision: revision(9),
+                },
+                ApplyOutcomeKind::Reloaded,
+            ),
+            (
+                ApplyOutcome::Restarted {
+                    revision: revision(10),
+                },
+                ApplyOutcomeKind::Restarted,
+            ),
+        ];
+        for (outcome, expected) in cases {
+            let data = map_apply_outcome(&outcome);
+            assert_eq!(data.outcome, expected);
+            assert_eq!(data.revision.effective_hash, "fedcba9876543210");
+            assert!(data.warning.is_none());
+            assert!(data.failed_apply.is_none());
+        }
+    }
+
+    /// The report's sharpest requirement: a rollback must not be
+    /// indistinguishable from a success. The core is running the OLD config, so
+    /// the reported revision is the old one and the rejection reason comes with
+    /// it.
+    #[test]
+    fn a_rolled_back_apply_reports_the_old_revision_and_the_failure() {
+        let data = map_apply_outcome(&ApplyOutcome::RolledBack {
+            revision: revision(7),
+            failed_apply: "core failed to start".to_owned(),
+        });
+        assert_eq!(data.outcome, ApplyOutcomeKind::RolledBack);
+        assert_eq!(data.revision.generation, 7);
+        assert_eq!(data.failed_apply.as_deref(), Some("core failed to start"));
+    }
+
+    /// `DurabilityUncertain` is a wrapper, and the apply path can wrap twice —
+    /// a commit warning around a restore warning. Both must survive, and the
+    /// wrapper must never be reported as the outcome.
+    #[test]
+    fn durability_warnings_unwrap_to_the_real_outcome() {
+        let single = ApplyOutcome::DurabilityUncertain {
+            outcome: Box::new(ApplyOutcome::Patched {
+                revision: revision(8),
+            }),
+            warning: "directory sync failed".to_owned(),
+        };
+        let data = map_apply_outcome(&single);
+        assert_eq!(data.outcome, ApplyOutcomeKind::Patched);
+        assert_eq!(data.warning.as_deref(), Some("directory sync failed"));
+
+        let nested = ApplyOutcome::DurabilityUncertain {
+            outcome: Box::new(ApplyOutcome::DurabilityUncertain {
+                outcome: Box::new(ApplyOutcome::RolledBack {
+                    revision: revision(7),
+                    failed_apply: "boom".to_owned(),
+                }),
+                warning: "restore sync failed".to_owned(),
+            }),
+            warning: "commit sync failed".to_owned(),
+        };
+        let data = map_apply_outcome(&nested);
+        assert_eq!(data.outcome, ApplyOutcomeKind::RolledBack);
+        assert_eq!(
+            data.warning.as_deref(),
+            Some("commit sync failed; restore sync failed")
+        );
+        assert_eq!(data.failed_apply.as_deref(), Some("boom"));
+    }
+
+    #[test]
+    fn manager_errors_map_onto_the_wire_error_kinds() {
+        let cases: [(ManagerError, Option<&str>); 8] = [
+            (ManagerError::NotStarted, Some("not_started")),
+            (ManagerError::AlreadyRunning, Some("already_running")),
+            (
+                ManagerError::RevisionConflict {
+                    expected: RevisionId {
+                        epoch: 3,
+                        generation: 7,
+                        effective_hash: "fedcba9876543210".to_owned(),
+                    },
+                    actual: None,
+                },
+                Some("revision_conflict"),
+            ),
+            (
+                ManagerError::ManagerQuarantined {
+                    epoch: 3,
+                    reason: "death unconfirmed".to_owned(),
+                },
+                Some("quarantined"),
+            ),
+            (
+                ManagerError::ConfigCheckFailed("unknown field".to_owned()),
+                Some("config_check_failed"),
+            ),
+            (ManagerError::ControllerMissing, Some("controller_missing")),
+            // The durability wrapper reports the wrapped failure's kind.
+            (
+                ManagerError::DurabilityUncertain {
+                    source: Box::new(ManagerError::ApplyFailed("boom".to_owned())),
+                    warning: "sync failed".to_owned(),
+                },
+                Some("apply_failed"),
+            ),
+            // Unmapped until report P3: no kind rather than a guessed one.
+            (
+                ManagerError::StartupFailed {
+                    stderr_tail: String::new(),
+                },
+                None,
+            ),
+        ];
+        for (error, expected) in cases {
+            assert_eq!(map_error_kind(&error), expected, "{error}");
+        }
+    }
+
+    /// `apply` on a stopped core answers with the same string `restart` does,
+    /// so a GUI branching on it keeps working, and gains the kind beside it.
+    #[test]
+    fn the_not_started_failure_keeps_the_legacy_wire_string() {
+        let error = OpError::from(ManagerError::NotStarted);
+        assert_eq!(error.message, MSG_CORE_NOT_STARTED);
+        assert_eq!(error.kind, Some("not_started"));
+    }
+
+    #[test]
+    fn expected_revisions_cross_the_wire_unchanged() {
+        assert_eq!(
+            map_revision_id(&RevisionIdInfo {
+                epoch: 3,
+                generation: 7,
+                effective_hash: "fedcba9876543210".to_owned(),
+            }),
+            RevisionId {
+                epoch: 3,
+                generation: 7,
+                effective_hash: "fedcba9876543210".to_owned(),
+            }
+        );
     }
 }
 

--- a/crates/nyanpasu-service-runtime/src/server/manager_bridge.rs
+++ b/crates/nyanpasu-service-runtime/src/server/manager_bridge.rs
@@ -2,11 +2,15 @@ use std::{path::PathBuf, sync::Arc};
 
 use camino::{Utf8Path, Utf8PathBuf};
 use nyanpasu_core_manager::{
-    ControllerMode, CoreKind, CoreManager as Manager, CoreSpec, CoreState as ManagerCoreState,
-    Error as ManagerError, InstanceOptions, InstanceSpec, LogFrame, LogStream, ManagerOptions,
+    ConfigRevision, ControllerMode, CoreKind, CoreManager as Manager, CoreSpec,
+    CoreState as ManagerCoreState, Error as ManagerError, HealthState, HealthStatus, Host,
+    InstanceOptions, InstanceSpec, LogFrame, LogStream, ManagerOptions,
 };
 use nyanpasu_ipc::api::{
-    status::{CoreInfos, CoreState},
+    status::{
+        ConfigRevisionInfo, CoreControllerInfo, CoreHealthInfo, CoreHealthState, CoreInfos,
+        CoreState, CoreStateDetail,
+    },
     ws::events::Event as WsEvent,
 };
 use nyanpasu_utils::core::{ClashCoreType, CoreType};
@@ -169,6 +173,10 @@ impl CoreManagerService {
             state: map_core_state(&status.state),
             state_changed_at: status.changed_at,
             config_path: status.spec.map(|spec| spec.config_path.into_std_path_buf()),
+            controller: status.controller.as_ref().and_then(map_controller),
+            health: status.health.as_ref().map(map_health),
+            revision: status.revision.as_ref().map(map_revision),
+            detail: map_state_detail(&status.state),
         }
     }
 
@@ -236,6 +244,82 @@ fn map_core_state(state: &ManagerCoreState) -> CoreState {
         }
         // `CoreState` is `#[non_exhaustive]`; an unknown state is not proven running.
         _ => CoreState::Stopped(None),
+    }
+}
+
+/// The controller endpoint, minus anything credential-bearing.
+///
+/// The manager never publishes the secret (only `ResolvedController.host`
+/// reaches the watch channel), but an HTTP endpoint is parsed from the
+/// caller's own `external-controller` value, which can carry userinfo — so
+/// strip it here rather than trusting the shape of that string.
+fn map_controller(host: &Host) -> Option<CoreControllerInfo> {
+    match host {
+        Host::NamedPipe(path) => Some(CoreControllerInfo::NamedPipe(path.clone())),
+        Host::UnixSocket(path) => Some(CoreControllerInfo::UnixSocket(path.clone())),
+        Host::Http(url) => {
+            let mut url = url.clone();
+            let _ = url.set_username("");
+            let _ = url.set_password(None);
+            Some(CoreControllerInfo::Http(url.to_string()))
+        }
+        // `Host` is `#[non_exhaustive]`; an unknown transport is reported as
+        // absent rather than guessed at.
+        _ => None,
+    }
+}
+
+fn map_health(health: &HealthStatus) -> CoreHealthInfo {
+    CoreHealthInfo {
+        state: match health.state {
+            HealthState::Starting => CoreHealthState::Starting,
+            HealthState::Healthy => CoreHealthState::Healthy,
+            HealthState::Unhealthy => CoreHealthState::Unhealthy,
+            // `HealthState` is `#[non_exhaustive]`; an unknown state is not
+            // proven healthy.
+            _ => CoreHealthState::Unhealthy,
+        },
+        changed_at: health.changed_at,
+        consecutive_failures: health.consecutive_failures,
+        last_error: health.last_error.clone(),
+        last_success_at: health.last_success_at,
+    }
+}
+
+/// `runtime_path` is dropped on purpose: it points inside the manager's
+/// 0o700 runtime directory, which the client cannot read.
+fn map_revision(revision: &ConfigRevision) -> ConfigRevisionInfo {
+    ConfigRevisionInfo {
+        epoch: revision.epoch,
+        generation: revision.generation,
+        source_hash: revision.source_hash.clone(),
+        effective_hash: revision.effective_hash.clone(),
+    }
+}
+
+/// The lossless counterpart to `map_core_state`.
+fn map_state_detail(state: &ManagerCoreState) -> Option<CoreStateDetail> {
+    match state {
+        ManagerCoreState::Stopped { reason } => Some(CoreStateDetail::Stopped {
+            reason: reason.as_ref().map(ToString::to_string),
+        }),
+        ManagerCoreState::Starting { epoch } => Some(CoreStateDetail::Starting { epoch: *epoch }),
+        ManagerCoreState::Running { epoch, pid } => Some(CoreStateDetail::Running {
+            epoch: *epoch,
+            pid: *pid,
+        }),
+        ManagerCoreState::Restarting { epoch, attempt } => Some(CoreStateDetail::Restarting {
+            epoch: *epoch,
+            attempt: *attempt,
+        }),
+        ManagerCoreState::Switching { from, to } => Some(CoreStateDetail::Switching {
+            from: *from,
+            to: *to,
+        }),
+        ManagerCoreState::Stopping { epoch } => Some(CoreStateDetail::Stopping { epoch: *epoch }),
+        // `CoreState` is `#[non_exhaustive]`; an unknown state has no faithful
+        // projection, so it is reported as absent.
+        _ => None,
     }
 }
 
@@ -456,6 +540,161 @@ mod tests {
                 r#"Stopped(Some("stopped by user"))"#,
             ]
         );
+    }
+
+    #[test]
+    fn manager_states_map_onto_the_wire_state_detail() {
+        let cases = [
+            (
+                ManagerCoreState::Stopped { reason: None },
+                CoreStateDetail::Stopped { reason: None },
+            ),
+            (
+                ManagerCoreState::Stopped {
+                    reason: Some(StopReason::User),
+                },
+                CoreStateDetail::Stopped {
+                    reason: Some("stopped by user".to_owned()),
+                },
+            ),
+            (
+                ManagerCoreState::Starting { epoch: 1 },
+                CoreStateDetail::Starting { epoch: 1 },
+            ),
+            (
+                ManagerCoreState::Running { epoch: 1, pid: 42 },
+                CoreStateDetail::Running { epoch: 1, pid: 42 },
+            ),
+            (
+                ManagerCoreState::Restarting {
+                    epoch: 1,
+                    attempt: 2,
+                },
+                CoreStateDetail::Restarting {
+                    epoch: 1,
+                    attempt: 2,
+                },
+            ),
+            (
+                ManagerCoreState::Switching {
+                    from: Some(1),
+                    to: 2,
+                },
+                CoreStateDetail::Switching {
+                    from: Some(1),
+                    to: 2,
+                },
+            ),
+            (
+                ManagerCoreState::Stopping { epoch: 2 },
+                CoreStateDetail::Stopping { epoch: 2 },
+            ),
+        ];
+        for (raw, expected) in cases {
+            assert_eq!(map_state_detail(&raw), Some(expected));
+        }
+    }
+
+    /// The detail projection must disagree with the lossy wire state exactly
+    /// where the report says it does: a crash loop and a start-up both look
+    /// stopped on the old field.
+    #[test]
+    fn the_detail_field_recovers_what_the_wire_state_flattens() {
+        let restarting = ManagerCoreState::Restarting {
+            epoch: 1,
+            attempt: 3,
+        };
+        assert!(matches!(
+            map_core_state(&restarting),
+            CoreState::Stopped(None)
+        ));
+        assert_eq!(
+            map_state_detail(&restarting),
+            Some(CoreStateDetail::Restarting {
+                epoch: 1,
+                attempt: 3,
+            })
+        );
+    }
+
+    #[test]
+    fn controller_hosts_map_onto_the_wire_controller() {
+        assert_eq!(
+            map_controller(&Host::named_pipe(r"\\.\pipe\nyanpasu\core-1")),
+            Some(CoreControllerInfo::NamedPipe(std::path::PathBuf::from(
+                r"\\.\pipe\nyanpasu\core-1"
+            )))
+        );
+        assert_eq!(
+            map_controller(&Host::unix_socket("/run/nyanpasu/core-1.sock")),
+            Some(CoreControllerInfo::UnixSocket(std::path::PathBuf::from(
+                "/run/nyanpasu/core-1.sock"
+            )))
+        );
+        assert_eq!(
+            map_controller(&Host::http("127.0.0.1:9090").unwrap()),
+            Some(CoreControllerInfo::Http(
+                "http://127.0.0.1:9090/".to_owned()
+            ))
+        );
+    }
+
+    /// The HTTP endpoint is parsed from the caller's own config value; if that
+    /// value carried userinfo, it must not reach the wire.
+    #[test]
+    fn http_controller_credentials_never_reach_the_wire() {
+        for raw in [
+            "http://user:pass@127.0.0.1:9090",
+            "http://user@127.0.0.1:9090",
+        ] {
+            assert_eq!(
+                map_controller(&Host::http(raw).unwrap()),
+                Some(CoreControllerInfo::Http(
+                    "http://127.0.0.1:9090/".to_owned()
+                )),
+                "raw = {raw}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_revision_projection_drops_the_runtime_path() {
+        let revision = ConfigRevision {
+            epoch: 3,
+            generation: 7,
+            source_hash: "0123456789abcdef".to_owned(),
+            effective_hash: "fedcba9876543210".to_owned(),
+            runtime_path: "/srv/data/core-runtime/config-3.yaml".into(),
+        };
+        assert_eq!(
+            map_revision(&revision),
+            ConfigRevisionInfo {
+                epoch: 3,
+                generation: 7,
+                source_hash: "0123456789abcdef".to_owned(),
+                effective_hash: "fedcba9876543210".to_owned(),
+            }
+        );
+    }
+
+    #[test]
+    fn health_states_map_onto_the_wire_health() {
+        // `HealthStatus::starting()` is `pub(crate)` to the manager
+        // (`state.rs:41`) and unreachable from here, but all five fields are
+        // `pub` and the struct is not `#[non_exhaustive]`.
+        let health = HealthStatus {
+            state: HealthState::Unhealthy,
+            changed_at: 1_700_000_000_123,
+            consecutive_failures: 4,
+            last_error: Some("probe timed out".to_owned()),
+            last_success_at: Some(1_700_000_000_000),
+        };
+        let mapped = map_health(&health);
+        assert_eq!(mapped.state, CoreHealthState::Unhealthy);
+        assert_eq!(mapped.changed_at, 1_700_000_000_123);
+        assert_eq!(mapped.consecutive_failures, 4);
+        assert_eq!(mapped.last_error.as_deref(), Some("probe timed out"));
+        assert_eq!(mapped.last_success_at, Some(1_700_000_000_000));
     }
 }
 

--- a/crates/nyanpasu-service-runtime/src/server/manager_bridge.rs
+++ b/crates/nyanpasu-service-runtime/src/server/manager_bridge.rs
@@ -6,9 +6,10 @@ use std::{
 
 use camino::{Utf8Path, Utf8PathBuf};
 use nyanpasu_core_manager::{
-    ApplyOutcome, ConfigRevision, ControllerMode, CoreKind, CoreManager as Manager, CoreSpec,
+    ApplyOutcome, ConfigRevision, CoreKind, CoreManager as Manager, CoreSpec,
     CoreState as ManagerCoreState, CoreStatus, Error as ManagerError, HealthState, HealthStatus,
-    Host, InstanceOptions, InstanceSpec, LogFrame, LogStream, ManagerOptions, RevisionId,
+    Host, InstanceOptions, InstanceSpec, LocalIpcPolicy, LogFrame, LogStream, ManagerOptions,
+    RevisionId,
 };
 use nyanpasu_ipc::api::{
     R, RBuilder,
@@ -109,10 +110,13 @@ pub struct CoreManagerService {
 }
 
 impl CoreManagerService {
-    pub async fn new(runtime_dir: Utf8PathBuf) -> Result<Self, anyhow::Error> {
+    pub async fn new(
+        runtime_dir: Utf8PathBuf,
+        local_ipc_policy: LocalIpcPolicy,
+    ) -> Result<Self, anyhow::Error> {
         let manager = Manager::new(ManagerOptions {
-            controller_mode: ControllerMode::Passthrough,
             runtime_dir: Some(runtime_dir),
+            local_ipc_policy,
             ..ManagerOptions::default()
         })
         .await?;
@@ -469,11 +473,11 @@ fn map_apply_outcome(outcome: &ApplyOutcome) -> CoreApplyData {
         ApplyOutcome::Noop { revision } => (ApplyOutcomeKind::Noop, revision, None),
         ApplyOutcome::Patched { revision } => (ApplyOutcomeKind::Patched, revision, None),
         ApplyOutcome::Reloaded { revision } => (ApplyOutcomeKind::Reloaded, revision, None),
-        // The core-switch path reports `Restarted` too (`manager/apply.rs:531`),
-        // so `ApplyOutcomeKind::Switched` is never produced here. Do not try to
-        // infer it from an epoch change: the pre-call epoch can only be read
-        // outside the manager's control lock.
         ApplyOutcome::Restarted { revision } => (ApplyOutcomeKind::Restarted, revision, None),
+        // Live since S10: the manager reports the core-switch path separately
+        // from a same-epoch restart, so the wire value S8 declared and never
+        // sent is finally produced here.
+        ApplyOutcome::Switched { revision } => (ApplyOutcomeKind::Switched, revision, None),
         ApplyOutcome::RolledBack {
             revision,
             failed_apply,
@@ -995,6 +999,12 @@ mod tests {
                     revision: revision(10),
                 },
                 ApplyOutcomeKind::Restarted,
+            ),
+            (
+                ApplyOutcome::Switched {
+                    revision: revision(11),
+                },
+                ApplyOutcomeKind::Switched,
             ),
         ];
         for (outcome, expected) in cases {

--- a/crates/nyanpasu-service-runtime/src/server/manager_bridge.rs
+++ b/crates/nyanpasu-service-runtime/src/server/manager_bridge.rs
@@ -109,7 +109,7 @@ struct Inner {
     /// Wire-type echo: the manager knows nothing about the alpha variants.
     ///
     /// A watch channel rather than a lock, because committing the echo has to be
-    /// *observable*: it is the only signal a connected v2 client has that the
+    /// *observable*: it is the only signal a connected client has that the
     /// type it was last told about changed, and the manager will not publish a
     /// transition on its behalf. The bridge task holds only a receiver — an
     /// `Arc<Inner>` inside that task would keep the manager alive, so its watch
@@ -340,7 +340,7 @@ impl CoreManagerService {
         )
     }
 
-    /// Publish the wire-type echo the bridge projects into v2 snapshots.
+    /// Publish the wire-type echo the bridge projects into status snapshots.
     ///
     /// `Some` commits a new type, `None` republishes the current one; either way
     /// the send notifies, which is the point. A rolled-back apply must not move
@@ -406,9 +406,9 @@ impl CoreManagerService {
 /// Manager transitions and requested-type commits → ws events.
 ///
 /// Two sources, one emitter. `states` carries the manager's own snapshots and is
-/// the sole input to the v1 `CoreStateChanged` stream, whose guards below are
-/// unchanged. `requested_core` carries the adapter's wire-type echo, which the
-/// manager knows nothing about: without watching it, a client connected over v2
+/// the sole input to the legacy `CoreStateChanged` stream, whose guards below
+/// are unchanged. `requested_core` carries the adapter's wire-type echo, which
+/// the manager knows nothing about: without watching it, a connected client
 /// would keep the type it was last told about until the manager's next
 /// transition, because committing the echo publishes nothing by itself.
 ///
@@ -438,13 +438,14 @@ async fn status_bridge(
                 }
                 let raw = states.borrow_and_update().clone();
                 let next = map_core_state(&raw.state);
-                // v2 leads and is never suppressed: it carries every manager
-                // transition, including the ones the two-valued v1 state cannot
-                // express (Starting, Restarting, and the Stopping/Switching
-                // arrivals the guards below drop). Emitting it here rather than
-                // after the guards is what keeps the v1 path below untouched.
-                // Deliberately no `tracing::info!` for it — that would re-enter
-                // the hub as an `Event::Log` and change what v1 streams carry.
+                // The snapshot leads and is never suppressed: it carries every
+                // manager transition, including the ones the two-valued legacy
+                // state cannot express (Starting, Restarting, and the
+                // Stopping/Switching arrivals the guards below drop). Emitting
+                // it here rather than after the guards is what keeps the legacy
+                // path below untouched. Deliberately no `tracing::info!` for it
+                // — that would re-enter the hub as an `Event::Log` and change
+                // what the legacy stream carries.
                 let requested = requested_core.borrow_and_update().clone();
                 hub.send(WsEvent::new_core_status_changed(project_core_infos(
                     &raw, requested,
@@ -468,10 +469,11 @@ async fn status_bridge(
                     break;
                 }
                 // The echo moved without the manager moving, so this refreshes
-                // the v2 snapshot and nothing else — v1 carries no type and has
-                // no transition to report. `states.borrow()`, never
-                // `borrow_and_update`: marking a manager transition seen here
-                // would swallow it from the v1 path above.
+                // the status snapshot and nothing else — the legacy state
+                // carries no type and has no transition to report.
+                // `states.borrow()`, never `borrow_and_update`: marking a
+                // manager transition seen here would swallow it from the legacy
+                // path above.
                 let raw = states.borrow().clone();
                 let requested = requested_core.borrow_and_update().clone();
                 hub.send(WsEvent::new_core_status_changed(project_core_infos(
@@ -678,10 +680,10 @@ fn same_ipc_state(previous: &CoreState, next: &CoreState) -> bool {
 
 /// The wire projection of a manager snapshot.
 ///
-/// One function so `/status` and the v2 `CoreStatusChanged` frame cannot drift:
+/// One function so `/status` and the `CoreStatusChanged` frame cannot drift:
 /// the event *is* the snapshot (report §4 P1-A). `state` stays the lossy
-/// two-valued field v1 clients depend on; `detail` is the faithful six-state
-/// view beside it.
+/// two-valued field the GUI has always consumed; `detail` is the faithful
+/// six-state view beside it.
 fn project_core_infos(status: &CoreStatus, requested_core: Option<CoreType>) -> CoreInfos {
     CoreInfos {
         r#type: requested_core,
@@ -1320,7 +1322,7 @@ mod tests {
     /// adapter's wire-type echo moves, so before this the frames from a
     /// cross-core apply carried the *previous* type until the next transition.
     #[tokio::test]
-    async fn committing_the_requested_type_publishes_a_fresh_v2_snapshot() {
+    async fn committing_the_requested_type_publishes_a_fresh_status_snapshot() {
         let states = watch::Sender::new(status_of(ManagerCoreState::Stopped { reason: None }));
         let requested = watch::Sender::new(None);
         let hub = EventHub::new();
@@ -1340,7 +1342,8 @@ mod tests {
             .expect("the event hub must stay open");
         assert_eq!(status_frame_type(handshake), None);
 
-        // A manager transition with no echo yet: v2 leads, v1 follows.
+        // A manager transition with no echo yet: the snapshot leads, the legacy
+        // state follows.
         states.send_replace(status_of(ManagerCoreState::Running { epoch: 1, pid: 7 }));
         let status = tokio::time::timeout(Duration::from_secs(5), events.recv())
             .await
@@ -1356,8 +1359,9 @@ mod tests {
             TestEvent::CoreStateChanged(CoreState::Running)
         ));
 
-        // The commit: one v2 snapshot carrying the committed type, and no v1
-        // frame — v1 has no type and no transition to report.
+        // The commit: one status snapshot carrying the committed type, and no
+        // legacy frame — the legacy state carries no type and has no transition
+        // to report.
         requested.send_replace(Some(mihomo()));
         let committed = tokio::time::timeout(Duration::from_secs(5), events.recv())
             .await
@@ -1374,7 +1378,7 @@ mod tests {
             .expect("the bridge must not panic");
         assert!(
             events.try_recv().is_err(),
-            "the echo commit must not produce a v1 frame"
+            "the echo commit must not produce a legacy state frame"
         );
     }
 
@@ -1508,16 +1512,16 @@ mod tests {
         );
     }
 
-    /// Mirrors the restructured bridge loop: what a v1 connection receives
-    /// (after the unchanged suppression rules) and what a v2 connection
-    /// receives (one snapshot per manager transition, none suppressed).
+    /// Mirrors the restructured bridge loop: what the legacy `CoreStateChanged`
+    /// stream carries (after the unchanged suppression rules) and what the
+    /// snapshot stream carries (one per manager transition, none suppressed).
     fn simulate_both(statuses: &[CoreStatus]) -> (Vec<String>, Vec<Option<CoreStateDetail>>) {
         let mut last = CoreState::Stopped(None);
-        let mut v1 = Vec::new();
-        let mut v2 = Vec::new();
+        let mut legacy = Vec::new();
+        let mut snapshots = Vec::new();
         for raw in statuses {
             let next = map_core_state(&raw.state);
-            v2.push(project_core_infos(raw, None).detail);
+            snapshots.push(project_core_infos(raw, None).detail);
             if matches!(
                 raw.state,
                 ManagerCoreState::Stopping { .. } | ManagerCoreState::Switching { .. }
@@ -1528,18 +1532,18 @@ mod tests {
             if same_ipc_state(&last, &next) {
                 continue;
             }
-            v1.push(format!("{next:?}"));
+            legacy.push(format!("{next:?}"));
             last = next;
         }
-        (v1, v2)
+        (legacy, snapshots)
     }
 
-    /// The point of S9: the v1 stream keeps suppressing exactly what it always
-    /// suppressed, while the v2 stream carries every transition — including the
-    /// crash-loop and start-up ones the two-valued v1 state cannot express
-    /// (report §1.2).
+    /// The point of S9, restated after S11: the legacy stream keeps suppressing
+    /// exactly what it always suppressed, while the snapshot stream carries
+    /// every transition — including the crash-loop and start-up ones the
+    /// two-valued legacy state cannot express (report §1.2).
     #[test]
-    fn the_v2_stream_carries_every_transition_the_v1_stream_suppresses() {
+    fn the_snapshot_stream_carries_every_transition_the_legacy_stream_suppresses() {
         let states = [
             ManagerCoreState::Starting { epoch: 1 },
             ManagerCoreState::Running { epoch: 1, pid: 42 },
@@ -1554,12 +1558,12 @@ mod tests {
             },
         ];
         let statuses: Vec<CoreStatus> = states.iter().cloned().map(status_of).collect();
-        let (v1, v2) = simulate_both(&statuses);
+        let (legacy, snapshots) = simulate_both(&statuses);
 
-        // The lossy v1 stream, defect included: the restart in the middle is
-        // reported as a stop, which is why S9 exists.
+        // The lossy legacy stream, defect included: the restart in the middle
+        // is reported as a stop, which is why the snapshot variant exists.
         assert_eq!(
-            v1,
+            legacy,
             [
                 "Running",
                 "Stopped(None)",
@@ -1567,11 +1571,11 @@ mod tests {
                 r#"Stopped(Some("stopped by user"))"#,
             ]
         );
-        // …and the mirror above agrees with the untouched v1 helper.
-        assert_eq!(v1, simulate(&states));
+        // …and the mirror above agrees with the untouched legacy helper.
+        assert_eq!(legacy, simulate(&states));
         // One faithful frame per manager transition, none dropped.
         assert_eq!(
-            v2,
+            snapshots,
             [
                 Some(CoreStateDetail::Starting { epoch: 1 }),
                 Some(CoreStateDetail::Running { epoch: 1, pid: 42 }),
@@ -1588,11 +1592,11 @@ mod tests {
         );
     }
 
-    /// The v2 payload is the S7 projection unchanged: `state` stays the lossy
-    /// field the v1 wire has always carried, `detail` is the faithful one, and
-    /// the type echo comes from the adapter rather than the manager.
+    /// The snapshot payload is the S7 projection unchanged: `state` stays the
+    /// lossy field the wire has always carried, `detail` is the faithful one,
+    /// and the type echo comes from the adapter rather than the manager.
     #[test]
-    fn the_v2_payload_keeps_the_lossy_state_and_adds_the_faithful_detail() {
+    fn the_snapshot_payload_keeps_the_lossy_state_and_adds_the_faithful_detail() {
         let infos = project_core_infos(
             &status_of(ManagerCoreState::Restarting {
                 epoch: 3,

--- a/crates/nyanpasu-service-runtime/src/server/manager_bridge.rs
+++ b/crates/nyanpasu-service-runtime/src/server/manager_bridge.rs
@@ -1330,23 +1330,40 @@ mod tests {
             requested.subscribe(),
             hub.clone(),
         ));
-        tokio::task::yield_now().await;
+
+        // A no-op echo notification proves the bridge has consumed its initial
+        // manager snapshot before the transition below can be published.
+        requested.send_modify(|_| {});
+        let handshake = tokio::time::timeout(Duration::from_secs(5), events.recv())
+            .await
+            .expect("timed out waiting for the bridge readiness snapshot")
+            .expect("the event hub must stay open");
+        assert_eq!(status_frame_type(handshake), None);
 
         // A manager transition with no echo yet: v2 leads, v1 follows.
         states.send_replace(status_of(ManagerCoreState::Running { epoch: 1, pid: 7 }));
-        assert_eq!(status_frame_type(events.recv().await.unwrap()), None);
+        let status = tokio::time::timeout(Duration::from_secs(5), events.recv())
+            .await
+            .expect("timed out waiting for the manager status snapshot")
+            .expect("the event hub must stay open");
+        assert_eq!(status_frame_type(status), None);
+        let state = tokio::time::timeout(Duration::from_secs(5), events.recv())
+            .await
+            .expect("timed out waiting for the legacy state transition")
+            .expect("the event hub must stay open");
         assert!(matches!(
-            events.recv().await.unwrap(),
+            state,
             TestEvent::CoreStateChanged(CoreState::Running)
         ));
 
         // The commit: one v2 snapshot carrying the committed type, and no v1
         // frame — v1 has no type and no transition to report.
         requested.send_replace(Some(mihomo()));
-        assert_eq!(
-            status_frame_type(events.recv().await.unwrap()),
-            Some(mihomo())
-        );
+        let committed = tokio::time::timeout(Duration::from_secs(5), events.recv())
+            .await
+            .expect("timed out waiting for the committed type snapshot")
+            .expect("the event hub must stay open");
+        assert_eq!(status_frame_type(committed), Some(mihomo()));
 
         // Closing the manager's channel ends the task, so anything it was going
         // to send has been sent: the emptiness below is a fact, not a race.
@@ -1377,10 +1394,11 @@ mod tests {
         ));
 
         requested.send_modify(|_| {});
-        assert_eq!(
-            status_frame_type(events.recv().await.unwrap()),
-            Some(mihomo())
-        );
+        let refreshed = tokio::time::timeout(Duration::from_secs(5), events.recv())
+            .await
+            .expect("timed out waiting for the refreshed status snapshot")
+            .expect("the event hub must stay open");
+        assert_eq!(status_frame_type(refreshed), Some(mihomo()));
 
         drop(states);
         tokio::time::timeout(Duration::from_secs(5), task)

--- a/crates/nyanpasu-service-runtime/src/server/manager_bridge.rs
+++ b/crates/nyanpasu-service-runtime/src/server/manager_bridge.rs
@@ -22,14 +22,21 @@ use nyanpasu_ipc::api::{
     ws::events::Event as WsEvent,
 };
 use nyanpasu_utils::core::{ClashCoreType, CoreType};
-use parking_lot::RwLock;
 use serde::{Serialize, de::DeserializeOwned};
-use tokio::sync::broadcast::error::RecvError;
+use tokio::sync::{Semaphore, broadcast::error::RecvError, watch};
 use tracing::instrument;
 
 use super::{consts::RuntimeInfos, events::EventHub};
 
 const CORE_LOG_TARGET: &str = "nyanpasu_service::core";
+
+/// Concurrent `/core/check` operations a service will run. Each one spawns a
+/// core binary, so this is a resource bound, not a fairness knob: two lets an
+/// honest client fire a second check while the first is running, and refuses
+/// the flood a third would begin. Per-service rather than a `static` so the
+/// bound is testable without the runtime crate's tests interfering with each
+/// other.
+const MAX_CONCURRENT_CHECKS: usize = 2;
 
 /// Legacy wire strings the GUI branches on. These are protocol, not
 /// diagnostics: changing any of them is a breaking change to clash-nyanpasu.
@@ -54,6 +61,15 @@ impl OpError {
     fn plain(message: impl Into<String>) -> Self {
         Self {
             kind: None,
+            message: message.into(),
+        }
+    }
+
+    /// A failure the service *can* classify, where the classification is a fact
+    /// about the failure and not a guess about its cause.
+    fn with_kind(kind: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            kind: Some(kind),
             message: message.into(),
         }
     }
@@ -91,13 +107,18 @@ impl From<anyhow::Error> for OpError {
 struct Inner {
     manager: Manager,
     /// Wire-type echo: the manager knows nothing about the alpha variants.
-    /// Behind an `Arc` so the state bridge can read it without capturing the
-    /// whole adapter — an `Arc<Inner>` inside that task would keep the manager
-    /// alive, so its watch channel would never close and the task would never
-    /// exit.
-    requested_core: Arc<RwLock<Option<CoreType>>>,
+    ///
+    /// A watch channel rather than a lock, because committing the echo has to be
+    /// *observable*: it is the only signal a connected v2 client has that the
+    /// type it was last told about changed, and the manager will not publish a
+    /// transition on its behalf. The bridge task holds only a receiver — an
+    /// `Arc<Inner>` inside that task would keep the manager alive, so its watch
+    /// channel would never close and the task would never exit.
+    requested_core: watch::Sender<Option<CoreType>>,
     /// Serializes adapter-level control ops and carries the closing latch.
     control: tokio::sync::Mutex<ControlState>,
+    /// F2 lands here too; see §2.2.
+    check_slots: Semaphore,
 }
 
 struct ControlState {
@@ -123,49 +144,21 @@ impl CoreManagerService {
         Ok(Self {
             inner: Arc::new(Inner {
                 manager,
-                requested_core: Arc::new(RwLock::new(None)),
+                requested_core: watch::Sender::new(None),
                 control: tokio::sync::Mutex::new(ControlState { closing: false }),
+                check_slots: Semaphore::new(MAX_CONCURRENT_CHECKS),
             }),
         })
     }
 
     /// State → ws events and core logs → tracing.
     pub fn spawn_bridges(&self, hub: EventHub) {
-        let mut states = self.inner.manager.subscribe();
-        // Only the echo is cloned in, never the whole adapter: see `Inner`.
-        let requested_core = self.inner.requested_core.clone();
-        tokio::spawn(async move {
-            let raw = states.borrow_and_update().clone();
-            let mut last = map_core_state(&raw.state);
-            while states.changed().await.is_ok() {
-                let raw = states.borrow_and_update().clone();
-                let next = map_core_state(&raw.state);
-                // v2 leads and is never suppressed: it carries every manager
-                // transition, including the ones the two-valued v1 state cannot
-                // express (Starting, Restarting, and the Stopping/Switching
-                // arrivals the guards below drop). Emitting it here rather than
-                // after the guards is what keeps the v1 path below untouched.
-                // Deliberately no `tracing::info!` for it — that would re-enter
-                // the hub as an `Event::Log` and change what v1 streams carry.
-                let requested = requested_core.read().clone();
-                hub.send(WsEvent::new_core_status_changed(project_core_infos(
-                    &raw, requested,
-                )));
-                if matches!(
-                    raw.state,
-                    ManagerCoreState::Stopping { .. } | ManagerCoreState::Switching { .. }
-                ) && matches!(last, CoreState::Stopped(_))
-                {
-                    continue;
-                }
-                if same_ipc_state(&last, &next) {
-                    continue;
-                }
-                tracing::info!("State changed: {:?}", next);
-                hub.send(WsEvent::new_core_state_changed(next.clone()));
-                last = next;
-            }
-        });
+        // Only the two receivers are moved in, never the adapter: see `Inner`.
+        tokio::spawn(status_bridge(
+            self.inner.manager.subscribe(),
+            self.inner.requested_core.subscribe(),
+            hub,
+        ));
 
         let mut logs = self.inner.manager.subscribe_logs();
         tokio::spawn(async move {
@@ -216,7 +209,9 @@ impl CoreManagerService {
         ) {
             anyhow::bail!(MSG_CORE_ALREADY_RUNNING);
         }
-        let spec = self.instance_spec(infos, core_type, config_path)?;
+        let spec = self
+            .instance_spec(infos, core_type, config_path)
+            .map_err(|error| anyhow::anyhow!(error.message))?;
         tracing::info!(
             core_type = %core_type,
             kind = %spec.core.kind,
@@ -226,7 +221,7 @@ impl CoreManagerService {
             "Starting Core"
         );
         self.inner.manager.start(spec).await?;
-        *self.inner.requested_core.write() = Some(core_type.clone());
+        self.publish_requested_core(Some(core_type));
         Ok(())
     }
 
@@ -272,7 +267,7 @@ impl CoreManagerService {
         if control.closing {
             return Err(OpError::plain("service is shutting down"));
         }
-        let config_path = canonical_config_path(config_file)?;
+        let config_path = canonical_config_path(config_file).await?;
         let spec = self.instance_spec(infos, core_type, config_path)?;
         let outcome = self
             .inner
@@ -287,10 +282,11 @@ impl CoreManagerService {
             "Applied config"
         );
         // A rollback put the *old* spec back, so the wire echo must not claim
-        // the core type that was asked for.
-        if data.outcome != ApplyOutcomeKind::RolledBack {
-            *self.inner.requested_core.write() = Some(core_type.clone());
-        }
+        // the core type that was asked for — but the snapshot still moved, so
+        // publish either way.
+        self.publish_requested_core(
+            (data.outcome != ApplyOutcomeKind::RolledBack).then_some(core_type),
+        );
         Ok(data)
     }
 
@@ -311,7 +307,15 @@ impl CoreManagerService {
                 return Err(OpError::plain("service is shutting down"));
             }
         }
-        let config_path = canonical_config_path(config_file)?;
+        // Refused, not queued: waiting would convert a flood into a backlog of
+        // futures that each still intend to spawn a core, and the caller would
+        // learn nothing until its request timed out.
+        let _slot = self.inner.check_slots.try_acquire().map_err(|_| {
+            OpError::plain(format!(
+                "at most {MAX_CONCURRENT_CHECKS} config checks may run at once; retry"
+            ))
+        })?;
+        let config_path = canonical_config_path(config_file).await?;
         let spec = self.instance_spec(infos, core_type, config_path)?;
         self.inner.manager.check_config(&spec).await?;
         Ok(())
@@ -332,23 +336,57 @@ impl CoreManagerService {
     pub async fn status(&self) -> CoreInfos {
         project_core_infos(
             &self.inner.manager.status(),
-            self.inner.requested_core.read().clone(),
+            self.inner.requested_core.borrow().clone(),
         )
     }
 
+    /// Publish the wire-type echo the bridge projects into v2 snapshots.
+    ///
+    /// `Some` commits a new type, `None` republishes the current one; either way
+    /// the send notifies, which is the point. A rolled-back apply must not move
+    /// the echo but still moved the revision and possibly the state, so its
+    /// clients need the fresh snapshot too.
+    ///
+    /// `send_modify`, never `send`: `send` fails when nothing is subscribed and
+    /// does not store the value, so a service whose bridges were never spawned
+    /// would silently lose the echo and report `"type": null` from `/status`
+    /// forever.
+    fn publish_requested_core(&self, committed: Option<&CoreType>) {
+        self.inner.requested_core.send_modify(|echo| {
+            if let Some(core_type) = committed {
+                *echo = Some(core_type.clone());
+            }
+        });
+    }
+
+    /// The manager-facing spec for a wire request.
+    ///
+    /// Returns `OpError` rather than `anyhow::Error` because this is where the
+    /// binary lookup fails, and `find_binary_path`'s only possible error is a
+    /// missing binary (`:601-616`) — a fact worth classifying. The other two
+    /// failures here (a non-UTF-8 directory, an unsupported core kind) stay
+    /// unclassified on purpose.
     fn instance_spec(
         &self,
         infos: &RuntimeInfos,
         core_type: &CoreType,
         config_path: Utf8PathBuf,
-    ) -> Result<InstanceSpec, anyhow::Error> {
+    ) -> Result<InstanceSpec, OpError> {
         let working_dir =
             Utf8PathBuf::from_path_buf(infos.nyanpasu_data_dir.clone()).map_err(|path| {
-                anyhow::anyhow!("nyanpasu data dir is not UTF-8: {}", path.display())
+                OpError::plain(format!(
+                    "nyanpasu data dir is not UTF-8: {}",
+                    path.display()
+                ))
             })?;
-        let binary_path = Utf8PathBuf::from_path_buf(find_binary_path(infos, core_type)?)
-            .map_err(|path| anyhow::anyhow!("core binary path is not UTF-8: {}", path.display()))?;
-        let kind = core_kind(core_type)?;
+        let binary_path = find_binary_path(infos, core_type)
+            .map_err(|error| OpError::with_kind(error_kind::BINARY_NOT_FOUND, error.to_string()))
+            .and_then(|path| {
+                Utf8PathBuf::from_path_buf(path).map_err(|path| {
+                    OpError::plain(format!("core binary path is not UTF-8: {}", path.display()))
+                })
+            })?;
+        let kind = core_kind(core_type).map_err(|error| OpError::plain(error.to_string()))?;
         Ok(InstanceSpec {
             core: CoreSpec {
                 kind,
@@ -362,6 +400,85 @@ impl CoreManagerService {
             pid_file: None,
             options: InstanceOptions::default(),
         })
+    }
+}
+
+/// Manager transitions and requested-type commits → ws events.
+///
+/// Two sources, one emitter. `states` carries the manager's own snapshots and is
+/// the sole input to the v1 `CoreStateChanged` stream, whose guards below are
+/// unchanged. `requested_core` carries the adapter's wire-type echo, which the
+/// manager knows nothing about: without watching it, a client connected over v2
+/// would keep the type it was last told about until the manager's next
+/// transition, because committing the echo publishes nothing by itself.
+///
+/// Ordering, stated honestly: every frame is a snapshot of state observed at or
+/// after the change that woke this task, and after any quiescent moment the last
+/// frame carries the committed values. It is not a 1:1 log of changes — `watch`
+/// coalesces, and when both sources move at once the two arms can emit two
+/// `CoreStatusChanged` frames carrying the same status. Snapshots are
+/// idempotent, so that is harmless.
+///
+/// This is a free function, not a closure, for two reasons: it must not capture
+/// `Arc<Inner>` (its only exit condition is the manager's watch channel closing,
+/// which cannot happen while the manager is alive), and a test can drive it with
+/// hand-built channels.
+async fn status_bridge(
+    mut states: watch::Receiver<CoreStatus>,
+    mut requested_core: watch::Receiver<Option<CoreType>>,
+    hub: EventHub,
+) {
+    let raw = states.borrow_and_update().clone();
+    let mut last = map_core_state(&raw.state);
+    loop {
+        tokio::select! {
+            changed = states.changed() => {
+                if changed.is_err() {
+                    break;
+                }
+                let raw = states.borrow_and_update().clone();
+                let next = map_core_state(&raw.state);
+                // v2 leads and is never suppressed: it carries every manager
+                // transition, including the ones the two-valued v1 state cannot
+                // express (Starting, Restarting, and the Stopping/Switching
+                // arrivals the guards below drop). Emitting it here rather than
+                // after the guards is what keeps the v1 path below untouched.
+                // Deliberately no `tracing::info!` for it — that would re-enter
+                // the hub as an `Event::Log` and change what v1 streams carry.
+                let requested = requested_core.borrow_and_update().clone();
+                hub.send(WsEvent::new_core_status_changed(project_core_infos(
+                    &raw, requested,
+                )));
+                if matches!(
+                    raw.state,
+                    ManagerCoreState::Stopping { .. } | ManagerCoreState::Switching { .. }
+                ) && matches!(last, CoreState::Stopped(_))
+                {
+                    continue;
+                }
+                if same_ipc_state(&last, &next) {
+                    continue;
+                }
+                tracing::info!("State changed: {:?}", next);
+                hub.send(WsEvent::new_core_state_changed(next.clone()));
+                last = next;
+            }
+            changed = requested_core.changed() => {
+                if changed.is_err() {
+                    break;
+                }
+                // The echo moved without the manager moving, so this refreshes
+                // the v2 snapshot and nothing else — v1 carries no type and has
+                // no transition to report. `states.borrow()`, never
+                // `borrow_and_update`: marking a manager transition seen here
+                // would swallow it from the v1 path above.
+                let raw = states.borrow().clone();
+                let requested = requested_core.borrow_and_update().clone();
+                hub.send(WsEvent::new_core_status_changed(project_core_infos(
+                    &raw, requested,
+                )));
+            }
+        }
     }
 }
 
@@ -620,21 +737,36 @@ fn find_binary_path(infos: &RuntimeInfos, core_type: &CoreType) -> std::io::Resu
 /// Same shape as `start`'s inline version: canonicalizing makes the source path
 /// a stable identity, and `dunce::simplified` strips the Windows `\\?\` prefix
 /// the core's own command line cannot use. Canonicalization is also the
-/// existence check.
-fn canonical_config_path(config_file: &Path) -> Result<Utf8PathBuf, OpError> {
-    let canonical = config_file.canonicalize().map_err(|error| {
-        OpError::plain(format!(
-            "failed to resolve config path {}: {error}",
-            config_file.display()
-        ))
-    })?;
+/// existence check, which is why `NotFound` is classified here and nothing else
+/// is: any other io error is a permission or device failure this layer cannot
+/// name without guessing. The path stays in the message — the caller supplied
+/// it and it is the only way to tell which of two paths failed.
+async fn canonical_config_path(config_file: &Path) -> Result<Utf8PathBuf, OpError> {
+    let canonical = tokio::fs::canonicalize(config_file)
+        .await
+        .map_err(|error| {
+            let message = format!(
+                "failed to resolve config path {}: {error}",
+                config_file.display()
+            );
+            match error.kind() {
+                std::io::ErrorKind::NotFound => {
+                    OpError::with_kind(error_kind::CONFIG_NOT_FOUND, message)
+                }
+                _ => OpError::plain(message),
+            }
+        })?;
     Utf8PathBuf::from_path_buf(dunce::simplified(&canonical).to_path_buf())
         .map_err(|path| OpError::plain(format!("config path is not UTF-8: {}", path.display())))
 }
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use nyanpasu_core_manager::StopReason;
+    use nyanpasu_ipc::api::ws::events::Event as TestEvent;
+    use tokio::sync::watch;
 
     use super::*;
 
@@ -1148,6 +1280,214 @@ mod tests {
             controller: None,
             revision: None,
         }
+    }
+
+    fn mihomo() -> CoreType {
+        CoreType::Clash(ClashCoreType::Mihomo)
+    }
+
+    /// The `type` a `CoreStatusChanged` frame carries, or a panic naming what
+    /// arrived instead.
+    fn status_frame_type(event: TestEvent) -> Option<CoreType> {
+        match event {
+            TestEvent::CoreStatusChanged(infos) => infos.r#type,
+            other => panic!("expected a CoreStatusChanged frame, got {other:?}"),
+        }
+    }
+
+    async fn test_service() -> (tempfile::TempDir, CoreManagerService) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let runtime_dir = Utf8PathBuf::from_path_buf(dir.path().join("core-runtime"))
+            .expect("temp path is UTF-8");
+        let service = CoreManagerService::new(runtime_dir, LocalIpcPolicy::Disable)
+            .await
+            .expect("the manager builds on a fresh runtime dir");
+        (dir, service)
+    }
+
+    fn test_infos(root: &std::path::Path) -> RuntimeInfos {
+        RuntimeInfos {
+            service_data_dir: root.join("service-data"),
+            service_config_dir: root.join("service-config"),
+            nyanpasu_config_dir: root.join("nyanpasu-config"),
+            nyanpasu_data_dir: root.join("nyanpasu-data"),
+            nyanpasu_app_dir: root.join("nyanpasu-app"),
+        }
+    }
+
+    /// The review finding, pinned: committing the echo has to reach a client
+    /// that is already connected. The manager publishes nothing when the
+    /// adapter's wire-type echo moves, so before this the frames from a
+    /// cross-core apply carried the *previous* type until the next transition.
+    #[tokio::test]
+    async fn committing_the_requested_type_publishes_a_fresh_v2_snapshot() {
+        let states = watch::Sender::new(status_of(ManagerCoreState::Stopped { reason: None }));
+        let requested = watch::Sender::new(None);
+        let hub = EventHub::new();
+        let mut events = hub.subscribe();
+        let task = tokio::spawn(status_bridge(
+            states.subscribe(),
+            requested.subscribe(),
+            hub.clone(),
+        ));
+        tokio::task::yield_now().await;
+
+        // A manager transition with no echo yet: v2 leads, v1 follows.
+        states.send_replace(status_of(ManagerCoreState::Running { epoch: 1, pid: 7 }));
+        assert_eq!(status_frame_type(events.recv().await.unwrap()), None);
+        assert!(matches!(
+            events.recv().await.unwrap(),
+            TestEvent::CoreStateChanged(CoreState::Running)
+        ));
+
+        // The commit: one v2 snapshot carrying the committed type, and no v1
+        // frame — v1 has no type and no transition to report.
+        requested.send_replace(Some(mihomo()));
+        assert_eq!(
+            status_frame_type(events.recv().await.unwrap()),
+            Some(mihomo())
+        );
+
+        // Closing the manager's channel ends the task, so anything it was going
+        // to send has been sent: the emptiness below is a fact, not a race.
+        drop(states);
+        tokio::time::timeout(Duration::from_secs(5), task)
+            .await
+            .expect("the bridge must exit when the manager drops")
+            .expect("the bridge must not panic");
+        assert!(
+            events.try_recv().is_err(),
+            "the echo commit must not produce a v1 frame"
+        );
+    }
+
+    /// A rolled-back apply must not move the echo, but its clients still need
+    /// the snapshot: the revision moved even though the type did not. The
+    /// adapter republishes the unchanged value, which `send_modify` notifies on.
+    #[tokio::test]
+    async fn republishing_an_unchanged_echo_still_refreshes_the_snapshot() {
+        let states = watch::Sender::new(status_of(ManagerCoreState::Running { epoch: 1, pid: 7 }));
+        let requested = watch::Sender::new(Some(mihomo()));
+        let hub = EventHub::new();
+        let mut events = hub.subscribe();
+        let task = tokio::spawn(status_bridge(
+            states.subscribe(),
+            requested.subscribe(),
+            hub.clone(),
+        ));
+
+        requested.send_modify(|_| {});
+        assert_eq!(
+            status_frame_type(events.recv().await.unwrap()),
+            Some(mihomo())
+        );
+
+        drop(states);
+        tokio::time::timeout(Duration::from_secs(5), task)
+            .await
+            .expect("the bridge must exit when the manager drops")
+            .expect("the bridge must not panic");
+    }
+
+    /// The invariant behind `Inner`'s comment: the task exits when the manager's
+    /// watch channel closes. It must not be kept alive by the echo channel,
+    /// which outlives nothing — a task that survives its manager would hold a
+    /// subscription forever and never emit again.
+    #[tokio::test]
+    async fn the_status_bridge_exits_with_the_manager_even_while_the_echo_lives() {
+        let states = watch::Sender::new(status_of(ManagerCoreState::Stopped { reason: None }));
+        let requested = watch::Sender::new(None);
+        let task = tokio::spawn(status_bridge(
+            states.subscribe(),
+            requested.subscribe(),
+            EventHub::new(),
+        ));
+        drop(states);
+        tokio::time::timeout(Duration::from_secs(5), task)
+            .await
+            .expect("the bridge must exit when the manager drops")
+            .expect("the bridge must not panic");
+        // The echo channel is still open and still writable; nobody is listening.
+        requested.send_modify(|_| {});
+    }
+
+    /// `watch::Sender::send` fails when nothing is subscribed and drops the
+    /// value on the floor. A service whose bridges were never spawned — every
+    /// route test, and the window before `run` spawns them — would then report
+    /// `"type": null` from `/status` forever.
+    #[tokio::test]
+    async fn the_echo_survives_a_service_with_no_bridge_subscribed() {
+        let (_dir, service) = test_service().await;
+        assert!(service.status().await.r#type.is_none());
+        service.publish_requested_core(Some(&mihomo()));
+        assert_eq!(service.status().await.r#type, Some(mihomo()));
+    }
+
+    /// Each check spawns a core binary, so the overflow is refused rather than
+    /// queued. The permit is taken before the path is resolved, which is what
+    /// makes the refusal observable here — and what proves an unresolvable path
+    /// is *not* what produced it: with a slot free, the same call reaches the
+    /// path and reports it with its kind.
+    #[tokio::test]
+    async fn a_third_concurrent_check_is_refused_before_it_can_spawn_a_core() {
+        let (dir, service) = test_service().await;
+        let infos = test_infos(dir.path());
+        let missing = dir.path().join("nope.yaml");
+
+        let held: Vec<_> = (0..MAX_CONCURRENT_CHECKS)
+            .map(|_| {
+                service
+                    .inner
+                    .check_slots
+                    .try_acquire()
+                    .expect("a fresh service has every slot free")
+            })
+            .collect();
+        let refused = service
+            .check(&infos, &mihomo(), &missing)
+            .await
+            .expect_err("the overflow must be refused");
+        assert!(
+            refused.message.contains("config checks may run at once"),
+            "unexpected refusal: {}",
+            refused.message
+        );
+        assert!(refused.kind.is_none(), "a refusal is not a manager error");
+
+        drop(held);
+        let resolved = service
+            .check(&infos, &mihomo(), &missing)
+            .await
+            .expect_err("the path does not exist");
+        assert_eq!(resolved.kind, Some(error_kind::CONFIG_NOT_FOUND));
+        assert!(
+            resolved.message.contains("nope.yaml"),
+            "the failure must name the path: {}",
+            resolved.message
+        );
+    }
+
+    /// A missing core binary is the only failure `find_binary_path` can produce,
+    /// so `apply`/`check` classify it instead of sending an unclassified
+    /// envelope the GUI has to string-match.
+    #[tokio::test]
+    async fn a_missing_core_binary_is_classified_on_the_check_path() {
+        let (dir, service) = test_service().await;
+        let infos = test_infos(dir.path());
+        std::fs::create_dir_all(&infos.nyanpasu_data_dir).unwrap();
+        let config = infos.nyanpasu_data_dir.join("config.yaml");
+        std::fs::write(&config, b"mixed-port: 7890\n").unwrap();
+
+        let error = service
+            .check(&infos, &mihomo(), &config)
+            .await
+            .expect_err("no binary exists under either dir");
+        assert_eq!(error.kind, Some(error_kind::BINARY_NOT_FOUND));
+        assert!(
+            error.message.contains(mihomo().get_executable_name()),
+            "the failure must name the binary: {}",
+            error.message
+        );
     }
 
     /// Mirrors the restructured bridge loop: what a v1 connection receives

--- a/crates/nyanpasu-service-runtime/src/server/mod.rs
+++ b/crates/nyanpasu-service-runtime/src/server/mod.rs
@@ -10,6 +10,7 @@ use consts::RuntimeInfos;
 pub use events::EventHub;
 pub use logger::Logger;
 pub use manager_bridge::CoreManagerService as CoreManager;
+use nyanpasu_core_manager::LocalIpcPolicy;
 use nyanpasu_ipc::{
     SERVICE_PLACEHOLDER,
     api::ws::events::{Event as WsEvent, TraceLog},
@@ -24,6 +25,7 @@ const SERVER_DRAIN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs
 #[instrument(skip(runtime))]
 pub async fn run(
     runtime: RuntimeInfos,
+    local_ipc_policy: LocalIpcPolicy,
     token: CancellationToken,
     #[cfg(windows)] sids: &[&str],
     #[cfg(not(windows))] sids: (),
@@ -31,7 +33,7 @@ pub async fn run(
     let runtime_dir =
         camino::Utf8PathBuf::from_path_buf(crate::utils::dirs::service_core_runtime_dir())
             .map_err(|path| anyhow::anyhow!("core runtime dir is not UTF-8: {}", path.display()))?;
-    let core_manager = CoreManager::new(runtime_dir).await?;
+    let core_manager = CoreManager::new(runtime_dir, local_ipc_policy).await?;
     let hub = EventHub::new();
     core_manager.spawn_bridges(hub.clone());
 

--- a/crates/nyanpasu-service-runtime/src/server/routing/core/apply.rs
+++ b/crates/nyanpasu-service-runtime/src/server/routing/core/apply.rs
@@ -1,0 +1,29 @@
+use axum::{Json, extract::State, http::StatusCode};
+use nyanpasu_ipc::api::{
+    RBuilder,
+    core::apply::{CoreApplyReq, CoreApplyRes},
+};
+
+use crate::server::routing::AppState;
+
+pub async fn apply(
+    State(state): State<AppState>,
+    Json(payload): Json<CoreApplyReq<'_>>,
+) -> (StatusCode, Json<CoreApplyRes<'static>>) {
+    match state
+        .core_manager
+        .apply(
+            &state.runtime,
+            &payload.core_type,
+            &payload.config_file,
+            payload.expected_revision.as_ref(),
+        )
+        .await
+    {
+        Ok(data) => (StatusCode::OK, Json(RBuilder::success(data))),
+        Err(error) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(error.into_envelope()),
+        ),
+    }
+}

--- a/crates/nyanpasu-service-runtime/src/server/routing/core/check.rs
+++ b/crates/nyanpasu-service-runtime/src/server/routing/core/check.rs
@@ -1,0 +1,24 @@
+use axum::{Json, extract::State, http::StatusCode};
+use nyanpasu_ipc::api::{
+    RBuilder,
+    core::check::{CoreCheckReq, CoreCheckRes},
+};
+
+use crate::server::routing::AppState;
+
+pub async fn check(
+    State(state): State<AppState>,
+    Json(payload): Json<CoreCheckReq<'_>>,
+) -> (StatusCode, Json<CoreCheckRes<'static>>) {
+    match state
+        .core_manager
+        .check(&state.runtime, &payload.core_type, &payload.config_file)
+        .await
+    {
+        Ok(()) => (StatusCode::OK, Json(RBuilder::success(()))),
+        Err(error) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(error.into_envelope()),
+        ),
+    }
+}

--- a/crates/nyanpasu-service-runtime/src/server/routing/core/mod.rs
+++ b/crates/nyanpasu-service-runtime/src/server/routing/core/mod.rs
@@ -1,11 +1,14 @@
 use axum::Router;
 use nyanpasu_ipc::{
-    api::contract::{CoreRestart, CoreStart, CoreStop},
+    api::contract::{CoreApply, CoreCheck, CoreRecover, CoreRestart, CoreStart, CoreStop},
     server::RegisterOperation,
 };
 
 use super::AppState;
 
+pub mod apply;
+pub mod check;
+pub mod recover;
 pub mod restart;
 pub mod start;
 pub mod stop;
@@ -15,4 +18,7 @@ pub fn setup() -> Router<AppState> {
         .register(CoreStart, start::start)
         .register(CoreStop, stop::stop)
         .register(CoreRestart, restart::restart)
+        .register(CoreApply, apply::apply)
+        .register(CoreCheck, check::check)
+        .register(CoreRecover, recover::recover)
 }

--- a/crates/nyanpasu-service-runtime/src/server/routing/core/recover.rs
+++ b/crates/nyanpasu-service-runtime/src/server/routing/core/recover.rs
@@ -1,0 +1,14 @@
+use axum::{Json, extract::State, http::StatusCode};
+use nyanpasu_ipc::api::{RBuilder, core::recover::CoreRecoverRes};
+
+use crate::server::routing::AppState;
+
+pub async fn recover(State(state): State<AppState>) -> (StatusCode, Json<CoreRecoverRes<'static>>) {
+    match state.core_manager.recover().await {
+        Ok(()) => (StatusCode::OK, Json(RBuilder::success(()))),
+        Err(error) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(error.into_envelope()),
+        ),
+    }
+}

--- a/crates/nyanpasu-service-runtime/src/server/routing/tests.rs
+++ b/crates/nyanpasu-service-runtime/src/server/routing/tests.rs
@@ -476,9 +476,9 @@ async fn recovering_without_a_quarantine_succeeds() {
     assert!(envelope.data.is_none());
 }
 
-/// The version query is a hint, never a gate: whatever `v` says — including the
-/// duplicated parameter that a `Query` extractor would reject with 400 — the
-/// handshake gets exactly as far as it does without one.
+/// The query string is not protocol: `/ws/events` takes no parameters and must
+/// ignore whatever it is handed — including the duplicated key that a `Query`
+/// extractor would reject with 400, which is the regression this pins.
 ///
 /// 426 is as far as it can get here: `tower::oneshot` hands the router no hyper
 /// upgrade state, so `WebSocketUpgrade` rejects with `ConnectionNotUpgradable`
@@ -486,14 +486,9 @@ async fn recovering_without_a_quarantine_succeeds() {
 /// assertion — a 400 would mean the query string was rejected, a 404/405 that
 /// the route moved.
 #[tokio::test]
-async fn the_event_stream_accepts_any_version_query() {
+async fn the_event_stream_ignores_any_query() {
     let env = TestEnv::new().await;
-    for uri in [
-        EVENT_URI,
-        "/ws/events?v=2",
-        "/ws/events?v=nonsense",
-        "/ws/events?v=1&v=2",
-    ] {
+    for uri in [EVENT_URI, "/ws/events?v=1&v=2"] {
         let response = create_router(env.state.clone())
             .oneshot(
                 Request::builder()

--- a/crates/nyanpasu-service-runtime/src/server/routing/tests.rs
+++ b/crates/nyanpasu-service-runtime/src/server/routing/tests.rs
@@ -1,20 +1,29 @@
-use std::sync::Arc;
+use std::{borrow::Cow, sync::Arc};
 
 use axum::{
     body::{Body, to_bytes},
-    http::{Method, Request, StatusCode, header::HeaderName},
+    http::{
+        Method, Request, StatusCode,
+        header::{CONTENT_TYPE, HeaderName},
+    },
     response::Response,
 };
 use camino::Utf8PathBuf;
 use nyanpasu_ipc::api::{
     ResponseCode,
     contract::{
-        CoreRestart, CoreStart, CoreStop, IpcOperation, LogsInspect, LogsRetrieve, NetworkSetDns,
-        Status as StatusOp,
+        CoreApply, CoreCheck, CoreRecover, CoreRestart, CoreStart, CoreStop, IpcOperation,
+        LogsInspect, LogsRetrieve, NetworkSetDns, Status as StatusOp,
     },
-    core::stop::{CORE_STOP_ENDPOINT, CoreStopRes},
+    core::{
+        apply::{CoreApplyReq, CoreApplyRes},
+        check::{CoreCheckReq, CoreCheckRes},
+        recover::CoreRecoverRes,
+        stop::{CORE_STOP_ENDPOINT, CoreStopRes},
+    },
     status::{CoreState, CoreStateDetail, STATUS_ENDPOINT, StatusRes},
 };
+use nyanpasu_utils::core::{ClashCoreType, CoreType};
 use serde::de::DeserializeOwned;
 use tempfile::TempDir;
 use tower::ServiceExt;
@@ -209,6 +218,9 @@ async fn every_operation_is_mounted_where_its_contract_says() {
         (CoreStart::METHOD, CoreStart::PATH),
         (CoreStop::METHOD, CoreStop::PATH),
         (CoreRestart::METHOD, CoreRestart::PATH),
+        (CoreApply::METHOD, CoreApply::PATH),
+        (CoreCheck::METHOD, CoreCheck::PATH),
+        (CoreRecover::METHOD, CoreRecover::PATH),
         (LogsRetrieve::METHOD, LogsRetrieve::PATH),
         (LogsInspect::METHOD, LogsInspect::PATH),
         (NetworkSetDns::METHOD, NetworkSetDns::PATH),
@@ -319,4 +331,107 @@ async fn status_projects_the_new_fields_from_the_manager_snapshot() {
         body.core_infos.detail,
         Some(CoreStateDetail::Stopped { reason: None })
     );
+}
+
+/// A JSON POST through the production router.
+async fn post_json<T: serde::Serialize>(state: AppState, path: &str, payload: &T) -> Response {
+    create_router(state)
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri(path)
+                .header(CONTENT_TYPE, "application/json")
+                .body(Body::from(serde_json::to_vec(payload).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap()
+}
+
+/// `apply` refuses a stopped core instead of starting one, and the refusal
+/// carries both the legacy string and the new machine-readable kind.
+///
+/// The manager rejects a stopped core before it reads either file
+/// (`manager/apply.rs:25-26`), but the bridge resolves both first, so both have
+/// to exist — the "binary" only has to be findable, never runnable.
+#[tokio::test]
+async fn applying_to_a_stopped_core_reports_not_started_with_its_kind() {
+    let env = TestEnv::new().await;
+    let core_type = CoreType::Clash(ClashCoreType::Mihomo);
+    let data_dir = &env.state.runtime.nyanpasu_data_dir;
+    std::fs::create_dir_all(data_dir).unwrap();
+    std::fs::write(data_dir.join(core_type.get_executable_name()), b"").unwrap();
+    let config = data_dir.join("config.yaml");
+    std::fs::write(&config, b"mixed-port: 7890\n").unwrap();
+
+    let response = post_json(
+        env.state.clone(),
+        CoreApply::PATH,
+        &CoreApplyReq {
+            core_type: Cow::Borrowed(&core_type),
+            config_file: Cow::Borrowed(&config),
+            expected_revision: None,
+        },
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    let envelope: CoreApplyRes<'static> = body_of(response).await;
+    assert_eq!(envelope.code, ResponseCode::OtherError);
+    assert_eq!(envelope.msg, "core have not been started yet");
+    assert_eq!(envelope.error_kind.as_deref(), Some("not_started"));
+    assert!(envelope.data.is_none());
+}
+
+/// An unresolvable config path is answered in the envelope, not by a panic the
+/// catch layer has to convert — and with no kind, because there is no manager
+/// error to classify.
+#[tokio::test]
+async fn checking_an_unresolvable_config_answers_in_the_envelope() {
+    let env = TestEnv::new().await;
+    let core_type = CoreType::Clash(ClashCoreType::Mihomo);
+    let missing = env.state.runtime.nyanpasu_data_dir.join("nope.yaml");
+
+    let response = post_json(
+        env.state.clone(),
+        CoreCheck::PATH,
+        &CoreCheckReq {
+            core_type: Cow::Borrowed(&core_type),
+            config_file: Cow::Borrowed(&missing),
+        },
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    let envelope: CoreCheckRes<'static> = body_of(response).await;
+    assert_eq!(envelope.code, ResponseCode::OtherError);
+    assert!(envelope.error_kind.is_none());
+    assert!(
+        envelope.msg.contains("nope.yaml"),
+        "the failure must name the path: {}",
+        envelope.msg
+    );
+}
+
+/// Recovery is idempotent: with nothing quarantined it succeeds, which is what
+/// makes it safe for a client to call before retrying an operation.
+#[tokio::test]
+async fn recovering_without_a_quarantine_succeeds() {
+    let env = TestEnv::new().await;
+    let response = create_router(env.state.clone())
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri(CoreRecover::PATH)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let envelope: CoreRecoverRes<'static> = body_of(response).await;
+    assert_eq!(envelope.code, ResponseCode::Ok);
+    assert!(envelope.error_kind.is_none());
+    assert!(envelope.data.is_none());
 }

--- a/crates/nyanpasu-service-runtime/src/server/routing/tests.rs
+++ b/crates/nyanpasu-service-runtime/src/server/routing/tests.rs
@@ -11,6 +11,7 @@ use axum::{
     response::Response,
 };
 use camino::Utf8PathBuf;
+use nyanpasu_core_manager::LocalIpcPolicy;
 use nyanpasu_ipc::api::{
     ResponseCode,
     contract::{
@@ -45,7 +46,9 @@ impl TestEnv {
         let root = dir.path();
         let runtime_dir =
             Utf8PathBuf::from_path_buf(root.join("core-runtime")).expect("temp path is UTF-8");
-        let core_manager = CoreManager::new(runtime_dir).await.unwrap();
+        let core_manager = CoreManager::new(runtime_dir, LocalIpcPolicy::Disable)
+            .await
+            .unwrap();
         let runtime = Arc::new(RuntimeInfos {
             service_data_dir: root.join("service-data"),
             service_config_dir: root.join("service-config"),

--- a/crates/nyanpasu-service-runtime/src/server/routing/tests.rs
+++ b/crates/nyanpasu-service-runtime/src/server/routing/tests.rs
@@ -4,7 +4,9 @@ use axum::{
     body::{Body, to_bytes},
     http::{
         Method, Request, StatusCode,
-        header::{CONTENT_TYPE, HeaderName},
+        header::{
+            CONNECTION, CONTENT_TYPE, HeaderName, SEC_WEBSOCKET_KEY, SEC_WEBSOCKET_VERSION, UPGRADE,
+        },
     },
     response::Response,
 };
@@ -22,6 +24,7 @@ use nyanpasu_ipc::api::{
         stop::{CORE_STOP_ENDPOINT, CoreStopRes},
     },
     status::{CoreState, CoreStateDetail, STATUS_ENDPOINT, StatusRes},
+    ws::events::EVENT_URI,
 };
 use nyanpasu_utils::core::{ClashCoreType, CoreType};
 use serde::de::DeserializeOwned;
@@ -434,4 +437,41 @@ async fn recovering_without_a_quarantine_succeeds() {
     assert_eq!(envelope.code, ResponseCode::Ok);
     assert!(envelope.error_kind.is_none());
     assert!(envelope.data.is_none());
+}
+
+/// The version query is a hint, never a gate: whatever `v` says — including the
+/// duplicated parameter that a `Query` extractor would reject with 400 — the
+/// handshake gets exactly as far as it does without one.
+///
+/// 426 is as far as it can get here: `tower::oneshot` hands the router no hyper
+/// upgrade state, so `WebSocketUpgrade` rejects with `ConnectionNotUpgradable`
+/// after every header check has passed. That is what makes it a useful
+/// assertion — a 400 would mean the query string was rejected, a 404/405 that
+/// the route moved.
+#[tokio::test]
+async fn the_event_stream_accepts_any_version_query() {
+    let env = TestEnv::new().await;
+    for uri in [
+        EVENT_URI,
+        "/ws/events?v=2",
+        "/ws/events?v=nonsense",
+        "/ws/events?v=1&v=2",
+    ] {
+        let response = create_router(env.state.clone())
+            .oneshot(
+                Request::builder()
+                    .method(Method::GET)
+                    .uri(uri)
+                    .header(CONNECTION, "upgrade")
+                    .header(UPGRADE, "websocket")
+                    .header(SEC_WEBSOCKET_VERSION, "13")
+                    .header(SEC_WEBSOCKET_KEY, "dGhlIHNhbXBsZSBub25jZQ==")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UPGRADE_REQUIRED, "{uri}");
+    }
 }

--- a/crates/nyanpasu-service-runtime/src/server/routing/tests.rs
+++ b/crates/nyanpasu-service-runtime/src/server/routing/tests.rs
@@ -13,7 +13,7 @@ use nyanpasu_ipc::api::{
         Status as StatusOp,
     },
     core::stop::{CORE_STOP_ENDPOINT, CoreStopRes},
-    status::{CoreState, STATUS_ENDPOINT, StatusRes},
+    status::{CoreState, CoreStateDetail, STATUS_ENDPOINT, StatusRes},
 };
 use serde::de::DeserializeOwned;
 use tempfile::TempDir;
@@ -290,4 +290,33 @@ async fn responses_carry_a_request_id() {
         .await
         .unwrap();
     assert_eq!(echoed.headers().get(&header).unwrap(), "caller-supplied");
+}
+
+#[tokio::test]
+async fn status_projects_the_new_fields_from_the_manager_snapshot() {
+    let env = TestEnv::new().await;
+    let response = create_router(env.state.clone())
+        .oneshot(
+            Request::builder()
+                .uri(STATUS_ENDPOINT)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let envelope: StatusRes<'static> = body_of(response).await;
+    let body = envelope.data.unwrap();
+    // A never-started core: the manager has no instance to report an
+    // endpoint, health observation or revision for.
+    assert!(body.core_infos.controller.is_none());
+    assert!(body.core_infos.health.is_none());
+    assert!(body.core_infos.revision.is_none());
+    // `detail` is populated even when the others are not, and unlike the
+    // two-valued `state` it names the stop reason slot explicitly.
+    assert_eq!(
+        body.core_infos.detail,
+        Some(CoreStateDetail::Stopped { reason: None })
+    );
 }

--- a/crates/nyanpasu-service-runtime/src/server/routing/tests.rs
+++ b/crates/nyanpasu-service-runtime/src/server/routing/tests.rs
@@ -390,8 +390,8 @@ async fn applying_to_a_stopped_core_reports_not_started_with_its_kind() {
 }
 
 /// An unresolvable config path is answered in the envelope, not by a panic the
-/// catch layer has to convert — and with no kind, because there is no manager
-/// error to classify.
+/// catch layer has to convert — and with the kind that says which of the two
+/// paths in the request was the bad one.
 #[tokio::test]
 async fn checking_an_unresolvable_config_answers_in_the_envelope() {
     let env = TestEnv::new().await;
@@ -411,10 +411,44 @@ async fn checking_an_unresolvable_config_answers_in_the_envelope() {
     assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
     let envelope: CoreCheckRes<'static> = body_of(response).await;
     assert_eq!(envelope.code, ResponseCode::OtherError);
-    assert!(envelope.error_kind.is_none());
+    assert_eq!(envelope.error_kind.as_deref(), Some("config_not_found"));
     assert!(
         envelope.msg.contains("nope.yaml"),
         "the failure must name the path: {}",
+        envelope.msg
+    );
+}
+
+/// The mirror image of the fixture above: the config resolves and the binary
+/// does not. Both failures reach the client through the same envelope, and the
+/// kind is what tells them apart without parsing the message.
+#[tokio::test]
+async fn applying_without_a_core_binary_reports_binary_not_found() {
+    let env = TestEnv::new().await;
+    let core_type = CoreType::Clash(ClashCoreType::Mihomo);
+    let data_dir = &env.state.runtime.nyanpasu_data_dir;
+    std::fs::create_dir_all(data_dir).unwrap();
+    let config = data_dir.join("config.yaml");
+    std::fs::write(&config, b"mixed-port: 7890\n").unwrap();
+
+    let response = post_json(
+        env.state.clone(),
+        CoreApply::PATH,
+        &CoreApplyReq {
+            core_type: Cow::Borrowed(&core_type),
+            config_file: Cow::Borrowed(&config),
+            expected_revision: None,
+        },
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    let envelope: CoreApplyRes<'static> = body_of(response).await;
+    assert_eq!(envelope.code, ResponseCode::OtherError);
+    assert_eq!(envelope.error_kind.as_deref(), Some("binary_not_found"));
+    assert!(
+        envelope.msg.contains(core_type.get_executable_name()),
+        "the failure must name the binary: {}",
         envelope.msg
     );
 }

--- a/crates/nyanpasu-service-runtime/src/server/routing/ws.rs
+++ b/crates/nyanpasu-service-runtime/src/server/routing/ws.rs
@@ -1,22 +1,63 @@
 use axum::{
     Router,
     extract::{
-        FromRef, State, WebSocketUpgrade,
+        RawQuery, State, WebSocketUpgrade,
         ws::{Message, WebSocket},
     },
     response::Response,
     routing::any,
 };
-use futures_util::{SinkExt, StreamExt};
-use nyanpasu_ipc::api::ws::events::EVENT_URI;
+use futures_util::{SinkExt, StreamExt, stream::SplitSink};
+use nyanpasu_ipc::api::ws::events::{EVENT_URI, EVENT_VERSION_PARAM, EVENT_VERSION_V2, Event};
 use tokio::sync::broadcast::error::RecvError;
 
 use super::AppState;
-use crate::server::events::{EventHub, WS_LAG_LOG_TARGET};
+use crate::server::{
+    CoreManager,
+    events::{EventHub, WS_LAG_LOG_TARGET},
+};
 
-impl FromRef<AppState> for EventHub {
-    fn from_ref(state: &AppState) -> Self {
-        state.hub.clone()
+/// The event protocol one connection speaks, negotiated once at upgrade time.
+///
+/// Per-connection rather than per-hub: the hub carries every variant and each
+/// socket filters, which is the only arrangement in which one v2 subscriber
+/// cannot expose a new variant to a v1 subscriber.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EventProtocol {
+    V1,
+    V2,
+}
+
+impl EventProtocol {
+    /// Read the version out of a raw query string. Never fails.
+    ///
+    /// Only the exact token `v=2` opts in; absent, empty, unknown, misspelled
+    /// and unparseable all answer v1, the stream every shipped client can
+    /// decode. Parsed by hand rather than with `Query`: `Query` deserialises
+    /// with `serde_urlencoded`, which **rejects** a repeated key with 400 — a
+    /// duplicated `?v=` would kill the upgrade instead of falling back. The
+    /// first `v` wins, and percent-encoding is not decoded: the token is
+    /// compared literally.
+    fn from_query(query: Option<&str>) -> Self {
+        let requested = query.unwrap_or_default().split('&').find_map(|pair| {
+            let (key, value) = pair.split_once('=')?;
+            (key == EVENT_VERSION_PARAM).then_some(value)
+        });
+        match requested {
+            Some(EVENT_VERSION_V2) => Self::V2,
+            _ => Self::V1,
+        }
+    }
+
+    /// Whether a connection at this version may see `event`.
+    ///
+    /// Consulted before serialization, so a v1 socket never carries even the
+    /// bytes of a variant its decoder does not know.
+    fn relays(self, event: &Event) -> bool {
+        match self {
+            Self::V1 => event.is_protocol_v1(),
+            Self::V2 => true,
+        }
     }
 }
 
@@ -25,28 +66,41 @@ pub fn setup() -> Router<AppState> {
     router.route(EVENT_URI, any(ws_handler))
 }
 
-async fn ws_handler(State(hub): State<EventHub>, ws: WebSocketUpgrade) -> Response {
-    ws.on_upgrade(|socket| handle_socket(socket, hub))
+async fn ws_handler(
+    State(state): State<AppState>,
+    RawQuery(query): RawQuery,
+    ws: WebSocketUpgrade,
+) -> Response {
+    let protocol = EventProtocol::from_query(query.as_deref());
+    ws.on_upgrade(move |socket| handle_socket(socket, state.hub, state.core_manager, protocol))
 }
 
-async fn handle_socket(socket: WebSocket, hub: EventHub) {
+async fn handle_socket(
+    socket: WebSocket,
+    hub: EventHub,
+    core_manager: CoreManager,
+    protocol: EventProtocol,
+) {
     // The subscription lives and dies with this task; there is no registry to
-    // insert into and no id to collide with.
+    // insert into and no id to collide with. Subscribing *before* the snapshot
+    // is read is deliberate: a transition landing in between is then delivered
+    // twice rather than lost.
     let mut events = hub.subscribe();
     let (mut sink, mut stream) = socket.split();
 
     let handler = async { while let Some(Ok(_)) = stream.next().await {} };
 
     let sender = async {
+        // Snapshot-on-connect, v2 only: a v1 client cannot decode the variant,
+        // and sending it the legacy state instead would give it a frame it has
+        // never received on connect before.
+        if protocol == EventProtocol::V2 && !send_snapshot(&mut sink, &core_manager).await {
+            return;
+        }
         loop {
             match events.recv().await {
                 Ok(event) => {
-                    let Ok(payload) = simd_json::to_vec(&event) else {
-                        tracing::error!("Failed to serialize event: {:?}", event);
-                        continue;
-                    };
-                    if let Err(e) = sink.send(Message::binary(payload)).await {
-                        tracing::error!("Failed to send event: {:?}", e);
+                    if protocol.relays(&event) && !send_event(&mut sink, &event).await {
                         break;
                     }
                 }
@@ -63,6 +117,15 @@ async fn handle_socket(socket: WebSocket, hub: EventHub) {
                         "ws subscriber dropped {skipped} events"
                     );
                     events = events.resubscribe();
+                    // The gap may have swallowed a transition, so a v2 client
+                    // is resynchronised exactly as it was on connect. This is
+                    // the whole point of the snapshot variant: v1 clients still
+                    // have to poll `/status` after a lag.
+                    if protocol == EventProtocol::V2
+                        && !send_snapshot(&mut sink, &core_manager).await
+                    {
+                        break;
+                    }
                 }
                 Err(RecvError::Closed) => break,
             }
@@ -72,5 +135,121 @@ async fn handle_socket(socket: WebSocket, hub: EventHub) {
     tokio::select! {
         _ = handler => (),
         _ = sender => (),
+    }
+}
+
+/// Push the current status as one frame. `false` means the socket is gone.
+async fn send_snapshot(
+    sink: &mut SplitSink<WebSocket, Message>,
+    core_manager: &CoreManager,
+) -> bool {
+    let event = Event::new_core_status_changed(core_manager.status().await);
+    send_event(sink, &event).await
+}
+
+/// Frame and write one event. `false` means the socket is gone and the sender
+/// must stop; a payload this service cannot serialize is a bug in the payload,
+/// not a broken socket, so it is logged and skipped exactly as before.
+async fn send_event(sink: &mut SplitSink<WebSocket, Message>, event: &Event) -> bool {
+    let Ok(payload) = simd_json::to_vec(event) else {
+        tracing::error!("Failed to serialize event: {:?}", event);
+        return true;
+    };
+    match sink.send(Message::binary(payload)).await {
+        Ok(()) => true,
+        Err(error) => {
+            tracing::error!("Failed to send event: {:?}", error);
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use nyanpasu_ipc::api::{
+        status::{CoreInfos, CoreState, CoreStateDetail},
+        ws::events::TraceLog,
+    };
+
+    use super::*;
+
+    fn snapshot_event() -> Event {
+        Event::new_core_status_changed(CoreInfos {
+            r#type: None,
+            state: CoreState::Stopped(None),
+            state_changed_at: 42,
+            config_path: None,
+            controller: None,
+            health: None,
+            revision: None,
+            detail: Some(CoreStateDetail::Stopped { reason: None }),
+        })
+    }
+
+    /// Negotiation is fail-closed and cannot reject: a typo, an empty value, a
+    /// future version, a duplicated parameter and a garbled query all answer
+    /// v1, which is the only stream every shipped client can decode.
+    #[test]
+    fn the_version_query_only_opts_in_on_the_exact_token() {
+        for query in [
+            Some("v=2"),
+            Some("foo=bar&v=2"),
+            Some("&v=2"),
+            Some("v=2&"),
+            // the first `v` wins
+            Some("v=2&v=1"),
+        ] {
+            assert_eq!(
+                EventProtocol::from_query(query),
+                EventProtocol::V2,
+                "{query:?}"
+            );
+        }
+        for query in [
+            None,
+            Some(""),
+            Some("v=1"),
+            Some("v="),
+            Some("v=abc"),
+            Some("v=3"),
+            Some("v=02"),
+            Some("V=2"),
+            Some("vv=2"),
+            Some("v"),
+            // percent-encoding is not decoded: the token is compared literally
+            Some("v=%32"),
+            Some("%zz"),
+            Some("v=1&v=2"),
+        ] {
+            assert_eq!(
+                EventProtocol::from_query(query),
+                EventProtocol::V1,
+                "{query:?}"
+            );
+        }
+    }
+
+    /// The filter is what makes the new variant safe to broadcast: it runs on
+    /// the decoded event, before serialization, so a v1 socket never carries
+    /// even the bytes of a variant its decoder does not know (report §7 R1).
+    #[test]
+    fn a_v1_connection_is_never_offered_the_v2_variant() {
+        let log = Event::new_log(TraceLog {
+            timestamp: "2026-01-01T00:00:00Z".to_owned(),
+            level: "INFO".to_owned(),
+            message: "hello".to_owned(),
+            target: "nyanpasu_service::core".to_owned(),
+            fields: Default::default(),
+        });
+        let legacy_state = Event::new_core_state_changed(CoreState::Running);
+        let snapshot = snapshot_event();
+
+        assert!(EventProtocol::V1.relays(&log));
+        assert!(EventProtocol::V1.relays(&legacy_state));
+        assert!(!EventProtocol::V1.relays(&snapshot));
+
+        assert!(EventProtocol::V2.relays(&log));
+        assert!(EventProtocol::V2.relays(&legacy_state));
+        assert!(EventProtocol::V2.relays(&snapshot));
     }
 }

--- a/crates/nyanpasu-service-runtime/src/server/routing/ws.rs
+++ b/crates/nyanpasu-service-runtime/src/server/routing/ws.rs
@@ -1,14 +1,14 @@
 use axum::{
     Router,
     extract::{
-        RawQuery, State, WebSocketUpgrade,
+        State, WebSocketUpgrade,
         ws::{Message, WebSocket},
     },
     response::Response,
     routing::any,
 };
 use futures_util::{SinkExt, StreamExt, stream::SplitSink};
-use nyanpasu_ipc::api::ws::events::{EVENT_URI, EVENT_VERSION_PARAM, EVENT_VERSION_V2, Event};
+use nyanpasu_ipc::api::ws::events::{EVENT_URI, Event};
 use tokio::sync::broadcast::error::RecvError;
 
 use super::AppState;
@@ -17,70 +17,19 @@ use crate::server::{
     events::{EventHub, WS_LAG_LOG_TARGET},
 };
 
-/// The event protocol one connection speaks, negotiated once at upgrade time.
-///
-/// Per-connection rather than per-hub: the hub carries every variant and each
-/// socket filters, which is the only arrangement in which one v2 subscriber
-/// cannot expose a new variant to a v1 subscriber.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum EventProtocol {
-    V1,
-    V2,
-}
-
-impl EventProtocol {
-    /// Read the version out of a raw query string. Never fails.
-    ///
-    /// Only the exact token `v=2` opts in; absent, empty, unknown, misspelled
-    /// and unparseable all answer v1, the stream every shipped client can
-    /// decode. Parsed by hand rather than with `Query`: `Query` deserialises
-    /// with `serde_urlencoded`, which **rejects** a repeated key with 400 — a
-    /// duplicated `?v=` would kill the upgrade instead of falling back. The
-    /// first `v` wins, and percent-encoding is not decoded: the token is
-    /// compared literally.
-    fn from_query(query: Option<&str>) -> Self {
-        let requested = query.unwrap_or_default().split('&').find_map(|pair| {
-            let (key, value) = pair.split_once('=')?;
-            (key == EVENT_VERSION_PARAM).then_some(value)
-        });
-        match requested {
-            Some(EVENT_VERSION_V2) => Self::V2,
-            _ => Self::V1,
-        }
-    }
-
-    /// Whether a connection at this version may see `event`.
-    ///
-    /// Consulted before serialization, so a v1 socket never carries even the
-    /// bytes of a variant its decoder does not know.
-    fn relays(self, event: &Event) -> bool {
-        match self {
-            Self::V1 => event.is_protocol_v1(),
-            Self::V2 => true,
-        }
-    }
-}
-
 pub fn setup() -> Router<AppState> {
     let router = Router::new();
     router.route(EVENT_URI, any(ws_handler))
 }
 
-async fn ws_handler(
-    State(state): State<AppState>,
-    RawQuery(query): RawQuery,
-    ws: WebSocketUpgrade,
-) -> Response {
-    let protocol = EventProtocol::from_query(query.as_deref());
-    ws.on_upgrade(move |socket| handle_socket(socket, state.hub, state.core_manager, protocol))
+/// One protocol, no negotiation: the service binary ships with the program that
+/// consumes it, so there is no client to shield from a variant it cannot decode.
+/// The query string is not extracted at all — routing ignores it, and so do we.
+async fn ws_handler(State(state): State<AppState>, ws: WebSocketUpgrade) -> Response {
+    ws.on_upgrade(move |socket| handle_socket(socket, state.hub, state.core_manager))
 }
 
-async fn handle_socket(
-    socket: WebSocket,
-    hub: EventHub,
-    core_manager: CoreManager,
-    protocol: EventProtocol,
-) {
+async fn handle_socket(socket: WebSocket, hub: EventHub, core_manager: CoreManager) {
     // The subscription lives and dies with this task; there is no registry to
     // insert into and no id to collide with. Subscribing *before* the snapshot
     // is read is deliberate: a transition landing in between is then delivered
@@ -91,16 +40,16 @@ async fn handle_socket(
     let handler = async { while let Some(Ok(_)) = stream.next().await {} };
 
     let sender = async {
-        // Snapshot-on-connect, v2 only: a v1 client cannot decode the variant,
-        // and sending it the legacy state instead would give it a frame it has
-        // never received on connect before.
-        if protocol == EventProtocol::V2 && !send_snapshot(&mut sink, &core_manager).await {
+        // Snapshot-on-connect, for everyone: the socket's first frame is the
+        // current status, so a client never has to poll `/status` to find out
+        // what it reconnected to.
+        if !send_snapshot(&mut sink, &core_manager).await {
             return;
         }
         loop {
             match events.recv().await {
                 Ok(event) => {
-                    if protocol.relays(&event) && !send_event(&mut sink, &event).await {
+                    if !send_event(&mut sink, &event).await {
                         break;
                     }
                 }
@@ -117,13 +66,11 @@ async fn handle_socket(
                         "ws subscriber dropped {skipped} events"
                     );
                     events = events.resubscribe();
-                    // The gap may have swallowed a transition, so a v2 client
-                    // is resynchronised exactly as it was on connect. This is
-                    // the whole point of the snapshot variant: v1 clients still
-                    // have to poll `/status` after a lag.
-                    if protocol == EventProtocol::V2
-                        && !send_snapshot(&mut sink, &core_manager).await
-                    {
+                    // The gap may have swallowed a transition, so the client is
+                    // resynchronised exactly as it was on connect. This is what
+                    // the snapshot variant is for: nobody has to poll `/status`
+                    // after a lag.
+                    if !send_snapshot(&mut sink, &core_manager).await {
                         break;
                     }
                 }
@@ -161,95 +108,5 @@ async fn send_event(sink: &mut SplitSink<WebSocket, Message>, event: &Event) -> 
             tracing::error!("Failed to send event: {:?}", error);
             false
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use nyanpasu_ipc::api::{
-        status::{CoreInfos, CoreState, CoreStateDetail},
-        ws::events::TraceLog,
-    };
-
-    use super::*;
-
-    fn snapshot_event() -> Event {
-        Event::new_core_status_changed(CoreInfos {
-            r#type: None,
-            state: CoreState::Stopped(None),
-            state_changed_at: 42,
-            config_path: None,
-            controller: None,
-            health: None,
-            revision: None,
-            detail: Some(CoreStateDetail::Stopped { reason: None }),
-        })
-    }
-
-    /// Negotiation is fail-closed and cannot reject: a typo, an empty value, a
-    /// future version, a duplicated parameter and a garbled query all answer
-    /// v1, which is the only stream every shipped client can decode.
-    #[test]
-    fn the_version_query_only_opts_in_on_the_exact_token() {
-        for query in [
-            Some("v=2"),
-            Some("foo=bar&v=2"),
-            Some("&v=2"),
-            Some("v=2&"),
-            // the first `v` wins
-            Some("v=2&v=1"),
-        ] {
-            assert_eq!(
-                EventProtocol::from_query(query),
-                EventProtocol::V2,
-                "{query:?}"
-            );
-        }
-        for query in [
-            None,
-            Some(""),
-            Some("v=1"),
-            Some("v="),
-            Some("v=abc"),
-            Some("v=3"),
-            Some("v=02"),
-            Some("V=2"),
-            Some("vv=2"),
-            Some("v"),
-            // percent-encoding is not decoded: the token is compared literally
-            Some("v=%32"),
-            Some("%zz"),
-            Some("v=1&v=2"),
-        ] {
-            assert_eq!(
-                EventProtocol::from_query(query),
-                EventProtocol::V1,
-                "{query:?}"
-            );
-        }
-    }
-
-    /// The filter is what makes the new variant safe to broadcast: it runs on
-    /// the decoded event, before serialization, so a v1 socket never carries
-    /// even the bytes of a variant its decoder does not know (report §7 R1).
-    #[test]
-    fn a_v1_connection_is_never_offered_the_v2_variant() {
-        let log = Event::new_log(TraceLog {
-            timestamp: "2026-01-01T00:00:00Z".to_owned(),
-            level: "INFO".to_owned(),
-            message: "hello".to_owned(),
-            target: "nyanpasu_service::core".to_owned(),
-            fields: Default::default(),
-        });
-        let legacy_state = Event::new_core_state_changed(CoreState::Running);
-        let snapshot = snapshot_event();
-
-        assert!(EventProtocol::V1.relays(&log));
-        assert!(EventProtocol::V1.relays(&legacy_state));
-        assert!(!EventProtocol::V1.relays(&snapshot));
-
-        assert!(EventProtocol::V2.relays(&log));
-        assert!(EventProtocol::V2.relays(&legacy_state));
-        assert!(EventProtocol::V2.relays(&snapshot));
     }
 }

--- a/docs/superpowers/specs/2026-07-30-ipc-protocol-evolution-report.md
+++ b/docs/superpowers/specs/2026-07-30-ipc-protocol-evolution-report.md
@@ -1,0 +1,202 @@
+# nyanpasu-service IPC 协议演进改进报告:状态暴露、update_config 与 config 一致性
+
+- 日期:2026-07-30
+- 状态:改进报告(提案,待评审)
+- 前置:docs/superpowers/specs/2026-07-29-service-evolution-design.md(S1–S5 已合入 main @ 940076b);其 §2.2 将"丰富状态暴露、switch 专用端点"明确列为非目标延后,O1/O6 记录了延后决定。本报告即该"协议演进"阶段的具体化。
+- 目标:**调用方使用 service client 与直接使用 `nyanpasu-core-manager` 拥有对等能力**(观测 + 运行时操作;不含嵌入期策略,见 §3)。
+- 调查方式:两个独立代码级调查(IPC 操作面 / core-manager 能力面),全部结论有 file:line 佐证。
+
+---
+
+## 1. 现状确认(代码证据)
+
+### 1.1 内核 IPC 端点信息:manager 已持有,桥接层丢弃
+
+- manager 侧完整持有:`CoreStatus.controller: Option<clash_api::Host>`(`crates/nyanpasu-core-manager/src/state.rs:181-190`),`Host = NamedPipe(PathBuf) | UnixSocket(PathBuf) | Http(Url)`(`crates/clash-api/src/client.rs:20-24`);secret 在 `ResolvedController { host, secret }`(`crates/nyanpasu-core-manager/src/spec.rs:52-57`)。
+- 丢弃点唯一:`CoreManagerService::status`(`crates/nyanpasu-service-runtime/src/server/manager_bridge.rs:165-173`)构造 wire `CoreInfos` 时仅保留 `type/state/state_changed_at/config_path`,`controller`、`health`、`revision`、`capabilities`、`pid`、`epoch` 全部读过即丢。
+- **secret 从不发布**:所有 publish 位点(`src/manager/publish.rs`)只发 host 不发 secret;secret 仅 `Instance::controller()` 可得,而 manager 不外借 `Instance`。
+- `ControllerMode::Passthrough` 硬编码于 `manager_bridge.rs:46-51`,无任何参数可改。Managed 模式的 epoch 级端点生成(`config/mod.rs:244-266`)、controller 重写(`config/clash.rs:61-76`)、graceful 零停机切换(`switching.rs:171-368`)对 service 全部是死代码。
+- Passthrough 下端点**来自调用方自己的 config**(`config/clash.rs:39-51` inspect;无 controller 声明则 `Error::ControllerMissing` 拒绝启动,`config/mod.rs:215-226`)。
+
+### 1.2 状态推送:二值枚举,有损且有语义缺陷
+
+- 事件枚举仅两变体:`Event::Log(TraceLog) | CoreStateChanged(CoreState)`(`nyanpasu_ipc/src/api/ws/events.rs:8-21`);`CoreState` 仅 `Running | Stopped(Option<String>)`。
+- `map_core_state`(`manager_bridge.rs:226-240`)有损映射:manager 六态 `Stopped/Starting/Running/Restarting/Switching/Stopping`(`state.rs:108-131`)压缩后丢弃 `epoch/pid/attempt/from/to`。两个尖锐后果:
+  1. **崩溃循环显示为已停止**:`Restarting { attempt }` → `Stopped(None)`,客户端无法区分真停止与自动重启中;
+  2. **Starting 期间自相矛盾**:事件流报 `Stopped(None)`,但此刻调 `start` 会收到 `"core is already running"`(`manager_bridge.rs:129-134`)。
+- ws 无重放/补发/快照:断线或 `Lagged` 后 `resubscribe()` 跳到实时尾部(`routing/ws.rs:60-66`),客户端必须另行轮询 `/status` 重新同步。
+- 兼容性事实(已实测确认):客户端 `EventStream` 逐条解码,未知变体只产生**单条** `Err(Decode)`,流不中断(`client/shortcuts.rs:89-108` filter_map 语义)。GUI 消费侧是否把单条错误当致命错误未验证。
+
+### 1.3 update_config:wire 零命中,manager 侧整套引擎无人调用
+
+- 契约封闭为 7 操作(`nyanpasu_ipc/src/api/contract.rs:45-113`):status / core-start / core-stop / core-restart / logs×2 / set_dns。grep `update_config|apply_config|patch_config|reload|switch` 全仓 wire 层零命中。
+- manager 侧**已实现且公开、但零调用方**的能力:
+  - `apply_config(spec, expected_revision)`(`manager/apply.rs:19`):自动分类 → `Noop | Patched(PATCH /configs,22+42+55 字段白名单)| Reloaded(PUT /configs)| Restarted(同 epoch,带备份回滚)| RolledBack | DurabilityUncertain`;`RevisionId` 乐观并发(`RevisionConflict` 错误);patch 后 `GET /configs` **逐叶校验**(`config/mihomo.rs:179-185`)。
+  - `switch(spec)`(`switching.rs:56`)、`check_config`(干跑校验,`manager/mod.rs:462`)、`recover_quarantine`(`quarantine.rs:18`)。
+- 设计稿 §4.1 预留的 `last_revision: RwLock<Option<RevisionId>>` 字段(设计稿 :102-104)在落地的 `Inner`(`manager_bridge.rs:27-33`)中不存在。
+- Passthrough 下 `restart()` 恒走 hard switch(`switching.rs:33-35` 返回 `DegradeReason::PassthroughMode`)。**服务客户端改配置的唯一途径 = 覆写文件 + `POST /core/restart` = 全量进程重启,有停机窗口,无回滚。**
+- 隔离死锁:未确认死亡触发 quarantine 后,`start/restart/switch/apply` 永久报 `ManagerQuarantined`,唯一解锁 API `recover_quarantine` 无 IPC 端点——客户端只能重启整个服务。
+
+### 1.4 config 一致性:机制存在,但对调用方完全不可观测
+
+回答"core manager 是否全权管理推送过来的 config":**是,且比预期更深**——
+
+- 调用方的 config 文件只是"源":manager `canonicalize`(递归按键排序、去注释、展开锚点、**拒绝** YAML tag 与非字符串键,`config/mod.rs:162-191`)→ 重新序列化 → 提交为私有运行时副本 `{service_data_dir}/core-runtime/config-{epoch}.yaml`(`runtime_store.rs:127-129,194-206`;目录 0o700/加固 ACL)。**核心运行的是运行时副本,不是调用方的文件**(`switching.rs:443-445` 重定向 `effective_spec.config_path`)。
+- Passthrough 下不注入/不改写任何语义字段(controller 三键与 secret 原样);变化仅在序列化形态与文件位置。
+- `/status` 回显的 `config_path` 是**源路径**(`publish.rs:116-126` 始终用 `source_spec`)——调用方改了源文件后读 status,路径不变、无 revision 可看,**无从判断运行中的核心是否已采纳修改**。
+- "最终一致"的保证机制 manager 内部其实完备:patch 逐叶验证、reload/restart 以运行时文件为准、失败显式回滚为 `RolledBack`、`effective_hash`(FNV-1a over canonical YAML,`config/mod.rs:197-206`)作为变更身份。**缺的只是可观测性**:`ApplyOutcome` 不可达、`SwitchOutcome` 被 `Ok(_outcome) => Ok(())` 丢弃(`manager_bridge.rs:158-159`)、`DurabilityUncertain` 压平成字符串。若 `apply_config` 接线后不暴露结果,`RolledBack`(核心实际在跑**旧**配置)将与成功不可区分——这是必须一并解决的。
+
+### 1.5 根因收敛
+
+整个差距面收敛于两点,均为上轮设计的**有意延后**(O1/O6),非疏漏:
+
+1. `manager_bridge.rs:47` 的 `ControllerMode::Passthrough` 硬编码 —— 独自关闭了 managed 端点、graceful 切换、无 controller 配置启动等一整类能力;
+2. `contract.rs` 七操作封闭集 —— 缺 apply/switch/check/recover 四个操作与状态载荷的丰富化。
+
+---
+
+## 2. 能力对等矩阵(摘要)
+
+完整 36 行矩阵见调查原文;按类别归并:
+
+| 类别 | 直接使用 manager | 经 service IPC | 差距定级 |
+|---|---|---|---|
+| 生命周期 start/stop/restart | ✅ | ✅(restart 恒 hard) | 可接受 |
+| 运行时改配置(patch/reload/同epoch重启+回滚/graceful切换) | ✅ `apply_config`/`switch` | ❌ 只能重启 | **P0** |
+| 乐观并发(RevisionId) | ✅ | ❌ | **P0**(随 apply) |
+| 观测:controller 端点 | ✅ host | ❌ | **P0**(O6 前置) |
+| 观测:revision(epoch/generation/双哈希/runtime_path) | ✅ | ❌ | **P0**(一致性确认的载体) |
+| 观测:health(状态/连败/最近错误) | ✅ | ❌(status.rs:38 留有 TODO) | **P1** |
+| 观测:epoch/pid/attempt/六态 | ✅ | ❌(压成二值) | **P1** |
+| 观测:apply/switch 结果(RolledBack 等) | ✅ | ❌ | **P0**(随 apply) |
+| check_config 干跑 | ✅ | ❌ | P1 |
+| recover_quarantine | ✅ | ❌(只能重启服务) | **P1**(运维死锁) |
+| 结构化错误(23 变体) | ✅ | ❌(压成字符串) | P2 |
+| 结构化 LogFrame | ✅ | 部分(压进 TraceLog.fields) | P2 |
+| 观测:生效 config 全文 | ❌(manager 也只给哈希+路径) | ❌ | 不做(见 §3) |
+
+## 3. 对等的边界:明确不暴露清单
+
+"对等"定义为**运行时操作 + 观测**对等。以下属嵌入期/进程内策略,不应过 IPC(避免过度设计):
+
+- probe 注入(`CoreManagerBuilder`)、`InstanceOptions`(超时/重启策略/退避)、`LocalIpcPolicy` 每请求定制 —— 服务级启动配置即可;
+- `Instance`/`InstanceBuilder` 直接监督、`RuntimeConfigStore` 直接读写 —— 服务私有;
+- **secret 不上 wire**:两种模式下 secret 都源自调用方 config(manager 从不生成),调用方本来就知道;而 IPC 的 HTTP 层无认证、socket ACL 是唯一门槛(`nyanpasu_ipc/src/server/mod.rs:106-128`),暴露 secret 只增风险无收益。若未来 Managed 模式自动生成 secret,再作为独立决策(带权限设计)重提;
+- 生效 config **全文**不暴露:`Active.effective_document` 连 manager 都是私有;哈希 + 结果枚举足以支撑一致性确认。
+
+## 4. 改进方案
+
+### P0-A:状态暴露增强(纯加字段,wire 兼容)
+
+`CoreInfos` 新增字段,全部 `Option` + `#[serde(default)]`(旧 GUI serde 默认忽略未知字段,旧 golden 样例继续通过):
+
+```rust
+pub struct CoreInfos {
+    pub r#type: Option<CoreType>,
+    pub state: CoreState,                      // wire 二值枚举不动(兼容)
+    pub state_changed_at: i64,
+    pub config_path: Option<PathBuf>,          // 语义不变:源路径
+    // ---- 新增 ----
+    pub controller: Option<CoreControllerInfo>, // NamedPipe(PathBuf)|UnixSocket(PathBuf)|Http(String)
+    pub health: Option<CoreHealthInfo>,         // state/changed_at/consecutive_failures/last_error
+    pub revision: Option<ConfigRevisionInfo>,   // epoch/generation/source_hash/effective_hash
+    pub detail: Option<CoreStateDetail>,        // 六态全息:epoch/pid/attempt/from/to
+}
+```
+
+- `CoreControllerInfo` 定义在 `nyanpasu_ipc::api`,**不直接复用** `clash_api::Host`(clash-api 目前只是 core-manager 的内部依赖,不让它泄漏进 wire 依赖树);
+- `runtime_path` 不进 wire:客户端因 0o700/ACL 读不了,暴露只会误导;一致性确认靠哈希(见 P0-C);
+- 顺带补齐 specta 派生缺口(现状仅 status 类型有 TS 绑定,请求载荷与事件全部没有 —— `api/core/start.rs`、`api/ws/events.rs` 等)。
+
+### P0-B:`/core/apply` 端点(update_config 的正式形态)
+
+```rust
+pub struct CoreApplyReq<'n> {
+    pub core_type: Cow<'n, CoreType>,
+    pub config_file: Cow<'n, PathBuf>,
+    pub expected_revision: Option<RevisionIdInfo>,  // 乐观并发,None = 不检查
+}
+pub struct CoreApplyData {
+    pub outcome: ApplyOutcomeKind,   // noop|patched|reloaded|restarted|switched|rolled_back
+    pub revision: ConfigRevisionInfo,
+    pub warning: Option<String>,     // DurabilityUncertain 等降级信息,结构化保留
+    pub failed_apply: Option<String>,// rolled_back 时:失败原因
+}
+```
+
+- 直通 `manager.apply_config`;`process_spec` 变化(含换核)manager 内部自动路由到 switch,**无需独立 `/core/switch` 端点**(O1 以此方式收敛);
+- 语义定界:核心未启动时报错(保持 `start` 的显式性,不做隐式启动);`start` 在运行中仍报错(旧语义不动);
+- `RevisionConflict` 等错误:**不动** `ResponseCode` 枚举(旧客户端对未知变体会解码失败),在 envelope `R` 上新增 `error_kind: Option<String>` 字段(additive-safe)或约定 msg 前缀;倾向前者;
+- 适配器补上设计稿预留的 `last_revision` 字段,`apply` 成功后更新,`expected_revision` 缺省时可选地以其兜底(细节实施时定);
+- CLI 同步:`rpc apply-config --core-type mihomo --config <path> [--expected-revision <id>]`。
+
+### P0-C:一致性确认闭环(回答"最终 config 应与修改一致")
+
+一致性语义定义:**canonical 语义等价**,以 `effective_hash` 为身份;字节级差异(排序/注释/锚点)是 canonicalize 的设计使然,不视为漂移。
+
+调用方确认协议:
+
+1. `apply` 响应携带 `revision.source_hash` —— 调用方持有源文件,service 回显它算出的源哈希,调用方对照即知"service 读到的就是我写的那份"(无需在客户端复刻 FNV-1a 实现);
+2. `outcome` 显式区分 `rolled_back`(此时核心运行**旧**配置,revision 为旧值)—— 消除"回滚被当成成功"的静默错误;
+3. `/status` 携带同一 `revision` —— 任意时刻可复核;`CoreStateChanged` v2 载荷同(见 P1-A),推送即自带一致性凭据;
+4. 漂移检测:调用方改盘上源文件未 apply → 本地文件 mtime/内容 与 status.revision.source_hash 不符,GUI 可提示"配置已修改未生效"。
+
+既有行为注明:canonicalize 拒绝 YAML tag 与非字符串键,比 mihomo 本身更严格(`config/mod.rs:166-171,186-188`)——`/core/check`(P1-B)可让 GUI 在保存前预检。
+
+### P1-A:事件推送增强
+
+- 新增变体 `Event::CoreStatusChanged(CoreStatusPayload)`,载荷 = P0-A 的完整快照(六态 detail + controller + revision + health)。**推送即快照**,对齐 manager 的 watch 语义;
+- 兼容策略:已确认旧 client 库遇未知变体仅单条 `Err(Decode)`、流不断;但 GUI 消费侧行为未验证 → 采用 **ws 版本协商**(`/ws/events?v=2`;无参数 = v1 只发旧两变体),一个过渡版本后 GUI 升级完毕再默认 v2。旧 `CoreStateChanged` 在 v2 下仍双发一版,给脚本类消费者缓冲;
+- **连接即快照**(snapshot-on-connect):ws 建立后先推一帧当前 `CoreStatusChanged`,消除"断线重连后必须轮询 /status"的重同步竞态,`Lagged` 后 `resubscribe()` 同样补发一帧;
+- 顺带修正语义缺陷:v2 载荷中 `Starting/Restarting` 不再伪装成 `Stopped(None)`(旧 v1 映射不动,保持兼容)。
+
+### P1-B:配套运维端点
+
+- `POST /core/check`:直通 `check_config` 干跑(GUI"验证配置"按钮;当前校验只能靠真启动);
+- `POST /core/recover`:直通 `recover_quarantine`,解除隔离死锁(当前唯一解法是重启整个服务)。与其他操作同 socket ACL,无新增权限面。
+
+### P2:移除 `ControllerMode`,`LocalIpcPolicy` 成为唯一旋钮(O6 收敛为一次性移除)
+
+2026-07-30 追加复核后的决策:不做"Managed 参数化 + 日后默认化翻转"的过渡态,直接删除 `ControllerMode` 枚举。依据:Managed 自带的 `LocalIpcPolicy` 三档(`spec.rs:62-73`)已覆盖 Passthrough 绝大部分场景——`Prefer` 承接不支持本地 IPC 的老内核(回落源 config 的 HTTP,`capability.rs:169-172`),`Disable` 承接 HTTP 面板直连诉求(行为 ≈ 今日 Passthrough)。Passthrough 独有语义仅剩"尊重用户自声明的 `external-controller-pipe`/`-unix`"(完整 `inspect` `clash.rs:39-51` vs `inspect_http` `clash.rs:53-58`),属小众用法,决定放弃。
+
+- **core-manager 侧**:删除 `ControllerMode` 枚举,`local_ipc_policy` / `derived_dir` / `controller_template` 平铺进 `ManagerOptions`;随之删除 `prepare` 的 mode match(`config/mod.rs:125-139`)、`DegradeReason::PassthroughMode` 臂(`switching.rs:33-35`)、`runtime_dir`/`derived_dir` 双目录兼容逻辑(`spec.rs:97-99`);graceful 门槛简化为 local-ipc + kind + overlap 三条件;测试矩阵少一个模式维度。
+- **service 侧**:`local_ipc_policy` 从服务启动参数/配置注入(`install` 长参 + `NYANPASU_*` env,沿用 S5 模式);**过渡默认 `Disable`**——对声明了 `external-controller` 的现有 GUI config 行为不变,过渡态由 policy 天然承载,不需要保留枚举做"日后翻转";GUI 完成端点发现适配(消费 P0-A 的 `controller` 字段)后,默认切 `Prefer`。
+- **收益**:服务端永久摆脱"restart 恒 hard switch"降级路径——policy 命中 LocalIpc 后,P0-B 的 `/core/apply` 无需任何改动即自动享受 graceful 零停机切换;config 不再强制声明 `external-controller`(`ControllerMissing` 仅剩 Disable / Prefer 回落且无 HTTP 键一种情形);控制通道默认收敛到 0o700 目录下的 pipe/socket,不再默认暴露 localhost TCP。
+- **代价(已接受)**:用户自声明 pipe/unix 路径不再支持;LocalIpc 命中时 HTTP `external-controller` 被无条件移除(`clash.rs:61-70`,graceful 的 epoch 隔离所需)——第三方面板(yacd/metacubexd)直连需显式 `Disable`,以放弃 graceful 为代价。
+- **约束解除**:上轮设计"crates/* 只消费不改动"的约束到此阶段正式解除;`ManagerOptions` 是公开 API,GUI 若有进程内复用计划需同版本协调。
+
+### P3(可选,不阻塞):错误与日志结构化
+
+- envelope 增 `error_kind`(见 P0-B)逐步映射 manager 的 23 个错误变体;
+- 新变体 `Event::CoreLog(LogFrameInfo)` 结构直通(epoch/stream/level/target/fields/truncated),替代现在压进 `TraceLog.fields` 的降级形态。
+
+## 5. 兼容与测试策略
+
+- **wire 闸门**:所有新字段 Option+default;`wire_golden.rs` 旧样例**逐字节不变**必须继续通过(向后兼容回归闸),新字段用新样例覆盖;
+- 契约测试随 op 清单增长(`routing/tests.rs:204-225` 模式);client shortcuts 一行别名(`call::<Op>` 泛型已使新 op 零成本可达);
+- 事件:roundtrip 测试按 v1/v2 参数化;`Event` 新变体的 golden 快照;
+- route 级测试用既有 fake_core 基建(core-manager tests/helpers)覆盖 apply 的 noop/patched/reloaded/restarted/rolled_back 各臂;
+- 与 GUI 协调:P0-A/P1-A 打包为 **"IPC v2"批次**与 GUI 同版本对齐(与 CLI v2 / O4 同一模式);P0-B/P1-B 是纯新增端点,可先行合并。
+
+## 6. 阶段划分建议
+
+| 阶段 | 内容 | 依赖 | 与 GUI 协调 |
+|---|---|---|---|
+| S7 | P0-A 状态字段 + P0-C 一致性凭据 + specta 补齐 | 无 | 纯加字段,可先行 |
+| S8 | P0-B `/core/apply` + P1-B check/recover + `last_revision` | S7(revision 类型) | 纯新增端点,可先行 |
+| S9 | P1-A 事件 v2 + snapshot-on-connect | S7 | ⚠️ ws 版本协商,IPC v2 批次 |
+| S10 | P2 移除 `ControllerMode` + policy 注入(过渡默认 `Disable`)→ GUI 端点发现 → 默认切 `Prefer` | S7(controller 字段)、S8(graceful 收益兑现) | ⚠️ GUI 适配端点发现;core-manager 公开 API 变更 |
+
+每阶段独立可合并;S7+S8 落地后,"service client ≈ core manager"的能力对等即达成 §2 矩阵中全部 P0 行。
+
+## 7. 风险与开放问题
+
+| # | 问题 | 处置建议 |
+|---|---|---|
+| R1 | GUI 消费侧对单条事件解码错误的容错未验证 | S9 前在 GUI 仓实测;ws 版本协商本身已兜底 |
+| R2 | `apply` 在核心停止态的语义(报错 vs 隐式 start) | 倾向报错,保持 start 显式;实施时与 GUI 确认交互预期 |
+| R3 | envelope 加 `error_kind` 字段对第三方脚本消费者的影响 | serde 默认忽略未知字段;wire golden 会暴露任何意外 |
+| R4 | Managed 模式下若未来自动生成 secret | 独立决策,需分发与权限设计;本轮明确不做 |
+| R5 | `expected_revision` 缺省语义(不检查 vs 以 last_revision 兜底) | 实施时定;倾向"缺省不检查",兜底逻辑放 GUI |
+| R6 | 存量用法:用户自声明 pipe/unix controller;第三方面板依赖 `external-controller` 直连 | 前者随 S10 放弃(小众,发布说明标注);后者文档化"显式 `Disable`",GUI 侧可评估面板流量代理作为后续增强 |
+| R7 | S10 删除 `ControllerMode` 是 core-manager 公开 API 破坏性变更 | "crates/* 不改动"约束自 S10 起解除;与 GUI 进程内复用(如有)同版本协调 |

--- a/docs/superpowers/specs/2026-07-30-ipc-protocol-evolution-report.md
+++ b/docs/superpowers/specs/2026-07-30-ipc-protocol-evolution-report.md
@@ -157,11 +157,12 @@ pub struct CoreApplyData {
 
 ### P2:移除 `ControllerMode`,`LocalIpcPolicy` 成为唯一旋钮(O6 收敛为一次性移除)
 
-2026-07-30 追加复核后的决策:不做"Managed 参数化 + 日后默认化翻转"的过渡态,直接删除 `ControllerMode` 枚举。依据:Managed 自带的 `LocalIpcPolicy` 三档(`spec.rs:62-73`)已覆盖 Passthrough 绝大部分场景——`Prefer` 承接不支持本地 IPC 的老内核(回落源 config 的 HTTP,`capability.rs:169-172`),`Disable` 承接 HTTP 面板直连诉求(行为 ≈ 今日 Passthrough)。Passthrough 独有语义仅剩"尊重用户自声明的 `external-controller-pipe`/`-unix`"(完整 `inspect` `clash.rs:39-51` vs `inspect_http` `clash.rs:53-58`),属小众用法,决定放弃。
+2026-07-30 追加复核后的决策:不做"Managed 参数化 + 日后默认化翻转"的过渡态,直接删除 `ControllerMode` 枚举。依据:Managed 自带的 `LocalIpcPolicy` 三档(`spec.rs:62-73`)已覆盖 Passthrough 绝大部分场景——`Prefer` 承接不支持本地 IPC 的老内核(回落源 config 的 HTTP,`capability.rs:169-172`),`Disable` 承接 HTTP 面板直连诉求(对**仅依赖 HTTP `external-controller`** 的 config 与今日 Passthrough 逐字节等价;若 config 同时声明了本地键,Passthrough 会优先取本地键而 Disable 直接忽略之——见"代价(已接受)")。Passthrough 独有语义仅剩"尊重用户自声明的 `external-controller-pipe`/`-unix`"(完整 `inspect` `clash.rs:39-51` vs `inspect_http` `clash.rs:53-58`),属小众用法,决定放弃。
 
 - **core-manager 侧**:删除 `ControllerMode` 枚举,`local_ipc_policy` / `derived_dir` / `controller_template` 平铺进 `ManagerOptions`;随之删除 `prepare` 的 mode match(`config/mod.rs:125-139`)、`DegradeReason::PassthroughMode` 臂(`switching.rs:33-35`)、`runtime_dir`/`derived_dir` 双目录兼容逻辑(`spec.rs:97-99`);graceful 门槛简化为 local-ipc + kind + overlap 三条件;测试矩阵少一个模式维度。
 - **service 侧**:`local_ipc_policy` 从服务启动参数/配置注入(`install` 长参 + `NYANPASU_*` env,沿用 S5 模式);**过渡默认 `Disable`**——对声明了 `external-controller` 的现有 GUI config 行为不变,过渡态由 policy 天然承载,不需要保留枚举做"日后翻转";GUI 完成端点发现适配(消费 P0-A 的 `controller` 字段)后,默认切 `Prefer`。
-- **收益**:服务端永久摆脱"restart 恒 hard switch"降级路径——policy 命中 LocalIpc 后,P0-B 的 `/core/apply` 无需任何改动即自动享受 graceful 零停机切换;config 不再强制声明 `external-controller`(`ControllerMissing` 仅剩 Disable / Prefer 回落且无 HTTP 键一种情形);控制通道默认收敛到 0o700 目录下的 pipe/socket,不再默认暴露 localhost TCP。
+- **收益**:服务端永久摆脱"restart 恒 hard switch"降级路径——policy 命中 LocalIpc 后,`restart()` / `switch()`(即 `POST /core/restart`)走 graceful 零停机切换;config 不再强制声明 `external-controller`(`ControllerMissing` 仅剩 Disable / Prefer 回落且无 HTTP 键一种情形);控制通道默认收敛到 0o700 目录下的 pipe/socket,不再默认暴露 localhost TCP。
+  - **2026-07-30 勘误(S10 实施后复核)**:本行原称"P0-B 的 `/core/apply` 无需任何改动即自动享受 graceful 零停机切换",与代码不符。`apply_config` 的 switch 类走 `switch_with_compensation`(旧 epoch 回滚的硬 stop→start),从不调用 `graceful_switch`,policy 命中 LocalIpc 对它没有影响。让 apply 复用 graceful 需要调和两套互不兼容的失败补偿,属独立变更(S10 计划 D6)。
 - **代价(已接受)**:用户自声明 pipe/unix 路径不再支持;LocalIpc 命中时 HTTP `external-controller` 被无条件移除(`clash.rs:61-70`,graceful 的 epoch 隔离所需)——第三方面板(yacd/metacubexd)直连需显式 `Disable`,以放弃 graceful 为代价。
 - **约束解除**:上轮设计"crates/* 只消费不改动"的约束到此阶段正式解除;`ManagerOptions` 是公开 API,GUI 若有进程内复用计划需同版本协调。
 
@@ -200,3 +201,5 @@ pub struct CoreApplyData {
 | R5 | `expected_revision` 缺省语义(不检查 vs 以 last_revision 兜底) | 实施时定;倾向"缺省不检查",兜底逻辑放 GUI |
 | R6 | 存量用法:用户自声明 pipe/unix controller;第三方面板依赖 `external-controller` 直连 | 前者随 S10 放弃(小众,发布说明标注);后者文档化"显式 `Disable`",GUI 侧可评估面板流量代理作为后续增强 |
 | R7 | S10 删除 `ControllerMode` 是 core-manager 公开 API 破坏性变更 | "crates/* 不改动"约束自 S10 起解除;与 GUI 进程内复用(如有)同版本协调 |
+| R8 | `/core/start`、`/core/apply`、`/core/check` 均接受调用方任意路径,组内成员可指向任何 root 可读文件 | **接受并记录**:socket ACL 是本服务唯一的授权边界,自 `/core/start` 起一贯如此,本轮 S8 新端点未扩大该面。若日后要收窄,应做成显式的路径白名单策略,而不是在各端点里零散校验 |
+| R9 | v2 事件与 v1 共用 256 槽广播环(`server/events.rs:6`),v2 帧更密,v1 客户端在启动抖动期可能略早触发 `Lagged` | **接受并记录**:稳态下事件稀疏;`Lagged` 已由 ws 处理器的 resubscribe 兜底并告知丢失条数(`events.rs` 的 `lag_recovery_with_feedback_reaches_the_tail` 已固定该路径)。若实测有压力,提高容量比拆分通道便宜 |

--- a/docs/superpowers/specs/2026-07-30-ipc-protocol-evolution-report.md
+++ b/docs/superpowers/specs/2026-07-30-ipc-protocol-evolution-report.md
@@ -147,6 +147,7 @@ pub struct CoreApplyData {
 
 - 新增变体 `Event::CoreStatusChanged(CoreStatusPayload)`,载荷 = P0-A 的完整快照(六态 detail + controller + revision + health)。**推送即快照**,对齐 manager 的 watch 语义;
 - 兼容策略:已确认旧 client 库遇未知变体仅单条 `Err(Decode)`、流不断;但 GUI 消费侧行为未验证 → 采用 **ws 版本协商**(`/ws/events?v=2`;无参数 = v1 只发旧两变体),一个过渡版本后 GUI 升级完毕再默认 v2。旧 `CoreStateChanged` 在 v2 下仍双发一版,给脚本类消费者缓冲;
+  - **2026-07-31 修订（owner 指令，S11 实施）**：ws 版本协商**已撤销**。服务二进制与 GUI 同版本分发，不存在独立/第三方消费者，`?v=2` 这一层协商是没有受益方的复杂度。现状：`/ws/events` 只有一种协议——全量事件集（含 `CoreStatusChanged`）、连接即快照、`Lagged` 后补发快照，查询串一律忽略、不解析、不拒绝；`EVENT_VERSION_PARAM`、`EVENT_VERSION_V2`、`Event::is_protocol_v1()`、`Client::events_v2()` 与服务端 `EventProtocol` 过滤器全部删除，`events()` 即快照流（client API 破坏性变更）。旧 `CoreStateChanged` 的**双发保留不变**——GUI 仍在消费，本次只删协商层，不动变体。
 - **连接即快照**(snapshot-on-connect):ws 建立后先推一帧当前 `CoreStatusChanged`,消除"断线重连后必须轮询 /status"的重同步竞态,`Lagged` 后 `resubscribe()` 同样补发一帧;
 - 顺带修正语义缺陷:v2 载荷中 `Starting/Restarting` 不再伪装成 `Stopped(None)`(旧 v1 映射不动,保持兼容)。
 
@@ -194,7 +195,7 @@ pub struct CoreApplyData {
 
 | # | 问题 | 处置建议 |
 |---|---|---|
-| R1 | GUI 消费侧对单条事件解码错误的容错未验证 | S9 前在 GUI 仓实测;ws 版本协商本身已兜底 |
+| R1 | GUI 消费侧对单条事件解码错误的容错未验证 | S9 前在 GUI 仓实测；ws 版本协商本身已兜底。**2026-07-31（S11）**：协商已撤销，该兜底不复存在——服务与 GUI 同版本分发，兼容性改由发布协调保证 |
 | R2 | `apply` 在核心停止态的语义(报错 vs 隐式 start) | 倾向报错,保持 start 显式;实施时与 GUI 确认交互预期 |
 | R3 | envelope 加 `error_kind` 字段对第三方脚本消费者的影响 | serde 默认忽略未知字段;wire golden 会暴露任何意外 |
 | R4 | Managed 模式下若未来自动生成 secret | 独立决策,需分发与权限设计;本轮明确不做 |
@@ -202,4 +203,4 @@ pub struct CoreApplyData {
 | R6 | 存量用法:用户自声明 pipe/unix controller;第三方面板依赖 `external-controller` 直连 | 前者随 S10 放弃(小众,发布说明标注);后者文档化"显式 `Disable`",GUI 侧可评估面板流量代理作为后续增强 |
 | R7 | S10 删除 `ControllerMode` 是 core-manager 公开 API 破坏性变更 | "crates/* 不改动"约束自 S10 起解除;与 GUI 进程内复用(如有)同版本协调 |
 | R8 | `/core/start`、`/core/apply`、`/core/check` 均接受调用方任意路径,组内成员可指向任何 root 可读文件 | **接受并记录**:socket ACL 是本服务唯一的授权边界,自 `/core/start` 起一贯如此,本轮 S8 新端点未扩大该面。若日后要收窄,应做成显式的路径白名单策略,而不是在各端点里零散校验 |
-| R9 | v2 事件与 v1 共用 256 槽广播环(`server/events.rs:6`),v2 帧更密,v1 客户端在启动抖动期可能略早触发 `Lagged` | **接受并记录**:稳态下事件稀疏;服务端日志记录 skipped 条数(该告警被过滤不入 EventHub);v2 连接重订阅后补发快照;v1 连接跳到实时尾部,需自行轮询 `/status` 重新同步(`events.rs` 的 `lag_recovery_with_feedback_reaches_the_tail` 已固定该路径)。若实测有压力,提高容量比拆分通道便宜 |
+| R9 | 事件流为单一协议，快照帧比旧的两变体更密，且与日志共用 256 槽广播环（`server/events.rs:6`），启动抖动期可能略早触发 `Lagged` | **接受并记录**：稳态下事件稀疏；服务端日志记录 skipped 条数（该告警被过滤，不入 EventHub）。**2026-07-31 更新（S11）**：协商撤销后不再有连接类别之分——任何连接 `resubscribe()` 之后一律补发一帧快照，"跳到实时尾部、需自行轮询 `/status` 重新同步"的情形已消失（`events.rs` 的 `lag_recovery_with_feedback_reaches_the_tail` 已固定该路径）。若实测有压力，提高容量比拆分通道便宜 |

--- a/docs/superpowers/specs/2026-07-30-ipc-protocol-evolution-report.md
+++ b/docs/superpowers/specs/2026-07-30-ipc-protocol-evolution-report.md
@@ -202,4 +202,4 @@ pub struct CoreApplyData {
 | R6 | 存量用法:用户自声明 pipe/unix controller;第三方面板依赖 `external-controller` 直连 | 前者随 S10 放弃(小众,发布说明标注);后者文档化"显式 `Disable`",GUI 侧可评估面板流量代理作为后续增强 |
 | R7 | S10 删除 `ControllerMode` 是 core-manager 公开 API 破坏性变更 | "crates/* 不改动"约束自 S10 起解除;与 GUI 进程内复用(如有)同版本协调 |
 | R8 | `/core/start`、`/core/apply`、`/core/check` 均接受调用方任意路径,组内成员可指向任何 root 可读文件 | **接受并记录**:socket ACL 是本服务唯一的授权边界,自 `/core/start` 起一贯如此,本轮 S8 新端点未扩大该面。若日后要收窄,应做成显式的路径白名单策略,而不是在各端点里零散校验 |
-| R9 | v2 事件与 v1 共用 256 槽广播环(`server/events.rs:6`),v2 帧更密,v1 客户端在启动抖动期可能略早触发 `Lagged` | **接受并记录**:稳态下事件稀疏;`Lagged` 已由 ws 处理器的 resubscribe 兜底并告知丢失条数(`events.rs` 的 `lag_recovery_with_feedback_reaches_the_tail` 已固定该路径)。若实测有压力,提高容量比拆分通道便宜 |
+| R9 | v2 事件与 v1 共用 256 槽广播环(`server/events.rs:6`),v2 帧更密,v1 客户端在启动抖动期可能略早触发 `Lagged` | **接受并记录**:稳态下事件稀疏;服务端日志记录 skipped 条数(该告警被过滤不入 EventHub);v2 连接重订阅后补发快照;v1 连接跳到实时尾部,需自行轮询 `/status` 重新同步(`events.rs` 的 `lag_recovery_with_feedback_reaches_the_tail` 已固定该路径)。若实测有压力,提高容量比拆分通道便宜 |

--- a/nyanpasu_ipc/Cargo.toml
+++ b/nyanpasu_ipc/Cargo.toml
@@ -30,7 +30,7 @@ interprocess = { version = "2.4.2", features = ["tokio"] }
 reqwest = { version = "0.13", features = ["json"], optional = true }
 reqwest-websocket = { version = "0.6.0", optional = true }
 serde = { workspace = true }
-specta = { version = "^2.0.0-rc.25", features = ["derive"], optional = true }
+specta = { version = "^2.0.0-rc.25", features = ["derive", "indexmap", "serde_json"], optional = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tower = { version = "0.5", features = ["util"], optional = true }

--- a/nyanpasu_ipc/src/api/contract.rs
+++ b/nyanpasu_ipc/src/api/contract.rs
@@ -11,7 +11,7 @@
 //! request/response operation, and has no `R` envelope. It keeps its own
 //! constant in [`super::ws::events::EVENT_URI`].
 //!
-//! Written by hand on purpose. Seven impls cost less than a macro to maintain.
+//! Written by hand on purpose. Ten impls cost less than a macro to maintain.
 
 use std::fmt::Debug;
 
@@ -20,7 +20,14 @@ use serde::{Serialize, de::DeserializeOwned};
 
 use super::{
     R,
-    core::{restart::CORE_RESTART_ENDPOINT, start::CORE_START_ENDPOINT, stop::CORE_STOP_ENDPOINT},
+    core::{
+        apply::{CORE_APPLY_ENDPOINT, CoreApplyData},
+        check::CORE_CHECK_ENDPOINT,
+        recover::CORE_RECOVER_ENDPOINT,
+        restart::CORE_RESTART_ENDPOINT,
+        start::CORE_START_ENDPOINT,
+        stop::CORE_STOP_ENDPOINT,
+    },
     log::{LOGS_INSPECT_ENDPOINT, LOGS_RETRIEVE_ENDPOINT, LogsResBody},
     network::set_dns::{NETWORK_SET_DNS_ENDPOINT, NetworkSetDnsReq},
     status::{STATUS_ENDPOINT, StatusResBody},
@@ -78,6 +85,36 @@ pub struct CoreRestart;
 impl IpcOperation for CoreRestart {
     const METHOD: Method = Method::POST;
     const PATH: &'static str = CORE_RESTART_ENDPOINT;
+    type Req<'a> = ();
+    type Data = ();
+}
+
+/// `POST /core/apply`
+pub struct CoreApply;
+
+impl IpcOperation for CoreApply {
+    const METHOD: Method = Method::POST;
+    const PATH: &'static str = CORE_APPLY_ENDPOINT;
+    type Req<'a> = super::core::apply::CoreApplyReq<'a>;
+    type Data = CoreApplyData;
+}
+
+/// `POST /core/check`
+pub struct CoreCheck;
+
+impl IpcOperation for CoreCheck {
+    const METHOD: Method = Method::POST;
+    const PATH: &'static str = CORE_CHECK_ENDPOINT;
+    type Req<'a> = super::core::check::CoreCheckReq<'a>;
+    type Data = ();
+}
+
+/// `POST /core/recover`
+pub struct CoreRecover;
+
+impl IpcOperation for CoreRecover {
+    const METHOD: Method = Method::POST;
+    const PATH: &'static str = CORE_RECOVER_ENDPOINT;
     type Req<'a> = ();
     type Data = ();
 }
@@ -145,6 +182,24 @@ mod tests {
         assert_eq!(
             (NetworkSetDns::METHOD, NetworkSetDns::PATH),
             (Method::POST, "/network/set_dns")
+        );
+    }
+
+    /// The S8 additions pin the report's addresses rather than legacy
+    /// behaviour, but for the same reason: a path typo is a protocol break.
+    #[test]
+    fn every_s8_operation_is_addressed_as_the_report_says() {
+        assert_eq!(
+            (CoreApply::METHOD, CoreApply::PATH),
+            (Method::POST, "/core/apply")
+        );
+        assert_eq!(
+            (CoreCheck::METHOD, CoreCheck::PATH),
+            (Method::POST, "/core/check")
+        );
+        assert_eq!(
+            (CoreRecover::METHOD, CoreRecover::PATH),
+            (Method::POST, "/core/recover")
         );
     }
 }

--- a/nyanpasu_ipc/src/api/core/apply.rs
+++ b/nyanpasu_ipc/src/api/core/apply.rs
@@ -44,10 +44,14 @@ pub enum ApplyOutcomeKind {
     Reloaded,
     /// The core process was replaced within the same epoch.
     Restarted,
-    /// Reserved, never sent today: the manager reports the core-switch path as
-    /// [`Self::Restarted`] too (`manager/apply.rs:531`). Declared now because a
-    /// variant added later would make every older client fail to decode this
-    /// field.
+    /// The process spec itself changed — a different core, binary, or launch
+    /// option — so the old epoch was stopped and a new one started. Distinct
+    /// from [`Self::Restarted`], which replaces the process inside one epoch.
+    ///
+    /// This is a hard switch today: the apply path runs a stop → start with
+    /// old-epoch rollback (`manager/apply.rs`, `switch_with_compensation`), not
+    /// the manager's graceful zero-downtime switch, which only
+    /// `restart()`/`switch()` reach.
     Switched,
     /// The apply failed and the previous revision was restored. **The core is
     /// running the OLD config**, `revision` is the old revision, and

--- a/nyanpasu_ipc/src/api/core/apply.rs
+++ b/nyanpasu_ipc/src/api/core/apply.rs
@@ -1,0 +1,83 @@
+use crate::api::{
+    R,
+    status::{ConfigRevisionInfo, RevisionIdInfo},
+};
+use serde::{Deserialize, Serialize};
+use std::{borrow::Cow, path::PathBuf};
+
+pub const CORE_APPLY_ENDPOINT: &str = "/core/apply";
+
+/// Apply a config to the running core.
+///
+/// The core must already be running: apply never starts one, so `/core/start`
+/// keeps its explicitness (report §7 R2). The manager classifies the change and
+/// picks the cheapest route that can carry it — an in-place `PATCH /configs`, a
+/// `PUT /configs` reload, a same-epoch restart with rollback, or a full core
+/// switch when the process spec itself changed — which is why there is no
+/// separate `/core/switch` operation. A `core_type` different from the running
+/// one is therefore legal and means "switch to this core".
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+pub struct CoreApplyReq<'n> {
+    pub core_type: Cow<'n, nyanpasu_utils::core::CoreType>,
+    /// The caller's own config file, and only ever the *source*: the service
+    /// commits a canonicalized private copy and the core runs that one.
+    pub config_file: Cow<'n, PathBuf>,
+    /// Compare-and-swap token. `None` applies unconditionally; `Some` applies
+    /// nothing and fails with `error_kind = "revision_conflict"` when the
+    /// running revision has moved on. Omitted from the wire when `None`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expected_revision: Option<RevisionIdInfo>,
+}
+
+/// How the manager carried the change.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+#[serde(rename_all = "snake_case")]
+pub enum ApplyOutcomeKind {
+    /// The config was already in effect; the core was not touched.
+    Noop,
+    /// Applied in place with `PATCH /configs` and verified leaf by leaf. No
+    /// downtime.
+    Patched,
+    /// Applied in place with `PUT /configs`. No downtime.
+    Reloaded,
+    /// The core process was replaced within the same epoch.
+    Restarted,
+    /// Reserved, never sent today: the manager reports the core-switch path as
+    /// [`Self::Restarted`] too (`manager/apply.rs:531`). Declared now because a
+    /// variant added later would make every older client fail to decode this
+    /// field.
+    Switched,
+    /// The apply failed and the previous revision was restored. **The core is
+    /// running the OLD config**, `revision` is the old revision, and
+    /// `failed_apply` says why the new one was rejected.
+    RolledBack,
+}
+
+/// The result of an apply.
+///
+/// `outcome` is the field to branch on. A rolled-back apply is reported as a
+/// *successful call* — HTTP 200, `code: "Ok"` — because the caller has to be
+/// told which config is actually running; treating it as an error would make it
+/// indistinguishable from "nothing happened" (report §4 P0-C).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+pub struct CoreApplyData {
+    pub outcome: ApplyOutcomeKind,
+    /// The revision the core is running now, `source_hash` included: a caller
+    /// holding the source file can confirm the service read the bytes it wrote
+    /// without reimplementing the hash (report §4 P0-C bullet 1).
+    pub revision: ConfigRevisionInfo,
+    /// A degradation the operation survived. Today only the manager's
+    /// durability warning: the runtime copy is in place but a directory sync
+    /// could not be confirmed, so a crash right now might lose it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub warning: Option<String>,
+    /// Why the desired config was rejected. Set only for
+    /// [`ApplyOutcomeKind::RolledBack`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub failed_apply: Option<String>,
+}
+
+pub type CoreApplyRes<'a> = R<'a, CoreApplyData>;

--- a/nyanpasu_ipc/src/api/core/check.rs
+++ b/nyanpasu_ipc/src/api/core/check.rs
@@ -1,0 +1,26 @@
+use crate::api::R;
+use serde::{Deserialize, Serialize};
+use std::{borrow::Cow, path::PathBuf};
+
+pub const CORE_CHECK_ENDPOINT: &str = "/core/check";
+
+/// Dry-run a config against a core binary. Touches no running core and needs
+/// none: it invokes the binary's own config check, so a GUI can validate before
+/// saving instead of finding out by failing to start (report §4 P1-B).
+///
+/// Its own type rather than a reuse of
+/// [`CoreStartReq`](super::start::CoreStartReq): the two operations happen to
+/// take the same two fields today and must stay free to diverge.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+pub struct CoreCheckReq<'n> {
+    pub core_type: Cow<'n, nyanpasu_utils::core::CoreType>,
+    pub config_file: Cow<'n, PathBuf>,
+}
+
+/// A rejected config is an error envelope with
+/// `error_kind = "config_check_failed"` and the core's own diagnostic in `msg`,
+/// not a `200` carrying `ok: false` — every other operation in this protocol
+/// reports failure through the envelope, and a second convention for one
+/// endpoint would fragment it.
+pub type CoreCheckRes<'a> = R<'a, ()>;

--- a/nyanpasu_ipc/src/api/core/mod.rs
+++ b/nyanpasu_ipc/src/api/core/mod.rs
@@ -1,3 +1,6 @@
+pub mod apply;
+pub mod check;
+pub mod recover;
 pub mod restart;
 pub mod start;
 pub mod stop;

--- a/nyanpasu_ipc/src/api/core/recover.rs
+++ b/nyanpasu_ipc/src/api/core/recover.rs
@@ -1,0 +1,14 @@
+use crate::api::R;
+
+pub const CORE_RECOVER_ENDPOINT: &str = "/core/recover";
+
+/// Clear the quarantine latch left behind by an epoch whose death could not be
+/// confirmed. Until it is cleared every lifecycle operation fails with
+/// `error_kind = "quarantined"`, and before S8 the only remedy was restarting
+/// the whole service (report §1.3).
+///
+/// No request body, and no payload on success: recovery is idempotent and
+/// succeeds when nothing was quarantined, which is what makes it safe to call
+/// speculatively. Whether a latch was actually cleared is deliberately not
+/// reported — the manager does not expose it (see the S8 plan §12/D3).
+pub type CoreRecoverRes<'a> = R<'a, ()>;

--- a/nyanpasu_ipc/src/api/core/start.rs
+++ b/nyanpasu_ipc/src/api/core/start.rs
@@ -5,6 +5,7 @@ use std::{borrow::Cow, path::PathBuf};
 pub const CORE_START_ENDPOINT: &str = "/core/start";
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
 pub struct CoreStartReq<'n> {
     pub core_type: Cow<'n, nyanpasu_utils::core::CoreType>,
     pub config_file: Cow<'n, PathBuf>,

--- a/nyanpasu_ipc/src/api/log.rs
+++ b/nyanpasu_ipc/src/api/log.rs
@@ -7,6 +7,7 @@ pub const LOGS_INSPECT_ENDPOINT: &str = "/logs/inspect";
 
 // TODO: more health check fields
 #[derive(Debug, Serialize, Deserialize, Clone)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
 pub struct LogsResBody<'a> {
     pub logs: Vec<Cow<'a, str>>,
 }

--- a/nyanpasu_ipc/src/api/mod.rs
+++ b/nyanpasu_ipc/src/api/mod.rs
@@ -25,6 +25,46 @@ impl ResponseCode {
     }
 }
 
+/// Stable machine-readable failure kinds carried by [`R::error_kind`].
+///
+/// These strings are protocol: a caller branches on them instead of parsing
+/// `msg`. [`ResponseCode`] deliberately stays a two-variant enum — a new
+/// variant would make every older client fail to decode the whole envelope —
+/// so the detail lives in an additive string field instead (report §4 P0-B).
+///
+/// Absent means "not classified", never "no error": only the operations added
+/// in S8 populate it, and only for the failures listed here. Mapping the
+/// manager's remaining error variants is report P3.
+pub mod error_kind {
+    /// The operation needs a running core and there is none.
+    pub const NOT_STARTED: &str = "not_started";
+    /// The operation needs a stopped core and one is running.
+    pub const ALREADY_RUNNING: &str = "already_running";
+    /// `expected_revision` did not match the running revision. Nothing was
+    /// applied; re-read `/status` for the current one and retry.
+    pub const REVISION_CONFLICT: &str = "revision_conflict";
+    /// An epoch whose death could not be confirmed has latched the manager.
+    /// Every lifecycle operation is refused until `POST /core/recover` clears
+    /// it.
+    pub const QUARANTINED: &str = "quarantined";
+    /// The core itself rejected the config in a dry run.
+    pub const CONFIG_CHECK_FAILED: &str = "config_check_failed";
+    pub const CONFIG_NOT_FOUND: &str = "config_not_found";
+    pub const BINARY_NOT_FOUND: &str = "binary_not_found";
+    /// The config could not be parsed or canonicalized.
+    pub const INVALID_CONFIG: &str = "invalid_config";
+    /// The config declares no external controller, so the core cannot be
+    /// health-probed.
+    pub const CONTROLLER_MISSING: &str = "controller_missing";
+    /// The apply failed and the previous revision was restored.
+    pub const APPLY_FAILED: &str = "apply_failed";
+    /// The apply failed and so did the rollback: no epoch is running.
+    pub const APPLY_ROLLBACK_FAILED: &str = "apply_rollback_failed";
+    /// A core process could not be proven dead; the manager is now
+    /// quarantined.
+    pub const STOP_UNCONFIRMED: &str = "stop_unconfirmed";
+}
+
 /// The IPC Response body definition
 #[derive(Debug, Serialize, Deserialize, Clone, Builder)]
 #[builder(build_fn(validate = "Self::validate"))]
@@ -37,6 +77,12 @@ pub struct R<'a, T: Serialize + DeserializeOwned + Debug> {
     pub data: Option<T>,
     #[builder(setter(skip), default = "self.default_ts()")]
     pub ts: i64,
+    /// Machine-readable failure classification, see [`error_kind`]. Declared
+    /// last and omitted when absent, so every pre-S8 envelope stays
+    /// byte-identical and every pre-S8 payload still decodes.
+    #[builder(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error_kind: Option<Cow<'a, str>>,
 }
 
 impl<T: Serialize + DeserializeOwned + Debug> R<'_, T> {
@@ -81,6 +127,22 @@ impl<'a, T: Serialize + DeserializeOwned + Debug> RBuilder<'a, T> {
             msg,
             data: None,
             ts: crate::utils::get_current_ts(),
+            error_kind: None,
+        }
+    }
+
+    /// An error envelope carrying a [`error_kind`] classification.
+    ///
+    /// `kind` is `Option` because a failure the service cannot classify must
+    /// still be reportable — guessing a kind is worse than omitting it.
+    pub fn other_error_with_kind(msg: Cow<'a, str>, kind: Option<Cow<'a, str>>) -> R<'a, T> {
+        let code = ResponseCode::OtherError;
+        R {
+            code,
+            msg,
+            data: None,
+            ts: crate::utils::get_current_ts(),
+            error_kind: kind,
         }
     }
 
@@ -91,6 +153,7 @@ impl<'a, T: Serialize + DeserializeOwned + Debug> RBuilder<'a, T> {
             msg: Cow::Borrowed(code.msg()),
             data: Some(data),
             ts: crate::utils::get_current_ts(),
+            error_kind: None,
         }
     }
 }

--- a/nyanpasu_ipc/src/api/network/set_dns.rs
+++ b/nyanpasu_ipc/src/api/network/set_dns.rs
@@ -5,6 +5,7 @@ use std::{borrow::Cow, net::IpAddr};
 pub const NETWORK_SET_DNS_ENDPOINT: &str = "/network/set_dns";
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
 pub struct NetworkSetDnsReq<'n> {
     pub dns_servers: Option<Vec<Cow<'n, IpAddr>>>,
 }

--- a/nyanpasu_ipc/src/api/status.rs
+++ b/nyanpasu_ipc/src/api/status.rs
@@ -17,6 +17,81 @@ impl Default for CoreState {
     }
 }
 
+/// The core's control endpoint, as the manager resolved it.
+///
+/// A deliberately separate type from `clash_api::Host`: clash-api is an
+/// internal dependency of the core manager and must not leak into the wire
+/// dependency tree. The controller secret is never carried here — it comes
+/// from the caller's own config, and the IPC transport's only gate is the
+/// socket ACL.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+pub enum CoreControllerInfo {
+    NamedPipe(PathBuf),
+    UnixSocket(PathBuf),
+    /// Normalized base URL with any credentials removed.
+    Http(String),
+}
+
+/// Health observation state for the active core.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+pub enum CoreHealthState {
+    Starting,
+    Healthy,
+    Unhealthy,
+}
+
+/// The manager's health observation for the active core. Absent while the
+/// core is stopping or stopped.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+pub struct CoreHealthInfo {
+    pub state: CoreHealthState,
+    /// Unix milliseconds of the last health-state transition.
+    pub changed_at: i64,
+    pub consecutive_failures: u32,
+    /// Last probe failure detail, capped by the manager at 512 bytes.
+    pub last_error: Option<String>,
+    /// Unix milliseconds of the last successful probe.
+    pub last_success_at: Option<i64>,
+}
+
+/// Identity of the config the running core actually adopted.
+///
+/// `source_hash` is computed over the caller's own file and `effective_hash`
+/// over the canonical form the core is running, both FNV-1a over canonical
+/// YAML. A caller that holds the source file can therefore confirm the
+/// service read the same bytes it wrote, without reimplementing the hash.
+/// The manager's private runtime copy path is deliberately not exposed: it
+/// lives in a 0o700 directory the caller cannot read, so it would only
+/// mislead.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+pub struct ConfigRevisionInfo {
+    pub epoch: u64,
+    pub generation: u64,
+    pub source_hash: String,
+    pub effective_hash: String,
+}
+
+/// The core's full lifecycle state.
+///
+/// [`CoreState`] is a two-valued projection kept for wire compatibility: it
+/// reports `Starting` and `Restarting` as `Stopped(None)`, so a crash loop is
+/// indistinguishable from a real stop. This is the faithful view; prefer it
+/// when present.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+pub enum CoreStateDetail {
+    Stopped { reason: Option<String> },
+    Starting { epoch: u64 },
+    Running { epoch: u64, pid: u32 },
+    Restarting { epoch: u64, attempt: u32 },
+    Switching { from: Option<u64>, to: u64 },
+    Stopping { epoch: u64 },
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "specta", derive(specta::Type))]
 pub struct CoreInfos {
@@ -24,6 +99,16 @@ pub struct CoreInfos {
     pub state: CoreState,
     pub state_changed_at: i64,
     pub config_path: Option<PathBuf>,
+    /// Omitted rather than null when absent, so a payload carrying none of
+    /// the fields below is byte-identical to the pre-S7 wire format.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub controller: Option<CoreControllerInfo>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub health: Option<CoreHealthInfo>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub revision: Option<ConfigRevisionInfo>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub detail: Option<CoreStateDetail>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -35,7 +120,6 @@ pub struct RuntimeInfos<'a> {
     pub nyanpasu_data_dir: Cow<'a, PathBuf>,
 }
 
-// TODO: more health check fields
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[cfg_attr(feature = "specta", derive(specta::Type))]
 pub struct StatusResBody<'a> {

--- a/nyanpasu_ipc/src/api/status.rs
+++ b/nyanpasu_ipc/src/api/status.rs
@@ -75,6 +75,35 @@ pub struct ConfigRevisionInfo {
     pub effective_hash: String,
 }
 
+/// The compare-and-swap identity of a config revision.
+///
+/// Deliberately a subset of [`ConfigRevisionInfo`]: the manager's CAS compares
+/// epoch, generation and `effective_hash` only, so carrying `source_hash` here
+/// would imply it takes part.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+pub struct RevisionIdInfo {
+    pub epoch: u64,
+    pub generation: u64,
+    pub effective_hash: String,
+}
+
+impl ConfigRevisionInfo {
+    /// The CAS token for this revision, for feeding a `/status` snapshot
+    /// straight back into `POST /core/apply`'s `expected_revision`.
+    ///
+    /// Which fields make up the identity is protocol knowledge, not caller
+    /// convenience — hence a method here rather than a struct literal at every
+    /// call site.
+    pub fn id(&self) -> RevisionIdInfo {
+        RevisionIdInfo {
+            epoch: self.epoch,
+            generation: self.generation,
+            effective_hash: self.effective_hash.clone(),
+        }
+    }
+}
+
 /// The core's full lifecycle state.
 ///
 /// [`CoreState`] is a two-valued projection kept for wire compatibility: it

--- a/nyanpasu_ipc/src/api/ws/events.rs
+++ b/nyanpasu_ipc/src/api/ws/events.rs
@@ -3,19 +3,10 @@ use serde::{Deserialize, Serialize};
 
 use crate::api::status::{CoreInfos, CoreState};
 
+/// The event endpoint. There is no protocol negotiation and no version
+/// parameter: the service binary ships with the program that consumes it, so
+/// every connection speaks the same stream and any query string is ignored.
 pub const EVENT_URI: &str = "/ws/events";
-
-/// Query parameter on [`EVENT_URI`] selecting the event protocol version.
-///
-/// Absent, empty, unknown or malformed all mean v1 — the two variants every
-/// shipped client already decodes. Only the exact value [`EVENT_VERSION_V2`]
-/// opts in. Fail-closed on purpose: a client that never asked for v2 must never
-/// be handed a variant it cannot decode, because the GUI's tolerance of a single
-/// decode error is unverified (report §7 R1).
-pub const EVENT_VERSION_PARAM: &str = "v";
-
-/// The one [`EVENT_VERSION_PARAM`] value that selects the v2 stream.
-pub const EVENT_VERSION_V2: &str = "2";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "specta", derive(specta::Type))]
@@ -33,16 +24,17 @@ pub enum Event {
     Log(TraceLog),
     /// The lossy state, kept exactly as it has always been: `Starting` and
     /// `Restarting` are reported as `Stopped(None)`, so a crash loop is
-    /// indistinguishable from a stop. v1 clients depend on this projection;
+    /// indistinguishable from a stop. Kept because the GUI still consumes it,
+    /// and emitted beside every [`Self::CoreStatusChanged`];
     /// [`Self::CoreStatusChanged`] is where the faithful view lives.
     CoreStateChanged(CoreState),
     /// The full status snapshot — the same [`CoreInfos`] `/status` returns,
-    /// including the faithful `detail`. Sent only to connections that asked for
-    /// v2 (`?v=2`), once when the socket opens, once after a dropped-event
-    /// recovery, and on every manager transition. Push *is* snapshot: the
-    /// payload is byte-identical to `/status`'s `core_infos`, so a client feeds
-    /// it into the same state it already keeps for `/status`. Treat it as
-    /// idempotent — a reconnect or a lag recovery can repeat one.
+    /// including the faithful `detail`. Sent to every connection: once when the
+    /// socket opens, once after a dropped-event recovery, and on every manager
+    /// transition. Push *is* snapshot: the payload is byte-identical to
+    /// `/status`'s `core_infos`, so a client feeds it into the same state it
+    /// already keeps for `/status`. Treat it as idempotent — a reconnect or a
+    /// lag recovery can repeat one.
     CoreStatusChanged(CoreInfos),
 }
 
@@ -57,16 +49,5 @@ impl Event {
 
     pub fn new_core_status_changed(infos: CoreInfos) -> Self {
         Self::CoreStatusChanged(infos)
-    }
-
-    /// Whether this event exists in protocol v1.
-    ///
-    /// An exhaustive match on purpose: a variant added later must fail to
-    /// compile here rather than default into a v1 stream that cannot decode it.
-    pub fn is_protocol_v1(&self) -> bool {
-        match self {
-            Self::Log(_) | Self::CoreStateChanged(_) => true,
-            Self::CoreStatusChanged(_) => false,
-        }
     }
 }

--- a/nyanpasu_ipc/src/api/ws/events.rs
+++ b/nyanpasu_ipc/src/api/ws/events.rs
@@ -1,9 +1,21 @@
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 
-use crate::api::status::CoreState;
+use crate::api::status::{CoreInfos, CoreState};
 
 pub const EVENT_URI: &str = "/ws/events";
+
+/// Query parameter on [`EVENT_URI`] selecting the event protocol version.
+///
+/// Absent, empty, unknown or malformed all mean v1 — the two variants every
+/// shipped client already decodes. Only the exact value [`EVENT_VERSION_V2`]
+/// opts in. Fail-closed on purpose: a client that never asked for v2 must never
+/// be handed a variant it cannot decode, because the GUI's tolerance of a single
+/// decode error is unverified (report §7 R1).
+pub const EVENT_VERSION_PARAM: &str = "v";
+
+/// The one [`EVENT_VERSION_PARAM`] value that selects the v2 stream.
+pub const EVENT_VERSION_V2: &str = "2";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "specta", derive(specta::Type))]
@@ -19,7 +31,19 @@ pub struct TraceLog {
 #[cfg_attr(feature = "specta", derive(specta::Type))]
 pub enum Event {
     Log(TraceLog),
+    /// The lossy state, kept exactly as it has always been: `Starting` and
+    /// `Restarting` are reported as `Stopped(None)`, so a crash loop is
+    /// indistinguishable from a stop. v1 clients depend on this projection;
+    /// [`Self::CoreStatusChanged`] is where the faithful view lives.
     CoreStateChanged(CoreState),
+    /// The full status snapshot — the same [`CoreInfos`] `/status` returns,
+    /// including the faithful `detail`. Sent only to connections that asked for
+    /// v2 (`?v=2`), once when the socket opens, once after a dropped-event
+    /// recovery, and on every manager transition. Push *is* snapshot: the
+    /// payload is byte-identical to `/status`'s `core_infos`, so a client feeds
+    /// it into the same state it already keeps for `/status`. Treat it as
+    /// idempotent — a reconnect or a lag recovery can repeat one.
+    CoreStatusChanged(CoreInfos),
 }
 
 impl Event {
@@ -29,5 +53,20 @@ impl Event {
 
     pub fn new_core_state_changed(state: CoreState) -> Self {
         Self::CoreStateChanged(state)
+    }
+
+    pub fn new_core_status_changed(infos: CoreInfos) -> Self {
+        Self::CoreStatusChanged(infos)
+    }
+
+    /// Whether this event exists in protocol v1.
+    ///
+    /// An exhaustive match on purpose: a variant added later must fail to
+    /// compile here rather than default into a v1 stream that cannot decode it.
+    pub fn is_protocol_v1(&self) -> bool {
+        match self {
+            Self::Log(_) | Self::CoreStateChanged(_) => true,
+            Self::CoreStatusChanged(_) => false,
+        }
     }
 }

--- a/nyanpasu_ipc/src/api/ws/events.rs
+++ b/nyanpasu_ipc/src/api/ws/events.rs
@@ -6,6 +6,7 @@ use crate::api::status::CoreState;
 pub const EVENT_URI: &str = "/ws/events";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
 pub struct TraceLog {
     pub timestamp: String,
     pub level: String,
@@ -15,6 +16,7 @@ pub struct TraceLog {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
 pub enum Event {
     Log(TraceLog),
     CoreStateChanged(CoreState),

--- a/nyanpasu_ipc/src/client/mod.rs
+++ b/nyanpasu_ipc/src/client/mod.rs
@@ -48,6 +48,9 @@ pub enum ClientError {
         operation: &'static str,
         code: ResponseCode,
         msg: String,
+        /// The envelope's `error_kind`, when the service classified the
+        /// failure. See [`crate::api::error_kind`].
+        error_kind: Option<String>,
     },
     #[error("IPC request `{operation}` succeeded but carried no data")]
     EmptyData { operation: &'static str },
@@ -136,6 +139,7 @@ impl Client {
                 operation,
                 code: envelope.code,
                 msg: envelope.msg.into_owned(),
+                error_kind: envelope.error_kind.map(|kind| kind.into_owned()),
             });
         }
         let body =
@@ -180,6 +184,7 @@ impl Client {
                 operation: Op::PATH,
                 code: envelope.code,
                 msg: envelope.msg.into_owned(),
+                error_kind: envelope.error_kind.map(|kind| kind.into_owned()),
             });
         }
         Ok(envelope)

--- a/nyanpasu_ipc/src/client/shortcuts.rs
+++ b/nyanpasu_ipc/src/client/shortcuts.rs
@@ -15,7 +15,7 @@ use crate::api::{
     core::apply::{CORE_APPLY_ENDPOINT, CoreApplyData},
     log::{LOGS_INSPECT_ENDPOINT, LOGS_RETRIEVE_ENDPOINT},
     status::STATUS_ENDPOINT,
-    ws::events::{EVENT_URI, EVENT_VERSION_PARAM, EVENT_VERSION_V2, Event},
+    ws::events::{EVENT_URI, Event},
 };
 
 use super::{ClientError, Result};
@@ -97,35 +97,19 @@ impl Client {
 
     /// Subscribe to the events pushed by the service over `/ws/events`.
     ///
-    /// The v1 stream: [`Event::Log`] and [`Event::CoreStateChanged`] only, no
-    /// frame until something happens. Unchanged since it shipped — see
-    /// [`Self::events_v2`] for the snapshot stream.
-    pub async fn events(&self) -> Result<EventStream> {
-        self.event_stream(EVENT_URI.to_owned()).await
-    }
-
-    /// Subscribe to the v2 event stream.
+    /// Snapshot first: the service pushes one [`Event::CoreStatusChanged`] the
+    /// moment the socket opens, one after every dropped-event recovery, and one
+    /// per manager transition — including the `Starting`/`Restarting`
+    /// transitions the two-valued [`Event::CoreStateChanged`] cannot express.
+    /// There is nothing to negotiate and no version parameter to pass; the
+    /// service ignores the query string.
     ///
-    /// Adds [`Event::CoreStatusChanged`]: one full snapshot the moment the
-    /// socket opens, one after every dropped-event recovery, and one per manager
-    /// transition — including the `Starting`/`Restarting` transitions the v1
-    /// state cannot express. [`Event::CoreStateChanged`] keeps arriving
-    /// alongside it during the transition (report §4 P1-A), so a consumer of
-    /// both sees each transition twice; the snapshot is idempotent, so the
-    /// simplest correct handling is to let the last frame win.
-    pub async fn events_v2(&self) -> Result<EventStream> {
-        self.event_stream(format!(
-            "{EVENT_URI}?{EVENT_VERSION_PARAM}={EVENT_VERSION_V2}"
-        ))
-        .await
-    }
-
-    /// The shared upgrade + decode path. `operation` stays [`EVENT_URI`] for
-    /// both versions: the version is a parameter of one endpoint, not a second
-    /// endpoint.
-    async fn event_stream(&self, endpoint: String) -> Result<EventStream> {
+    /// [`Event::CoreStateChanged`] keeps arriving alongside the snapshots, so a
+    /// consumer of both sees each transition twice. The snapshot is idempotent,
+    /// so the simplest correct handling is to let the last frame win.
+    pub async fn events(&self) -> Result<EventStream> {
         let response = self
-            .get(&endpoint)
+            .get(EVENT_URI)
             .upgrade()
             .send()
             .await

--- a/nyanpasu_ipc/src/client/shortcuts.rs
+++ b/nyanpasu_ipc/src/client/shortcuts.rs
@@ -15,7 +15,7 @@ use crate::api::{
     core::apply::{CORE_APPLY_ENDPOINT, CoreApplyData},
     log::{LOGS_INSPECT_ENDPOINT, LOGS_RETRIEVE_ENDPOINT},
     status::STATUS_ENDPOINT,
-    ws::events::{EVENT_URI, Event},
+    ws::events::{EVENT_URI, EVENT_VERSION_PARAM, EVENT_VERSION_V2, Event},
 };
 
 use super::{ClientError, Result};
@@ -96,9 +96,36 @@ impl Client {
     }
 
     /// Subscribe to the events pushed by the service over `/ws/events`.
+    ///
+    /// The v1 stream: [`Event::Log`] and [`Event::CoreStateChanged`] only, no
+    /// frame until something happens. Unchanged since it shipped — see
+    /// [`Self::events_v2`] for the snapshot stream.
     pub async fn events(&self) -> Result<EventStream> {
+        self.event_stream(EVENT_URI.to_owned()).await
+    }
+
+    /// Subscribe to the v2 event stream.
+    ///
+    /// Adds [`Event::CoreStatusChanged`]: one full snapshot the moment the
+    /// socket opens, one after every dropped-event recovery, and one per manager
+    /// transition — including the `Starting`/`Restarting` transitions the v1
+    /// state cannot express. [`Event::CoreStateChanged`] keeps arriving
+    /// alongside it during the transition (report §4 P1-A), so a consumer of
+    /// both sees each transition twice; the snapshot is idempotent, so the
+    /// simplest correct handling is to let the last frame win.
+    pub async fn events_v2(&self) -> Result<EventStream> {
+        self.event_stream(format!(
+            "{EVENT_URI}?{EVENT_VERSION_PARAM}={EVENT_VERSION_V2}"
+        ))
+        .await
+    }
+
+    /// The shared upgrade + decode path. `operation` stays [`EVENT_URI`] for
+    /// both versions: the version is a parameter of one endpoint, not a second
+    /// endpoint.
+    async fn event_stream(&self, endpoint: String) -> Result<EventStream> {
         let response = self
-            .get(EVENT_URI)
+            .get(&endpoint)
             .upgrade()
             .send()
             .await

--- a/nyanpasu_ipc/src/client/shortcuts.rs
+++ b/nyanpasu_ipc/src/client/shortcuts.rs
@@ -9,8 +9,10 @@ use reqwest_websocket::{Message, Upgrade};
 use crate::api::{
     self,
     contract::{
-        CoreRestart, CoreStart, CoreStop, LogsInspect, LogsRetrieve, NetworkSetDns, Status,
+        CoreApply, CoreCheck, CoreRecover, CoreRestart, CoreStart, CoreStop, LogsInspect,
+        LogsRetrieve, NetworkSetDns, Status,
     },
+    core::apply::{CORE_APPLY_ENDPOINT, CoreApplyData},
     log::{LOGS_INSPECT_ENDPOINT, LOGS_RETRIEVE_ENDPOINT},
     status::STATUS_ENDPOINT,
     ws::events::{EVENT_URI, Event},
@@ -40,6 +42,32 @@ impl Client {
 
     pub async fn restart_core(&self) -> Result<()> {
         self.call::<CoreRestart>(None).await.map(|_| ())
+    }
+
+    /// Apply a config to the running core. See
+    /// [`CoreApplyData::outcome`](api::core::apply::CoreApplyData::outcome):
+    /// `rolled_back` is a successful call reporting that the **old** config is
+    /// what runs.
+    pub async fn apply_config(
+        &self,
+        payload: &api::core::apply::CoreApplyReq<'_>,
+    ) -> Result<CoreApplyData> {
+        self.call::<CoreApply>(Some(payload))
+            .await?
+            .data
+            .ok_or(ClientError::EmptyData {
+                operation: CORE_APPLY_ENDPOINT,
+            })
+    }
+
+    /// Dry-run a config against a core binary without touching the running one.
+    pub async fn check_config(&self, payload: &api::core::check::CoreCheckReq<'_>) -> Result<()> {
+        self.call::<CoreCheck>(Some(payload)).await.map(|_| ())
+    }
+
+    /// Clear the manager's quarantine latch. Idempotent.
+    pub async fn recover_core(&self) -> Result<()> {
+        self.call::<CoreRecover>(None).await.map(|_| ())
     }
 
     pub async fn inspect_logs(&self) -> Result<api::log::LogsResBody<'static>> {

--- a/nyanpasu_ipc/tests/roundtrip.rs
+++ b/nyanpasu_ipc/tests/roundtrip.rs
@@ -25,7 +25,7 @@ use axum::{
     Json, Router,
     body::Bytes,
     extract::{
-        State,
+        RawQuery, State,
         ws::{Message, WebSocket, WebSocketUpgrade},
     },
     http::{HeaderMap, HeaderValue, StatusCode, header::CONTENT_TYPE},
@@ -53,8 +53,8 @@ use nyanpasu_ipc::{
         log::{LOGS_INSPECT_ENDPOINT, LOGS_RETRIEVE_ENDPOINT, LogsRes, LogsResBody},
         network::set_dns::{NETWORK_SET_DNS_ENDPOINT, NetworkSetDnsReq, NetworkSetDnsRes},
         status::{
-            ConfigRevisionInfo, CoreInfos, CoreState, RevisionIdInfo, RuntimeInfos,
-            STATUS_ENDPOINT, StatusRes, StatusResBody,
+            ConfigRevisionInfo, CoreInfos, CoreState, CoreStateDetail, RevisionIdInfo,
+            RuntimeInfos, STATUS_ENDPOINT, StatusRes, StatusResBody,
         },
         ws::events::{EVENT_URI, Event, TraceLog},
     },
@@ -300,18 +300,25 @@ async fn set_dns_handler(
     (StatusCode::OK, Json(RBuilder::success(())))
 }
 
-async fn ws_handler(ws: WebSocketUpgrade) -> Response {
-    ws.on_upgrade(|mut socket: WebSocket| async move {
-        let events = [
-            Event::new_log(TraceLog {
-                timestamp: "2026-01-01T00:00:00Z".to_owned(),
-                level: "INFO".to_owned(),
-                message: "hello events".to_owned(),
-                target: "roundtrip".to_owned(),
-                fields: IndexMap::new(),
-            }),
-            Event::new_core_state_changed(CoreState::Stopped(Some("bye".to_owned()))),
-        ];
+/// Mirrors the service's negotiation: a v2 connection is greeted with one full
+/// snapshot frame, a v1 connection never sees that variant at all.
+async fn ws_handler(RawQuery(query): RawQuery, ws: WebSocketUpgrade) -> Response {
+    let v2 = query.as_deref() == Some("v=2");
+    ws.on_upgrade(move |mut socket: WebSocket| async move {
+        let mut events = Vec::new();
+        if v2 {
+            events.push(Event::new_core_status_changed(test_snapshot()));
+        }
+        events.push(Event::new_log(TraceLog {
+            timestamp: "2026-01-01T00:00:00Z".to_owned(),
+            level: "INFO".to_owned(),
+            message: "hello events".to_owned(),
+            target: "roundtrip".to_owned(),
+            fields: IndexMap::new(),
+        }));
+        events.push(Event::new_core_state_changed(CoreState::Stopped(Some(
+            "bye".to_owned(),
+        ))));
         for event in events {
             let bytes = serde_json::to_vec(&event).unwrap();
             if socket.send(Message::binary(bytes)).await.is_err() {
@@ -321,6 +328,23 @@ async fn ws_handler(ws: WebSocketUpgrade) -> Response {
         // keep the socket open until the client goes away
         while let Some(Ok(_)) = socket.recv().await {}
     })
+}
+
+/// A crash loop: the v1 `state` says stopped, the v2 `detail` says restarting.
+fn test_snapshot() -> CoreInfos {
+    CoreInfos {
+        r#type: Some(CoreType::Clash(ClashCoreType::Mihomo)),
+        state: CoreState::Stopped(None),
+        state_changed_at: 42,
+        config_path: None,
+        controller: None,
+        health: None,
+        revision: None,
+        detail: Some(CoreStateDetail::Restarting {
+            epoch: 3,
+            attempt: 2,
+        }),
+    }
 }
 
 async fn status_fails_with_500() -> (StatusCode, Json<StatusRes<'static>>) {
@@ -521,6 +545,64 @@ async fn events_roundtrip() {
         }
         other => panic!("expected a core state changed event, got: {other:?}"),
     }
+
+    let _ = shutdown.send(());
+    cleanup(&placeholder);
+}
+
+/// The v2 stream, end to end over the real transport: `events_v2()` has to
+/// actually ask for it (the handler branches on the query, so a missing `?v=2`
+/// yields a log frame first and fails the first assertion), the new variant has
+/// to decode through the unchanged `EventStream` path, and the legacy variants
+/// have to keep flowing behind it — the transitional double-send.
+#[tokio::test]
+async fn events_v2_roundtrip() {
+    let placeholder = format!("nyanpasu-ipc-test-{}-events-v2", std::process::id());
+    let Some((shutdown, client)) = run_server(&placeholder, test_router(Shared::default())).await
+    else {
+        return;
+    };
+
+    let mut events = client.events_v2().await.expect("events_v2 should connect");
+
+    let event = events
+        .next()
+        .await
+        .expect("stream should yield a snapshot first")
+        .expect("snapshot should decode");
+    match event {
+        Event::CoreStatusChanged(infos) => {
+            assert!(matches!(infos.state, CoreState::Stopped(None)));
+            assert_eq!(
+                infos.detail,
+                Some(CoreStateDetail::Restarting {
+                    epoch: 3,
+                    attempt: 2
+                })
+            );
+        }
+        other => panic!("expected a status snapshot, got: {other:?}"),
+    }
+
+    let event = events
+        .next()
+        .await
+        .expect("stream should yield the log event")
+        .expect("log event should decode");
+    assert!(matches!(event, Event::Log(_)), "got: {event:?}");
+
+    let event = events
+        .next()
+        .await
+        .expect("stream should yield the legacy state event")
+        .expect("legacy state event should decode");
+    assert!(
+        matches!(
+            event,
+            Event::CoreStateChanged(CoreState::Stopped(Some(ref reason))) if reason == "bye"
+        ),
+        "got: {event:?}"
+    );
 
     let _ = shutdown.send(());
     cleanup(&placeholder);

--- a/nyanpasu_ipc/tests/roundtrip.rs
+++ b/nyanpasu_ipc/tests/roundtrip.rs
@@ -42,13 +42,20 @@ use nyanpasu_ipc::{
     api::{
         RBuilder, ResponseCode,
         core::{
+            apply::{
+                ApplyOutcomeKind, CORE_APPLY_ENDPOINT, CoreApplyData, CoreApplyReq, CoreApplyRes,
+            },
             restart::{CORE_RESTART_ENDPOINT, CoreRestartRes},
             start::{CORE_START_ENDPOINT, CoreStartReq, CoreStartRes},
             stop::{CORE_STOP_ENDPOINT, CoreStopRes},
         },
+        error_kind,
         log::{LOGS_INSPECT_ENDPOINT, LOGS_RETRIEVE_ENDPOINT, LogsRes, LogsResBody},
         network::set_dns::{NETWORK_SET_DNS_ENDPOINT, NetworkSetDnsReq, NetworkSetDnsRes},
-        status::{CoreInfos, CoreState, RuntimeInfos, STATUS_ENDPOINT, StatusRes, StatusResBody},
+        status::{
+            ConfigRevisionInfo, CoreInfos, CoreState, RevisionIdInfo, RuntimeInfos,
+            STATUS_ENDPOINT, StatusRes, StatusResBody,
+        },
         ws::events::{EVENT_URI, Event, TraceLog},
     },
     client::{Client, ClientError},
@@ -330,6 +337,53 @@ async fn status_fails_in_envelope() -> (StatusCode, Json<StatusRes<'static>>) {
     )
 }
 
+async fn apply_config_handler(
+    State(capture): State<SharedCapture>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> (StatusCode, Json<CoreApplyRes<'static>>) {
+    *capture.lock().unwrap() = Some(CapturedRequest {
+        content_type: headers.get(CONTENT_TYPE).cloned(),
+        body,
+    });
+    (
+        StatusCode::OK,
+        Json(RBuilder::success(CoreApplyData {
+            outcome: ApplyOutcomeKind::RolledBack,
+            revision: ConfigRevisionInfo {
+                epoch: 3,
+                generation: 7,
+                source_hash: "src".to_owned(),
+                effective_hash: "eff".to_owned(),
+            },
+            warning: Some("directory sync failed".to_owned()),
+            failed_apply: Some("core failed to start".to_owned()),
+        })),
+    )
+}
+
+async fn apply_config_conflict_handler() -> (StatusCode, Json<CoreApplyRes<'static>>) {
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(RBuilder::other_error_with_kind(
+            Cow::Borrowed("config revision conflict"),
+            Some(Cow::Borrowed(error_kind::REVISION_CONFLICT)),
+        )),
+    )
+}
+
+fn apply_payload() -> CoreApplyReq<'static> {
+    CoreApplyReq {
+        core_type: Cow::Owned(CoreType::Clash(ClashCoreType::Mihomo)),
+        config_file: Cow::Owned(PathBuf::from("/etc/nyanpasu/config.yaml")),
+        expected_revision: Some(RevisionIdInfo {
+            epoch: 3,
+            generation: 7,
+            effective_hash: "eff".to_owned(),
+        }),
+    }
+}
+
 fn test_router(state: Shared) -> Router {
     Router::new()
         .route(STATUS_ENDPOINT, get(status_handler))
@@ -567,6 +621,70 @@ async fn json_posts_send_the_exact_payload() {
     );
     let body: serde_json::Value = serde_json::from_slice(&request.body).unwrap();
     assert_eq!(body, serde_json::to_value(&payload).unwrap());
+
+    let _ = shutdown.send(());
+    cleanup(&placeholder);
+}
+
+/// A rolled-back apply crosses the transport as a success carrying the old
+/// revision — the client must not need the envelope code to tell it apart.
+#[tokio::test]
+async fn apply_config_roundtrip() {
+    let placeholder = format!("nyanpasu-ipc-test-{}-apply", std::process::id());
+    let capture = SharedCapture::default();
+    let router = Router::new()
+        .route(STATUS_ENDPOINT, get(status_handler))
+        .route(CORE_APPLY_ENDPOINT, post(apply_config_handler))
+        .with_state(capture.clone());
+    let Some((shutdown, client)) = run_server(&placeholder, router).await else {
+        return;
+    };
+    let payload = apply_payload();
+
+    let data = client
+        .apply_config(&payload)
+        .await
+        .expect("apply_config should succeed");
+    assert_eq!(data.outcome, ApplyOutcomeKind::RolledBack);
+    assert_eq!(data.revision.generation, 7);
+    assert_eq!(data.warning.as_deref(), Some("directory sync failed"));
+    assert_eq!(data.failed_apply.as_deref(), Some("core failed to start"));
+
+    let captured = capture.lock().unwrap();
+    let request = captured.as_ref().expect("request should be captured");
+    let body: serde_json::Value = serde_json::from_slice(&request.body).unwrap();
+    assert_eq!(body, serde_json::to_value(&payload).unwrap());
+    drop(captured);
+
+    let _ = shutdown.send(());
+    cleanup(&placeholder);
+}
+
+/// The envelope's `error_kind` has to reach the caller, or classifying failures
+/// server-side buys nothing.
+#[tokio::test]
+async fn a_server_error_kind_reaches_the_client() {
+    let placeholder = format!("nyanpasu-ipc-test-{}-kind", std::process::id());
+    let router = Router::new()
+        .route(STATUS_ENDPOINT, get(status_handler))
+        .route(CORE_APPLY_ENDPOINT, post(apply_config_conflict_handler));
+    let Some((shutdown, client)) = run_server(&placeholder, router).await else {
+        return;
+    };
+
+    match client.apply_config(&apply_payload()).await {
+        Err(ClientError::Server {
+            code,
+            msg,
+            error_kind,
+            ..
+        }) => {
+            assert_eq!(code, ResponseCode::OtherError);
+            assert_eq!(msg, "config revision conflict");
+            assert_eq!(error_kind.as_deref(), Some("revision_conflict"));
+        }
+        other => panic!("expected a classified server error, got: {other:?}"),
+    }
 
     let _ = shutdown.send(());
     cleanup(&placeholder);

--- a/nyanpasu_ipc/tests/roundtrip.rs
+++ b/nyanpasu_ipc/tests/roundtrip.rs
@@ -203,6 +203,10 @@ fn test_status_body() -> StatusResBody<'static> {
             state: CoreState::Running,
             state_changed_at: 42,
             config_path: None,
+            controller: None,
+            health: None,
+            revision: None,
+            detail: None,
         },
         runtime_infos: RuntimeInfos {
             service_data_dir: Cow::Owned(PathBuf::from("/srv/data")),

--- a/nyanpasu_ipc/tests/roundtrip.rs
+++ b/nyanpasu_ipc/tests/roundtrip.rs
@@ -25,7 +25,7 @@ use axum::{
     Json, Router,
     body::Bytes,
     extract::{
-        RawQuery, State,
+        State,
         ws::{Message, WebSocket, WebSocketUpgrade},
     },
     http::{HeaderMap, HeaderValue, StatusCode, header::CONTENT_TYPE},
@@ -300,25 +300,22 @@ async fn set_dns_handler(
     (StatusCode::OK, Json(RBuilder::success(())))
 }
 
-/// Mirrors the service's negotiation: a v2 connection is greeted with one full
-/// snapshot frame, a v1 connection never sees that variant at all.
-async fn ws_handler(RawQuery(query): RawQuery, ws: WebSocketUpgrade) -> Response {
-    let v2 = query.as_deref() == Some("v=2");
-    ws.on_upgrade(move |mut socket: WebSocket| async move {
-        let mut events = Vec::new();
-        if v2 {
-            events.push(Event::new_core_status_changed(test_snapshot()));
-        }
-        events.push(Event::new_log(TraceLog {
-            timestamp: "2026-01-01T00:00:00Z".to_owned(),
-            level: "INFO".to_owned(),
-            message: "hello events".to_owned(),
-            target: "roundtrip".to_owned(),
-            fields: IndexMap::new(),
-        }));
-        events.push(Event::new_core_state_changed(CoreState::Stopped(Some(
-            "bye".to_owned(),
-        ))));
+/// Mirrors the service's stream: every connection is greeted with one full
+/// snapshot frame, then the live events. No query is inspected — there is no
+/// version to negotiate.
+async fn ws_handler(ws: WebSocketUpgrade) -> Response {
+    ws.on_upgrade(|mut socket: WebSocket| async move {
+        let events = [
+            Event::new_core_status_changed(test_snapshot()),
+            Event::new_log(TraceLog {
+                timestamp: "2026-01-01T00:00:00Z".to_owned(),
+                level: "INFO".to_owned(),
+                message: "hello events".to_owned(),
+                target: "roundtrip".to_owned(),
+                fields: IndexMap::new(),
+            }),
+            Event::new_core_state_changed(CoreState::Stopped(Some("bye".to_owned()))),
+        ];
         for event in events {
             let bytes = serde_json::to_vec(&event).unwrap();
             if socket.send(Message::binary(bytes)).await.is_err() {
@@ -330,7 +327,8 @@ async fn ws_handler(RawQuery(query): RawQuery, ws: WebSocketUpgrade) -> Response
     })
 }
 
-/// A crash loop: the v1 `state` says stopped, the v2 `detail` says restarting.
+/// A crash loop: the lossy `state` says stopped, the faithful `detail` says
+/// restarting.
 fn test_snapshot() -> CoreInfos {
     CoreInfos {
         r#type: Some(CoreType::Clash(ClashCoreType::Mihomo)),
@@ -510,6 +508,11 @@ async fn rest_roundtrip() {
     cleanup(&placeholder);
 }
 
+/// The event stream end to end over the real transport: the snapshot the
+/// service pushes on connect arrives first and decodes through the unchanged
+/// `EventStream` path, and both legacy variants keep flowing behind it — the
+/// dual emission the GUI still consumes. A regression that reintroduced a
+/// version parameter would fail here first: `events()` requests the bare URI.
 #[tokio::test]
 async fn events_roundtrip() {
     let placeholder = format!("nyanpasu-ipc-test-{}-events", std::process::id());
@@ -519,51 +522,6 @@ async fn events_roundtrip() {
     };
 
     let mut events = client.events().await.expect("events should connect");
-
-    let event = events
-        .next()
-        .await
-        .expect("stream should yield a first event")
-        .expect("first event should decode");
-    match event {
-        Event::Log(log) => {
-            assert_eq!(log.message, "hello events");
-            assert_eq!(log.target, "roundtrip");
-            assert_eq!(log.level, "INFO");
-        }
-        other => panic!("expected a log event, got: {other:?}"),
-    }
-
-    let event = events
-        .next()
-        .await
-        .expect("stream should yield a second event")
-        .expect("second event should decode");
-    match event {
-        Event::CoreStateChanged(CoreState::Stopped(Some(reason))) => {
-            assert_eq!(reason, "bye");
-        }
-        other => panic!("expected a core state changed event, got: {other:?}"),
-    }
-
-    let _ = shutdown.send(());
-    cleanup(&placeholder);
-}
-
-/// The v2 stream, end to end over the real transport: `events_v2()` has to
-/// actually ask for it (the handler branches on the query, so a missing `?v=2`
-/// yields a log frame first and fails the first assertion), the new variant has
-/// to decode through the unchanged `EventStream` path, and the legacy variants
-/// have to keep flowing behind it — the transitional double-send.
-#[tokio::test]
-async fn events_v2_roundtrip() {
-    let placeholder = format!("nyanpasu-ipc-test-{}-events-v2", std::process::id());
-    let Some((shutdown, client)) = run_server(&placeholder, test_router(Shared::default())).await
-    else {
-        return;
-    };
-
-    let mut events = client.events_v2().await.expect("events_v2 should connect");
 
     let event = events
         .next()
@@ -589,20 +547,26 @@ async fn events_v2_roundtrip() {
         .await
         .expect("stream should yield the log event")
         .expect("log event should decode");
-    assert!(matches!(event, Event::Log(_)), "got: {event:?}");
+    match event {
+        Event::Log(log) => {
+            assert_eq!(log.message, "hello events");
+            assert_eq!(log.target, "roundtrip");
+            assert_eq!(log.level, "INFO");
+        }
+        other => panic!("expected a log event, got: {other:?}"),
+    }
 
     let event = events
         .next()
         .await
         .expect("stream should yield the legacy state event")
         .expect("legacy state event should decode");
-    assert!(
-        matches!(
-            event,
-            Event::CoreStateChanged(CoreState::Stopped(Some(ref reason))) if reason == "bye"
-        ),
-        "got: {event:?}"
-    );
+    match event {
+        Event::CoreStateChanged(CoreState::Stopped(Some(reason))) => {
+            assert_eq!(reason, "bye");
+        }
+        other => panic!("expected a core state changed event, got: {other:?}"),
+    }
 
     let _ = shutdown.send(());
     cleanup(&placeholder);

--- a/nyanpasu_ipc/tests/wire_golden.rs
+++ b/nyanpasu_ipc/tests/wire_golden.rs
@@ -17,7 +17,10 @@ use nyanpasu_ipc::api::{
     core::start::CoreStartReq,
     log::LogsResBody,
     network::set_dns::NetworkSetDnsReq,
-    status::{CoreInfos, CoreState, RuntimeInfos, StatusResBody},
+    status::{
+        ConfigRevisionInfo, CoreControllerInfo, CoreHealthInfo, CoreHealthState, CoreInfos,
+        CoreState, CoreStateDetail, RuntimeInfos, StatusResBody,
+    },
     ws::events::{Event, TraceLog},
 };
 use nyanpasu_utils::core::{ClashCoreType, CoreType};
@@ -147,6 +150,7 @@ fn the_logs_response_is_pinned() {
     );
 }
 
+/// The absent S7 fields keep this pre-S7 JSON byte-identical.
 #[test]
 fn the_status_response_is_pinned() {
     let body = StatusResBody {
@@ -156,6 +160,10 @@ fn the_status_response_is_pinned() {
             state: CoreState::Running,
             state_changed_at: 42,
             config_path: Some(PathBuf::from("/etc/nyanpasu/config.yaml")),
+            controller: None,
+            health: None,
+            revision: None,
+            detail: None,
         },
         runtime_infos: RuntimeInfos {
             service_data_dir: Cow::Owned(PathBuf::from("/srv/data")),
@@ -227,4 +235,205 @@ fn the_error_envelope_decodes_back() {
     assert_eq!(decoded.msg, "core is already stopped");
     assert!(decoded.data.is_none());
     assert_eq!(decoded.ts, TS);
+}
+
+#[test]
+fn the_controller_infos_are_pinned() {
+    // JSON escapes every backslash, so each one in a named pipe path doubles.
+    assert_eq!(
+        serde_json::to_string(&CoreControllerInfo::NamedPipe(PathBuf::from(
+            r"\\.\pipe\nyanpasu\core-1"
+        )))
+        .unwrap(),
+        r#"{"NamedPipe":"\\\\.\\pipe\\nyanpasu\\core-1"}"#
+    );
+    assert_eq!(
+        serde_json::to_string(&CoreControllerInfo::UnixSocket(PathBuf::from(
+            "/run/nyanpasu/core-1.sock"
+        )))
+        .unwrap(),
+        r#"{"UnixSocket":"/run/nyanpasu/core-1.sock"}"#
+    );
+    assert_eq!(
+        serde_json::to_string(&CoreControllerInfo::Http(
+            "http://127.0.0.1:9090/".to_owned()
+        ))
+        .unwrap(),
+        r#"{"Http":"http://127.0.0.1:9090/"}"#
+    );
+}
+
+#[test]
+fn the_core_state_details_are_pinned() {
+    for (value, expected) in [
+        (
+            CoreStateDetail::Stopped { reason: None },
+            r#"{"Stopped":{"reason":null}}"#,
+        ),
+        (
+            CoreStateDetail::Stopped {
+                reason: Some("boom".to_owned()),
+            },
+            r#"{"Stopped":{"reason":"boom"}}"#,
+        ),
+        (
+            CoreStateDetail::Starting { epoch: 3 },
+            r#"{"Starting":{"epoch":3}}"#,
+        ),
+        (
+            CoreStateDetail::Running {
+                epoch: 3,
+                pid: 4242,
+            },
+            r#"{"Running":{"epoch":3,"pid":4242}}"#,
+        ),
+        (
+            CoreStateDetail::Restarting {
+                epoch: 3,
+                attempt: 2,
+            },
+            r#"{"Restarting":{"epoch":3,"attempt":2}}"#,
+        ),
+        (
+            CoreStateDetail::Switching {
+                from: Some(2),
+                to: 3,
+            },
+            r#"{"Switching":{"from":2,"to":3}}"#,
+        ),
+        (
+            CoreStateDetail::Switching { from: None, to: 1 },
+            r#"{"Switching":{"from":null,"to":1}}"#,
+        ),
+        (
+            CoreStateDetail::Stopping { epoch: 3 },
+            r#"{"Stopping":{"epoch":3}}"#,
+        ),
+    ] {
+        assert_eq!(serde_json::to_string(&value).unwrap(), expected);
+    }
+}
+
+#[test]
+fn the_core_health_infos_are_pinned() {
+    for (value, expected) in [
+        (CoreHealthState::Starting, r#""Starting""#),
+        (CoreHealthState::Healthy, r#""Healthy""#),
+        (CoreHealthState::Unhealthy, r#""Unhealthy""#),
+    ] {
+        assert_eq!(serde_json::to_string(&value).unwrap(), expected);
+    }
+    assert_eq!(
+        serde_json::to_string(&CoreHealthInfo {
+            state: CoreHealthState::Unhealthy,
+            changed_at: 1_700_000_000_123,
+            consecutive_failures: 3,
+            last_error: Some("probe timed out".to_owned()),
+            last_success_at: Some(1_700_000_000_000),
+        })
+        .unwrap(),
+        concat!(
+            r#"{"state":"Unhealthy","changed_at":1700000000123,"#,
+            r#""consecutive_failures":3,"last_error":"probe timed out","#,
+            r#""last_success_at":1700000000000}"#
+        )
+    );
+}
+
+#[test]
+fn the_config_revision_info_is_pinned() {
+    assert_eq!(
+        serde_json::to_string(&ConfigRevisionInfo {
+            epoch: 3,
+            generation: 7,
+            source_hash: "0123456789abcdef".to_owned(),
+            effective_hash: "fedcba9876543210".to_owned(),
+        })
+        .unwrap(),
+        concat!(
+            r#"{"epoch":3,"generation":7,"source_hash":"0123456789abcdef","#,
+            r#""effective_hash":"fedcba9876543210"}"#
+        )
+    );
+}
+
+/// The S7 fields, all populated, inside the production envelope.
+#[test]
+fn the_enriched_status_response_is_pinned() {
+    let body = StatusResBody {
+        version: Cow::Borrowed("9.9.9-golden"),
+        core_infos: CoreInfos {
+            r#type: Some(CoreType::Clash(ClashCoreType::Mihomo)),
+            state: CoreState::Running,
+            state_changed_at: 42,
+            config_path: Some(PathBuf::from("/etc/nyanpasu/config.yaml")),
+            controller: Some(CoreControllerInfo::Http(
+                "http://127.0.0.1:9090/".to_owned(),
+            )),
+            health: Some(CoreHealthInfo {
+                state: CoreHealthState::Healthy,
+                changed_at: 1_700_000_000_123,
+                consecutive_failures: 0,
+                last_error: None,
+                last_success_at: Some(1_700_000_000_000),
+            }),
+            revision: Some(ConfigRevisionInfo {
+                epoch: 3,
+                generation: 7,
+                source_hash: "0123456789abcdef".to_owned(),
+                effective_hash: "fedcba9876543210".to_owned(),
+            }),
+            detail: Some(CoreStateDetail::Running {
+                epoch: 3,
+                pid: 4242,
+            }),
+        },
+        runtime_infos: RuntimeInfos {
+            service_data_dir: Cow::Owned(PathBuf::from("/srv/data")),
+            service_config_dir: Cow::Owned(PathBuf::from("/srv/config")),
+            nyanpasu_config_dir: Cow::Owned(PathBuf::from("/home/config")),
+            nyanpasu_data_dir: Cow::Owned(PathBuf::from("/home/data")),
+        },
+    };
+    assert_eq!(
+        serde_json::to_string(&ok_envelope(body)).unwrap(),
+        concat!(
+            r#"{"code":"Ok","msg":"ok","data":{"version":"9.9.9-golden","#,
+            r#""core_infos":{"type":{"clash":"mihomo"},"state":"Running","#,
+            r#""state_changed_at":42,"config_path":"/etc/nyanpasu/config.yaml","#,
+            r#""controller":{"Http":"http://127.0.0.1:9090/"},"#,
+            r#""health":{"state":"Healthy","changed_at":1700000000123,"#,
+            r#""consecutive_failures":0,"last_error":null,"#,
+            r#""last_success_at":1700000000000},"#,
+            r#""revision":{"epoch":3,"generation":7,"#,
+            r#""source_hash":"0123456789abcdef","#,
+            r#""effective_hash":"fedcba9876543210"},"#,
+            r#""detail":{"Running":{"epoch":3,"pid":4242}}},"#,
+            r#""runtime_infos":{"service_data_dir":"/srv/data","#,
+            r#""service_config_dir":"/srv/config","#,
+            r#""nyanpasu_config_dir":"/home/config","#,
+            r#""nyanpasu_data_dir":"/home/data"}},"ts":1700000000}"#
+        )
+    );
+}
+
+/// The other half of the compatibility gate: a payload written by a pre-S7
+/// service must still decode, with the new fields absent rather than an error.
+#[test]
+fn a_pre_s7_status_payload_still_decodes() {
+    let legacy = concat!(
+        r#"{"code":"Ok","msg":"ok","data":{"version":"1.4.5","#,
+        r#""core_infos":{"type":{"clash":"mihomo"},"state":"Running","#,
+        r#""state_changed_at":42,"config_path":"/etc/nyanpasu/config.yaml"},"#,
+        r#""runtime_infos":{"service_data_dir":"/srv/data","#,
+        r#""service_config_dir":"/srv/config","#,
+        r#""nyanpasu_config_dir":"/home/config","#,
+        r#""nyanpasu_data_dir":"/home/data"}},"ts":1700000000}"#
+    );
+    let decoded: R<'static, StatusResBody<'static>> = serde_json::from_str(legacy).unwrap();
+    let core_infos = decoded.data.unwrap().core_infos;
+    assert!(core_infos.controller.is_none());
+    assert!(core_infos.health.is_none());
+    assert!(core_infos.revision.is_none());
+    assert!(core_infos.detail.is_none());
 }

--- a/nyanpasu_ipc/tests/wire_golden.rs
+++ b/nyanpasu_ipc/tests/wire_golden.rs
@@ -26,7 +26,7 @@ use nyanpasu_ipc::api::{
         ConfigRevisionInfo, CoreControllerInfo, CoreHealthInfo, CoreHealthState, CoreInfos,
         CoreState, CoreStateDetail, RevisionIdInfo, RuntimeInfos, StatusResBody,
     },
-    ws::events::{EVENT_URI, EVENT_VERSION_PARAM, EVENT_VERSION_V2, Event, TraceLog},
+    ws::events::{EVENT_URI, Event, TraceLog},
 };
 use nyanpasu_utils::core::{ClashCoreType, CoreType};
 
@@ -108,7 +108,7 @@ fn minimal_core_infos() -> CoreInfos {
 }
 
 #[test]
-fn the_v2_status_event_is_pinned() {
+fn the_status_event_is_pinned() {
     assert_eq!(
         serde_json::to_string(&Event::new_core_status_changed(enriched_core_infos())).unwrap(),
         concat!(
@@ -135,10 +135,10 @@ fn the_v2_status_event_is_pinned() {
 }
 
 /// The defect the variant exists to fix (report §1.2): a crash loop reports
-/// `Stopped(None)` on the v1 field and `Restarting` on the faithful one, in the
+/// `Stopped(None)` on the lossy field and `Restarting` on the faithful one, in
 /// same frame.
 #[test]
-fn the_v2_payload_distinguishes_a_crash_loop_from_a_stop() {
+fn the_status_payload_distinguishes_a_crash_loop_from_a_stop() {
     let mut infos = minimal_core_infos();
     infos.r#type = Some(CoreType::Clash(ClashCoreType::Mihomo));
     infos.detail = Some(CoreStateDetail::Restarting {
@@ -158,38 +158,26 @@ fn the_v2_payload_distinguishes_a_crash_loop_from_a_stop() {
 /// Push *is* snapshot: the frame's payload is the same object `/status` puts in
 /// `core_infos`, byte for byte. A client decodes one with the other's decoder.
 #[test]
-fn the_v2_payload_is_the_status_core_infos() {
+fn the_status_payload_is_the_status_core_infos() {
     let infos = enriched_core_infos();
     let payload = serde_json::to_string(&infos).unwrap();
     let frame = serde_json::to_string(&Event::new_core_status_changed(infos)).unwrap();
     assert_eq!(frame, format!(r#"{{"CoreStatusChanged":{payload}}}"#));
 }
 
-/// The compatibility gate: v1 is exactly the two legacy variants, and the
-/// negotiation is opt-in.
+/// The endpoint string is protocol: the GUI builds the URL from it. There is
+/// no version parameter left to pin — the stream is unversioned, and the
+/// service ignores whatever query it is handed.
 #[test]
-fn only_the_legacy_variants_belong_to_protocol_v1() {
-    let log = Event::new_log(TraceLog {
-        timestamp: "2026-01-01T00:00:00Z".to_owned(),
-        level: "INFO".to_owned(),
-        message: "hello".to_owned(),
-        target: "nyanpasu_service::core".to_owned(),
-        fields: IndexMap::new(),
-    });
-    assert!(log.is_protocol_v1());
-    assert!(Event::new_core_state_changed(CoreState::Running).is_protocol_v1());
-    assert!(!Event::new_core_status_changed(minimal_core_infos()).is_protocol_v1());
-    // These three strings are protocol: the GUI builds the URL from them.
+fn the_event_endpoint_is_pinned() {
     assert_eq!(EVENT_URI, "/ws/events");
-    assert_eq!(EVENT_VERSION_PARAM, "v");
-    assert_eq!(EVENT_VERSION_V2, "2");
 }
 
-/// The other half: a v2 frame decodes back, and a frame written by a *newer*
-/// service — one extra field in the payload — still decodes instead of killing
-/// the stream.
+/// The other half: a status frame decodes back, and a frame written by a
+/// *newer* service — one extra field in the payload — still decodes instead of
+/// killing the stream.
 #[test]
-fn a_v2_status_frame_decodes_back() {
+fn a_status_frame_decodes_back() {
     let frame =
         serde_json::to_string(&Event::new_core_status_changed(enriched_core_infos())).unwrap();
     match serde_json::from_str::<Event>(&frame).unwrap() {

--- a/nyanpasu_ipc/tests/wire_golden.rs
+++ b/nyanpasu_ipc/tests/wire_golden.rs
@@ -26,7 +26,7 @@ use nyanpasu_ipc::api::{
         ConfigRevisionInfo, CoreControllerInfo, CoreHealthInfo, CoreHealthState, CoreInfos,
         CoreState, CoreStateDetail, RevisionIdInfo, RuntimeInfos, StatusResBody,
     },
-    ws::events::{Event, TraceLog},
+    ws::events::{EVENT_URI, EVENT_VERSION_PARAM, EVENT_VERSION_V2, Event, TraceLog},
 };
 use nyanpasu_utils::core::{ClashCoreType, CoreType};
 
@@ -59,6 +59,158 @@ where
         RBuilder::other_error_with_kind(Cow::Borrowed(msg), Some(Cow::Borrowed(kind)));
     envelope.ts = TS;
     envelope
+}
+
+/// The S7-enriched snapshot, the same value `the_enriched_status_response_is_pinned`
+/// carries — so a diff between the two literals is a real drift, not a fixture
+/// that fell behind.
+fn enriched_core_infos() -> CoreInfos {
+    CoreInfos {
+        r#type: Some(CoreType::Clash(ClashCoreType::Mihomo)),
+        state: CoreState::Running,
+        state_changed_at: 42,
+        config_path: Some(PathBuf::from("/etc/nyanpasu/config.yaml")),
+        controller: Some(CoreControllerInfo::Http(
+            "http://127.0.0.1:9090/".to_owned(),
+        )),
+        health: Some(CoreHealthInfo {
+            state: CoreHealthState::Healthy,
+            changed_at: 1_700_000_000_123,
+            consecutive_failures: 0,
+            last_error: None,
+            last_success_at: Some(1_700_000_000_000),
+        }),
+        revision: Some(ConfigRevisionInfo {
+            epoch: 3,
+            generation: 7,
+            source_hash: "0123456789abcdef".to_owned(),
+            effective_hash: "fedcba9876543210".to_owned(),
+        }),
+        detail: Some(CoreStateDetail::Running {
+            epoch: 3,
+            pid: 4242,
+        }),
+    }
+}
+
+/// A never-started core: every S7 field absent, `detail` still populated.
+fn minimal_core_infos() -> CoreInfos {
+    CoreInfos {
+        r#type: None,
+        state: CoreState::Stopped(None),
+        state_changed_at: 42,
+        config_path: None,
+        controller: None,
+        health: None,
+        revision: None,
+        detail: Some(CoreStateDetail::Stopped { reason: None }),
+    }
+}
+
+#[test]
+fn the_v2_status_event_is_pinned() {
+    assert_eq!(
+        serde_json::to_string(&Event::new_core_status_changed(enriched_core_infos())).unwrap(),
+        concat!(
+            r#"{"CoreStatusChanged":{"type":{"clash":"mihomo"},"state":"Running","#,
+            r#""state_changed_at":42,"config_path":"/etc/nyanpasu/config.yaml","#,
+            r#""controller":{"Http":"http://127.0.0.1:9090/"},"#,
+            r#""health":{"state":"Healthy","changed_at":1700000000123,"#,
+            r#""consecutive_failures":0,"last_error":null,"#,
+            r#""last_success_at":1700000000000},"#,
+            r#""revision":{"epoch":3,"generation":7,"#,
+            r#""source_hash":"0123456789abcdef","#,
+            r#""effective_hash":"fedcba9876543210"},"#,
+            r#""detail":{"Running":{"epoch":3,"pid":4242}}}}"#
+        )
+    );
+    assert_eq!(
+        serde_json::to_string(&Event::new_core_status_changed(minimal_core_infos())).unwrap(),
+        concat!(
+            r#"{"CoreStatusChanged":{"type":null,"state":{"Stopped":null},"#,
+            r#""state_changed_at":42,"config_path":null,"#,
+            r#""detail":{"Stopped":{"reason":null}}}}"#
+        )
+    );
+}
+
+/// The defect the variant exists to fix (report §1.2): a crash loop reports
+/// `Stopped(None)` on the v1 field and `Restarting` on the faithful one, in the
+/// same frame.
+#[test]
+fn the_v2_payload_distinguishes_a_crash_loop_from_a_stop() {
+    let mut infos = minimal_core_infos();
+    infos.r#type = Some(CoreType::Clash(ClashCoreType::Mihomo));
+    infos.detail = Some(CoreStateDetail::Restarting {
+        epoch: 3,
+        attempt: 2,
+    });
+    assert_eq!(
+        serde_json::to_string(&Event::new_core_status_changed(infos)).unwrap(),
+        concat!(
+            r#"{"CoreStatusChanged":{"type":{"clash":"mihomo"},"#,
+            r#""state":{"Stopped":null},"state_changed_at":42,"config_path":null,"#,
+            r#""detail":{"Restarting":{"epoch":3,"attempt":2}}}}"#
+        )
+    );
+}
+
+/// Push *is* snapshot: the frame's payload is the same object `/status` puts in
+/// `core_infos`, byte for byte. A client decodes one with the other's decoder.
+#[test]
+fn the_v2_payload_is_the_status_core_infos() {
+    let infos = enriched_core_infos();
+    let payload = serde_json::to_string(&infos).unwrap();
+    let frame = serde_json::to_string(&Event::new_core_status_changed(infos)).unwrap();
+    assert_eq!(frame, format!(r#"{{"CoreStatusChanged":{payload}}}"#));
+}
+
+/// The compatibility gate: v1 is exactly the two legacy variants, and the
+/// negotiation is opt-in.
+#[test]
+fn only_the_legacy_variants_belong_to_protocol_v1() {
+    let log = Event::new_log(TraceLog {
+        timestamp: "2026-01-01T00:00:00Z".to_owned(),
+        level: "INFO".to_owned(),
+        message: "hello".to_owned(),
+        target: "nyanpasu_service::core".to_owned(),
+        fields: IndexMap::new(),
+    });
+    assert!(log.is_protocol_v1());
+    assert!(Event::new_core_state_changed(CoreState::Running).is_protocol_v1());
+    assert!(!Event::new_core_status_changed(minimal_core_infos()).is_protocol_v1());
+    // These three strings are protocol: the GUI builds the URL from them.
+    assert_eq!(EVENT_URI, "/ws/events");
+    assert_eq!(EVENT_VERSION_PARAM, "v");
+    assert_eq!(EVENT_VERSION_V2, "2");
+}
+
+/// The other half: a v2 frame decodes back, and a frame written by a *newer*
+/// service — one extra field in the payload — still decodes instead of killing
+/// the stream.
+#[test]
+fn a_v2_status_frame_decodes_back() {
+    let frame =
+        serde_json::to_string(&Event::new_core_status_changed(enriched_core_infos())).unwrap();
+    match serde_json::from_str::<Event>(&frame).unwrap() {
+        Event::CoreStatusChanged(infos) => {
+            assert!(matches!(infos.state, CoreState::Running));
+            assert_eq!(
+                infos.detail,
+                Some(CoreStateDetail::Running {
+                    epoch: 3,
+                    pid: 4242
+                })
+            );
+            assert_eq!(infos.revision.unwrap().generation, 7);
+        }
+        other => panic!("expected a status snapshot, got: {other:?}"),
+    }
+    let forward = concat!(
+        r#"{"CoreStatusChanged":{"type":null,"state":"Running","#,
+        r#""state_changed_at":1,"config_path":null,"future_field":7}}"#
+    );
+    assert!(serde_json::from_str::<Event>(forward).is_ok());
 }
 
 #[test]

--- a/nyanpasu_ipc/tests/wire_golden.rs
+++ b/nyanpasu_ipc/tests/wire_golden.rs
@@ -612,8 +612,8 @@ fn the_apply_outcome_kinds_are_pinned() {
         (ApplyOutcomeKind::Patched, r#""patched""#),
         (ApplyOutcomeKind::Reloaded, r#""reloaded""#),
         (ApplyOutcomeKind::Restarted, r#""restarted""#),
-        // Reserved, never produced today; pinned so the day it is produced is
-        // not also the day its spelling is decided.
+        // Produced since S10 by the manager's core-switch path; the spelling was
+        // pinned a stage before it was reachable.
         (ApplyOutcomeKind::Switched, r#""switched""#),
         (ApplyOutcomeKind::RolledBack, r#""rolled_back""#),
     ] {

--- a/nyanpasu_ipc/tests/wire_golden.rs
+++ b/nyanpasu_ipc/tests/wire_golden.rs
@@ -14,12 +14,17 @@ use std::{
 use indexmap::IndexMap;
 use nyanpasu_ipc::api::{
     R, RBuilder, ResponseCode,
-    core::start::CoreStartReq,
+    core::{
+        apply::{ApplyOutcomeKind, CoreApplyData, CoreApplyReq},
+        check::CoreCheckReq,
+        start::CoreStartReq,
+    },
+    error_kind,
     log::LogsResBody,
     network::set_dns::NetworkSetDnsReq,
     status::{
         ConfigRevisionInfo, CoreControllerInfo, CoreHealthInfo, CoreHealthState, CoreInfos,
-        CoreState, CoreStateDetail, RuntimeInfos, StatusResBody,
+        CoreState, CoreStateDetail, RevisionIdInfo, RuntimeInfos, StatusResBody,
     },
     ws::events::{Event, TraceLog},
 };
@@ -42,6 +47,16 @@ where
     T: serde::Serialize + serde::de::DeserializeOwned + std::fmt::Debug,
 {
     let mut envelope: R<'static, T> = RBuilder::other_error(Cow::Borrowed(msg));
+    envelope.ts = TS;
+    envelope
+}
+
+fn error_envelope_with_kind<T>(msg: &'static str, kind: &'static str) -> R<'static, T>
+where
+    T: serde::Serialize + serde::de::DeserializeOwned + std::fmt::Debug,
+{
+    let mut envelope: R<'static, T> =
+        RBuilder::other_error_with_kind(Cow::Borrowed(msg), Some(Cow::Borrowed(kind)));
     envelope.ts = TS;
     envelope
 }
@@ -436,4 +451,171 @@ fn a_pre_s7_status_payload_still_decodes() {
     assert!(core_infos.health.is_none());
     assert!(core_infos.revision.is_none());
     assert!(core_infos.detail.is_none());
+}
+
+#[test]
+fn the_apply_outcome_kinds_are_pinned() {
+    for (value, expected) in [
+        (ApplyOutcomeKind::Noop, r#""noop""#),
+        (ApplyOutcomeKind::Patched, r#""patched""#),
+        (ApplyOutcomeKind::Reloaded, r#""reloaded""#),
+        (ApplyOutcomeKind::Restarted, r#""restarted""#),
+        // Reserved, never produced today; pinned so the day it is produced is
+        // not also the day its spelling is decided.
+        (ApplyOutcomeKind::Switched, r#""switched""#),
+        (ApplyOutcomeKind::RolledBack, r#""rolled_back""#),
+    ] {
+        assert_eq!(serde_json::to_string(&value).unwrap(), expected);
+    }
+}
+
+#[test]
+fn the_error_kind_strings_are_pinned() {
+    // These are protocol: a caller branches on them.
+    assert_eq!(error_kind::NOT_STARTED, "not_started");
+    assert_eq!(error_kind::ALREADY_RUNNING, "already_running");
+    assert_eq!(error_kind::REVISION_CONFLICT, "revision_conflict");
+    assert_eq!(error_kind::QUARANTINED, "quarantined");
+    assert_eq!(error_kind::CONFIG_CHECK_FAILED, "config_check_failed");
+    assert_eq!(error_kind::CONFIG_NOT_FOUND, "config_not_found");
+    assert_eq!(error_kind::BINARY_NOT_FOUND, "binary_not_found");
+    assert_eq!(error_kind::INVALID_CONFIG, "invalid_config");
+    assert_eq!(error_kind::CONTROLLER_MISSING, "controller_missing");
+    assert_eq!(error_kind::APPLY_FAILED, "apply_failed");
+    assert_eq!(error_kind::APPLY_ROLLBACK_FAILED, "apply_rollback_failed");
+    assert_eq!(error_kind::STOP_UNCONFIRMED, "stop_unconfirmed");
+}
+
+/// The new field is appended, so no existing key moves; the absent case is
+/// pinned by every other envelope golden in this file staying unchanged.
+#[test]
+fn an_error_envelope_carries_its_kind() {
+    let envelope: R<'static, ()> =
+        error_envelope_with_kind("config revision conflict", error_kind::REVISION_CONFLICT);
+    assert_eq!(
+        serde_json::to_string(&envelope).unwrap(),
+        concat!(
+            r#"{"code":"OtherError","msg":"config revision conflict","data":null,"#,
+            r#""ts":1700000000,"error_kind":"revision_conflict"}"#
+        )
+    );
+}
+
+/// The other half of the compatibility gate: an envelope written by a pre-S8
+/// service has no `error_kind` key and must still decode.
+#[test]
+fn a_pre_s8_envelope_still_decodes() {
+    let legacy = r#"{"code":"OtherError","msg":"boom","data":null,"ts":1700000000}"#;
+    let decoded: R<'static, ()> = serde_json::from_str(legacy).unwrap();
+    assert_eq!(decoded.code, ResponseCode::OtherError);
+    assert!(decoded.error_kind.is_none());
+}
+
+#[test]
+fn the_revision_id_info_is_pinned() {
+    let revision = ConfigRevisionInfo {
+        epoch: 3,
+        generation: 7,
+        source_hash: "0123456789abcdef".to_owned(),
+        effective_hash: "fedcba9876543210".to_owned(),
+    };
+    assert_eq!(
+        serde_json::to_string(&revision.id()).unwrap(),
+        r#"{"epoch":3,"generation":7,"effective_hash":"fedcba9876543210"}"#
+    );
+    // The CAS token is a strict subset: `source_hash` takes no part in it.
+    assert_eq!(
+        revision.id(),
+        RevisionIdInfo {
+            epoch: 3,
+            generation: 7,
+            effective_hash: "fedcba9876543210".to_owned(),
+        }
+    );
+}
+
+#[test]
+fn the_core_apply_request_is_pinned() {
+    let without = CoreApplyReq {
+        core_type: Cow::Owned(CoreType::Clash(ClashCoreType::Mihomo)),
+        config_file: Cow::Owned(PathBuf::from("/etc/nyanpasu/config.yaml")),
+        expected_revision: None,
+    };
+    // No CAS token: the key is omitted, not sent as null.
+    assert_eq!(
+        serde_json::to_string(&without).unwrap(),
+        r#"{"core_type":{"clash":"mihomo"},"config_file":"/etc/nyanpasu/config.yaml"}"#
+    );
+    let with = CoreApplyReq {
+        expected_revision: Some(RevisionIdInfo {
+            epoch: 3,
+            generation: 7,
+            effective_hash: "fedcba9876543210".to_owned(),
+        }),
+        ..without
+    };
+    assert_eq!(
+        serde_json::to_string(&with).unwrap(),
+        concat!(
+            r#"{"core_type":{"clash":"mihomo"},"#,
+            r#""config_file":"/etc/nyanpasu/config.yaml","#,
+            r#""expected_revision":{"epoch":3,"generation":7,"#,
+            r#""effective_hash":"fedcba9876543210"}}"#
+        )
+    );
+}
+
+#[test]
+fn the_core_check_request_is_pinned() {
+    let request = CoreCheckReq {
+        core_type: Cow::Owned(CoreType::Clash(ClashCoreType::Mihomo)),
+        config_file: Cow::Owned(PathBuf::from("/etc/nyanpasu/config.yaml")),
+    };
+    assert_eq!(
+        serde_json::to_string(&request).unwrap(),
+        r#"{"core_type":{"clash":"mihomo"},"config_file":"/etc/nyanpasu/config.yaml"}"#
+    );
+}
+
+#[test]
+fn the_core_apply_response_is_pinned() {
+    let revision = ConfigRevisionInfo {
+        epoch: 3,
+        generation: 7,
+        source_hash: "0123456789abcdef".to_owned(),
+        effective_hash: "fedcba9876543210".to_owned(),
+    };
+    let clean = CoreApplyData {
+        outcome: ApplyOutcomeKind::Patched,
+        revision: revision.clone(),
+        warning: None,
+        failed_apply: None,
+    };
+    assert_eq!(
+        serde_json::to_string(&ok_envelope(clean)).unwrap(),
+        concat!(
+            r#"{"code":"Ok","msg":"ok","data":{"outcome":"patched","#,
+            r#""revision":{"epoch":3,"generation":7,"#,
+            r#""source_hash":"0123456789abcdef","#,
+            r#""effective_hash":"fedcba9876543210"}},"ts":1700000000}"#
+        )
+    );
+    // A rollback is a *successful* call reporting that the old config runs.
+    let rolled_back = CoreApplyData {
+        outcome: ApplyOutcomeKind::RolledBack,
+        revision,
+        warning: Some("runtime directory sync failed".to_owned()),
+        failed_apply: Some("core failed to start".to_owned()),
+    };
+    assert_eq!(
+        serde_json::to_string(&ok_envelope(rolled_back)).unwrap(),
+        concat!(
+            r#"{"code":"Ok","msg":"ok","data":{"outcome":"rolled_back","#,
+            r#""revision":{"epoch":3,"generation":7,"#,
+            r#""source_hash":"0123456789abcdef","#,
+            r#""effective_hash":"fedcba9876543210"},"#,
+            r#""warning":"runtime directory sync failed","#,
+            r#""failed_apply":"core failed to start"},"ts":1700000000}"#
+        )
+    );
 }


### PR DESCRIPTION
## Summary

Implements the IPC protocol evolution proposed in `docs/superpowers/specs/2026-07-30-ipc-protocol-evolution-report.md` (committed as the first commit of this branch): callers using the service client now have the same runtime-operation and observability capabilities as direct `nyanpasu-core-manager` usage. Continues from #387 (S1-S5).

### S7 — status payload enrichment (`8f7c3e0`)

Four additive `Option` fields on the wire `CoreInfos`, projected from state the manager already published and the bridge previously discarded:

- `controller` — the resolved control endpoint (`NamedPipe|UnixSocket|Http`); HTTP userinfo is stripped, the secret is never carried
- `health` — state / changed_at / consecutive_failures / last_error / last_success_at
- `revision` — epoch / generation / **source_hash / effective_hash**: the consistency credential letting a caller confirm the running core adopted its edit
- `detail` — the faithful six-state view (a crash loop is no longer indistinguishable from a stop; the lossy two-valued `state` stays for compatibility)

### S8 — `/core/apply`, `/core/check`, `/core/recover` (`76b37de`)

The manager's complete-but-unwired config-apply engine is now reachable over IPC:

- `POST /core/apply`: automatic classification (patch / reload / same-epoch restart with rollback / core switch), `expected_revision` CAS, and an outcome that makes **`rolled_back` a visible success carrying the OLD revision** — never silently conflated with an applied config
- `POST /core/check`: dry-run validation without touching the running core
- `POST /core/recover`: clears the quarantine latch that previously required restarting the whole service
- Envelope gains additive `error_kind` (machine-readable failure classification); `ResponseCode` stays frozen at two variants

### S9 — event protocol v2 (`d722ece`)

- `Event::CoreStatusChanged(CoreInfos)` — the payload IS `/status`'s `core_infos`, byte for byte
- Opt-in via `/ws/events?v=2`; any other query answers v1, which stays byte- and order-identical (per-connection filtering runs before serialization)
- Snapshot-on-connect and snapshot-after-`Lagged`, so a v2 client resynchronises without polling

### S10 — `ControllerMode` removed (`dd78e47`) — BREAKING (core-manager public API)

- `LocalIpcPolicy` (`force|prefer|disable`) is the only knob, flattened into `ManagerOptions`; `derived_dir`, `DegradeReason::PassthroughMode` and the mode match deleted
- Policy injected at install time: `--local-ipc-policy` + `NYANPASU_LOCAL_IPC_POLICY` env fallback; **transition default `disable`** behaves exactly like the removed `Passthrough` for configs relying solely on HTTP `external-controller` (proof: all 13 pre-existing default-options test managers pass unedited); flip to `prefer` waits on GUI endpoint discovery
- `restart()`/`switch()` gain graceful zero-downtime switching once the policy resolves to local IPC; apply's switch class deliberately stays `switch_with_compensation` (hard, with rollback)
- `ApplyOutcome::Switched` split out of `Restarted`, so apply now answers `"switched"` for core switches

### Review-fix round (`f9f14fe`, `4f2d861`, `d7af967`, `3a6bbf6`)

Dual-model review (codex + antigravity), all Majors fixed:

- environment variable **values** no longer logged (they were retrievable via `/logs` by any socket-ACL client); names only, via `vars_os`
- v2 type-echo consistency: `requested_core` is a watch channel, committing it publishes a fresh snapshot (previously a cross-core apply left connected v2 clients with a stale `type` forever)
- config checks bounded: 30s timeout (kills the process tree, covers all five `check_config` call sites including the lock-holding ones) + per-service two-permit semaphore on `/core/check`
- `config_not_found` / `binary_not_found` error kinds populated; `tokio::fs::canonicalize` on the route path
- accepted-and-documented (report §7 R8/R9): the socket ACL is the sole authorization boundary (unchanged since `/core/start`); v2 events share the 256-slot ring so v1 can lag marginally earlier during startup churn

Final re-review verdict: **mergeable YES, 92/100**.

## Compatibility

- Every pre-existing wire golden stays byte-identical (enforced by tests both ways: old payloads decode, old serializations unchanged)
- `nyanpasu-ipc` consumers: `ClientError::Server` gained a field (non_exhaustive — exhaustive destructures need `..`); `Event` gained a variant (matches need a wildcard); clash-nyanpasu should be updated alongside if it links these as git deps
- **Accepted losses** (release notes): user-declared `external-controller-pipe`/`-unix` are no longer honoured (only `external-controller` is read on the HTTP paths); third-party dashboards need explicit `--local-ipc-policy disable` once the default flips to `prefer` (this release's default is already `disable`, so nothing breaks today)

## Tests

core-manager **144** · nyanpasu-ipc + service-runtime **143** · full workspace green. Every stage's plan-predicted test counts matched reality exactly.

Known pre-existing (not introduced, deliberately untouched): `cargo clippy --workspace --all-features -- -D warnings` fails on `logging.rs:25` (`debug` unused when the `tracing` feature is on); CI runs clippy without `-D warnings` and is unaffected.

## Deferred (recorded in the report / plans)

Shared fake-core test crate for route-level apply coverage; reporting whether `recover` actually cleared a latch (needs a wire change); `error_kind` backfill on legacy operations (P3); `Event::CoreLog` structured frames (P3); default flip `disable` → `prefer` (two tokens, after GUI endpoint discovery).