### PR TITLE
Core log pipeline: rotating JSONL archive, CoreLog event ring, /status log directories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1969,6 +1969,7 @@ dependencies = [
  "schemars",
  "semver",
  "serde",
+ "serde_json",
  "specta",
 ]
 
@@ -1984,6 +1985,7 @@ dependencies = [
  "http",
  "indexmap",
  "interprocess",
+ "nyanpasu-core-metadata",
  "nyanpasu-utils",
  "reqwest",
  "reqwest-websocket",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1950,6 +1950,7 @@ dependencies = [
  "parking_lot",
  "schemars",
  "serde",
+ "serde_json",
  "serde_yaml_ng",
  "specta",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2030,7 +2030,6 @@ dependencies = [
  "ctrlc",
  "dunce",
  "futures-util",
- "indexmap",
  "nyanpasu-core-manager",
  "nyanpasu-ipc",
  "nyanpasu-utils",

--- a/crates/nyanpasu-core-manager/Cargo.toml
+++ b/crates/nyanpasu-core-manager/Cargo.toml
@@ -33,6 +33,7 @@ nyanpasu-utils = {
 parking_lot.workspace = true
 schemars = { version = "1", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 serde_yaml_ng = "0.10"
 specta = { version = "^2.0.0-rc.25", features = ["derive"] }
 thiserror.workspace = true

--- a/crates/nyanpasu-core-manager/src/config/runtime_store.rs
+++ b/crates/nyanpasu-core-manager/src/config/runtime_store.rs
@@ -377,7 +377,10 @@ fn installed_commit(path: Utf8PathBuf, parent_sync: std::io::Result<()>) -> Runt
     RuntimeConfigCommit { path, durability }
 }
 
-fn validate_directory_metadata(path: &Utf8Path, metadata: &std::fs::Metadata) -> Result<(), Error> {
+pub(crate) fn validate_directory_metadata(
+    path: &Utf8Path,
+    metadata: &std::fs::Metadata,
+) -> Result<(), Error> {
     if metadata.file_type().is_symlink()
         || !metadata.is_dir()
         || atomic_fs::is_reparse_point(metadata)

--- a/crates/nyanpasu-core-manager/src/instance.rs
+++ b/crates/nyanpasu-core-manager/src/instance.rs
@@ -51,8 +51,8 @@ struct Shared {
     user_stop: AtomicBool,
     probe_timeout: AtomicBool,
     parser: parking_lot::Mutex<LogParser>,
-    log_tail: parking_lot::Mutex<VecDeque<LogFrame>>,
-    log_tx: broadcast::Sender<LogFrame>,
+    log_tail: parking_lot::Mutex<VecDeque<Arc<LogFrame>>>,
+    log_tx: broadcast::Sender<Arc<LogFrame>>,
     cancel: CancellationToken,
     probe_cancel: CancellationToken,
     probe_request_tx: mpsc::UnboundedSender<ProbeNowRequest>,
@@ -93,11 +93,14 @@ impl Shared {
     /// broadcast subscriber, so doing it here too was a second copy of every
     /// line paid for on the hot path.
     fn publish_log_frame(&self, frame: LogFrame) {
+        // Shared once, here: the tail and every subscriber hold the same
+        // allocation, so fan-out costs a refcount rather than a 16 KiB clone.
+        let frame = Arc::new(frame);
         let mut tail = self.log_tail.lock();
         if tail.len() == LOG_TAIL_FRAMES {
             tail.pop_front();
         }
-        tail.push_back(frame.clone());
+        tail.push_back(Arc::clone(&frame));
         drop(tail);
         let _ = self.log_tx.send(frame);
     }
@@ -111,7 +114,7 @@ impl Shared {
         }
     }
 
-    fn diagnostic_frames(&self) -> Vec<LogFrame> {
+    fn diagnostic_frames(&self) -> Vec<Arc<LogFrame>> {
         self.flush_log_record();
         self.log_tail.lock().iter().cloned().collect()
     }
@@ -139,7 +142,7 @@ pub struct InstanceBuilder {
     readiness_probe: Option<ProbeHandle>,
     liveness_probe: Option<ProbeHandle>,
     liveness_with_readiness: bool,
-    log_tx: Option<broadcast::Sender<LogFrame>>,
+    log_tx: Option<broadcast::Sender<Arc<LogFrame>>>,
 }
 
 impl Instance {
@@ -283,7 +286,7 @@ impl Instance {
         self.state_rx.clone()
     }
 
-    pub fn subscribe_logs(&self) -> broadcast::Receiver<LogFrame> {
+    pub fn subscribe_logs(&self) -> broadcast::Receiver<Arc<LogFrame>> {
         self.shared.log_tx.subscribe()
     }
 
@@ -476,7 +479,7 @@ impl InstanceBuilder {
 
     /// Lets the manager keep one log channel across epochs so subscriptions
     /// survive restarts and core switches.
-    pub(crate) fn log_sender(mut self, log_tx: broadcast::Sender<LogFrame>) -> Self {
+    pub(crate) fn log_sender(mut self, log_tx: broadcast::Sender<Arc<LogFrame>>) -> Self {
         self.log_tx = Some(log_tx);
         self
     }
@@ -971,10 +974,16 @@ mod tests {
 
         // A user stop reads no diagnostics, so the flush has to happen anyway.
         publish_terminal(&shared, None);
-        assert_eq!(
-            logs.try_recv().expect("held record").message,
-            "final record"
-        );
+        let emitted = logs.try_recv().expect("held record");
+        assert_eq!(emitted.message, "final record");
+        // One allocation reaches both the tail and the subscriber.
+        let buffered = shared
+            .log_tail
+            .lock()
+            .back()
+            .cloned()
+            .expect("the held record also lands in the diagnostic tail");
+        assert!(Arc::ptr_eq(&emitted, &buffered));
         assert!(matches!(
             state_rx_state(&shared),
             InstanceState::Stopped(StopReason::User)

--- a/crates/nyanpasu-core-manager/src/instance.rs
+++ b/crates/nyanpasu-core-manager/src/instance.rs
@@ -26,8 +26,8 @@ use crate::{
     },
     kind::{self, CLICOLOR_FORCE_ENV_NAME, MIHOMO_SAFE_PATHS_ENV_NAME},
     log::{
-        LOG_CHANNEL_CAPACITY, LogFrame, LogLevel, LogParser, LogStream, ParsedFrames,
-        error_summary, format_tail,
+        LOG_CHANNEL_CAPACITY, LogFrame, LogParser, LogStream, ParsedFrames, error_summary,
+        format_tail,
     },
     probe::{ControllerVersionProbe, ProbeHandle, ProbePhase, ProbeResult},
     spec::{InstanceOptions, InstanceSpec, ResolvedController},
@@ -84,15 +84,15 @@ impl Shared {
         self.parser.lock().finish()
     }
 
+    /// Buffer the frame for diagnostics and hand it to the subscribers.
+    ///
+    /// This runs inline on the supervision loop, in the same `select!` that
+    /// decides readiness, so it does exactly two cheap things. It used to emit a
+    /// tracing event as well; every consumer that fed — the JSONL archive, and
+    /// in the service the bridge that mirrors frames into tracing — is a
+    /// broadcast subscriber, so doing it here too was a second copy of every
+    /// line paid for on the hot path.
     fn publish_log_frame(&self, frame: LogFrame) {
-        let record = frame.raw.as_str();
-        match frame.level {
-            LogLevel::Trace => tracing::trace!(target: "core", "{record}"),
-            LogLevel::Debug => tracing::debug!(target: "core", "{record}"),
-            LogLevel::Info => tracing::info!(target: "core", "{record}"),
-            LogLevel::Warning => tracing::warn!(target: "core", "{record}"),
-            LogLevel::Error | LogLevel::Fatal => tracing::error!(target: "core", "{record}"),
-        }
         let mut tail = self.log_tail.lock();
         if tail.len() == LOG_TAIL_FRAMES {
             tail.pop_front();

--- a/crates/nyanpasu-core-manager/src/lib.rs
+++ b/crates/nyanpasu-core-manager/src/lib.rs
@@ -10,6 +10,7 @@ mod health;
 pub mod instance;
 pub mod kind;
 mod log;
+mod log_sink;
 pub mod manager;
 pub mod spec;
 pub mod state;

--- a/crates/nyanpasu-core-manager/src/lib.rs
+++ b/crates/nyanpasu-core-manager/src/lib.rs
@@ -22,7 +22,7 @@ pub use error::Error;
 pub use health::{HealthPolicy, probe};
 pub use instance::{Instance, InstanceBuilder};
 pub use kind::CoreKind;
-pub use log::{LogFrame, LogLevel, LogStream, LogTimestamp};
+pub use log::{LogField, LogFrame, LogLevel, LogStream, LogTimestamp};
 pub use manager::{ApplyOutcome, CoreManager, CoreManagerBuilder, DegradeReason, SwitchOutcome};
 pub use probe::{
     ControllerVersionProbe, HealthProbe, ProbeContext, ProbeFuture, ProbeHandle, ProbePhase,

--- a/crates/nyanpasu-core-manager/src/log.rs
+++ b/crates/nyanpasu-core-manager/src/log.rs
@@ -5,65 +5,26 @@
 //! ANSI when writing to a pipe. Parsing is header-only and per kind: a line whose
 //! header does not match degrades to an unformatted frame instead of being lost.
 
+use std::borrow::Borrow;
+
 use chrono::{DateTime, Duration, FixedOffset, NaiveDate, NaiveTime, TimeZone};
-use clash_api::LogField;
+
+pub use nyanpasu_core_metadata::{LogField, LogFrame, LogLevel, LogStream, LogTimestamp};
 
 use crate::kind::CoreKind;
 
 pub(crate) const LOG_CHANNEL_CAPACITY: usize = 256;
 const MAX_CONTINUATION_LINES: usize = 16;
-const MAX_LOGICAL_FRAME_BYTES: usize = 16 * 1024;
 
-/// Normalized severity. Go's `fatal` and `panic` both terminate the process, so
-/// they collapse into `Fatal`; the original spelling survives in [`LogFrame::raw`].
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize)]
-#[serde(rename_all = "lowercase")]
-pub enum LogLevel {
-    Trace,
-    Debug,
-    Info,
-    Warning,
-    Error,
-    Fatal,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
-#[serde(rename_all = "lowercase")]
-pub enum LogStream {
-    Stdout,
-    Stderr,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
-pub struct LogTimestamp {
-    /// Exactly as the core printed it.
-    pub raw: String,
-    /// Unix milliseconds, the same convention as `state::now_ms`.
-    pub unix_ms: Option<i64>,
-    /// The date or the zone offset came from the observation instant because the
-    /// core did not print one (clash premium and clash-rs).
-    pub inferred: bool,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
-pub struct LogFrame {
-    pub epoch: u64,
-    pub kind: CoreKind,
-    pub stream: LogStream,
-    pub timestamp: Option<LogTimestamp>,
-    pub level: LogLevel,
-    /// clash premium's `[Tag]` prefix (a message convention, not a field), meow's
-    /// tracing target, or clash-rs's `file:line`.
-    pub target: Option<String>,
-    pub message: String,
-    /// Filled only where field boundaries are decidable, which today means
-    /// mihomo's quoted logfmt.
-    pub fields: Vec<LogField>,
-    /// The whole logical record with ANSI removed, continuations included.
-    pub raw: String,
-    /// Continuations were dropped after hitting a size limit.
-    pub truncated: bool,
-}
+/// The caps every frame leaving this parser respects. They live here, and only
+/// here, because bounding at the source is what lets every downstream consumer —
+/// the 32-frame diagnostic tail, the JSONL archive, the ws stream — take the
+/// frame as it is. A frame that arrives anywhere else has already been cut.
+const MAX_LOG_TEXT_BYTES: usize = 16 * 1024;
+const MAX_LOG_TARGET_BYTES: usize = 2048;
+const MAX_LOG_TIMESTAMP_RAW_BYTES: usize = 256;
+const MAX_LOG_FIELDS: usize = 64;
+const MAX_LOG_FIELD_TEXT_BYTES: usize = 1024;
 
 /// At most two frames leave the parser per line: a flushed multi-line record and
 /// the line that ended it.
@@ -84,18 +45,92 @@ struct Pending {
 
 impl Pending {
     fn append(&mut self, line: &str) {
-        if self.continuations == MAX_CONTINUATION_LINES
-            || self.frame.raw.len() + 1 + line.len() > MAX_LOGICAL_FRAME_BYTES
-        {
+        if self.continuations == MAX_CONTINUATION_LINES {
             self.frame.truncated = true;
             return;
         }
-        self.frame.raw.push('\n');
-        self.frame.raw.push_str(line);
-        self.frame.message.push('\n');
-        self.frame.message.push_str(line);
-        self.continuations += 1;
+        // Never short-circuits: both texts take the same line, and they run out
+        // of budget at different points because `raw` also carries the header.
+        let cut = append_bounded(&mut self.frame.raw, line, MAX_LOG_TEXT_BYTES)
+            | append_bounded(&mut self.frame.message, line, MAX_LOG_TEXT_BYTES);
+        if cut {
+            self.frame.truncated = true;
+            // One of the two texts is now at its cap, so there is no room for a
+            // further continuation either.
+            self.continuations = MAX_CONTINUATION_LINES;
+        } else {
+            self.continuations += 1;
+        }
     }
+}
+
+/// Appends `\n` and as much of `line` as fits. `true` means something was left
+/// behind — the caller stops appending rather than growing a hole.
+///
+/// The separator comes out of the same budget as the content, and it is only
+/// written once something can follow it: a line whose first character does not
+/// fit is dropped whole rather than turned into a blank one.
+fn append_bounded(text: &mut String, line: &str, max_bytes: usize) -> bool {
+    if text.len() >= max_bytes {
+        return true;
+    }
+    // An empty continuation *is* the separator, so it always fits here.
+    if line.is_empty() {
+        text.push('\n');
+        return false;
+    }
+    let budget = max_bytes - text.len() - 1;
+    let end = char_boundary_at_or_below(line, budget.min(line.len()));
+    if end == 0 {
+        return true;
+    }
+    text.push('\n');
+    text.push_str(&line[..end]);
+    end < line.len()
+}
+
+/// Cuts `text` down to `max_bytes`. `true` means it was cut.
+fn truncate_text(text: &mut String, max_bytes: usize) -> bool {
+    if text.len() <= max_bytes {
+        return false;
+    }
+    text.truncate(char_boundary_at_or_below(text, max_bytes));
+    true
+}
+
+/// The largest index at or below `max_bytes` that does not split a character,
+/// so a cut string is still a `str` and still serializes as valid JSON.
+fn char_boundary_at_or_below(text: &str, max_bytes: usize) -> usize {
+    let mut end = max_bytes;
+    while !text.is_char_boundary(end) {
+        end -= 1;
+    }
+    end
+}
+
+/// Brings every free-text field within its cap, in place.
+///
+/// Runs exactly once per frame, before it is emitted or held. Everything
+/// downstream — the diagnostic tail, the JSONL archive, the ws stream — then
+/// consumes the frame as it stands, which is why none of them clamp any more.
+fn bound_frame(frame: &mut LogFrame) {
+    let mut cut = truncate_text(&mut frame.message, MAX_LOG_TEXT_BYTES);
+    cut |= truncate_text(&mut frame.raw, MAX_LOG_TEXT_BYTES);
+    if let Some(target) = frame.target.as_mut() {
+        cut |= truncate_text(target, MAX_LOG_TARGET_BYTES);
+    }
+    if let Some(timestamp) = frame.timestamp.as_mut() {
+        cut |= truncate_text(&mut timestamp.raw, MAX_LOG_TIMESTAMP_RAW_BYTES);
+    }
+    if frame.fields.len() > MAX_LOG_FIELDS {
+        frame.fields.truncate(MAX_LOG_FIELDS);
+        cut = true;
+    }
+    for field in &mut frame.fields {
+        cut |= truncate_text(&mut field.key, MAX_LOG_FIELD_TEXT_BYTES);
+        cut |= truncate_text(&mut field.value, MAX_LOG_FIELD_TEXT_BYTES);
+    }
+    frame.truncated |= cut;
 }
 
 /// Stateful because clash premium needs the previous timestamp to infer date
@@ -132,18 +167,20 @@ impl LogParser {
         let line = strip_ansi(line);
         if let Some(parsed) = self.parse_header(&line, observed_at) {
             let hold = parsed.level >= LogLevel::Error;
-            let frame = LogFrame {
+            let mut frame = LogFrame {
+                at: observed_at.timestamp_millis(),
                 epoch: self.epoch,
                 kind: self.kind,
                 stream,
-                timestamp: parsed.timestamp,
                 level: parsed.level,
+                timestamp: parsed.timestamp,
                 target: parsed.target,
                 message: parsed.message,
                 fields: parsed.fields,
                 raw: line,
                 truncated: false,
             };
+            bound_frame(&mut frame);
             return self.emit(stream, frame, hold);
         }
 
@@ -163,18 +200,20 @@ impl LogParser {
             (.., LogStream::Stdout) => LogLevel::Info,
             (.., LogStream::Stderr) => LogLevel::Warning,
         };
-        let frame = LogFrame {
+        let mut frame = LogFrame {
+            at: observed_at.timestamp_millis(),
             epoch: self.epoch,
             kind: self.kind,
             stream,
-            timestamp: None,
             level,
+            timestamp: None,
             target: None,
             message: line.clone(),
             fields: Vec::new(),
             raw: line,
             truncated: false,
         };
+        bound_frame(&mut frame);
         self.emit(stream, frame, error_root && stream == LogStream::Stderr)
     }
 
@@ -224,23 +263,27 @@ impl LogParser {
 
 /// The most severe recent frame, latest first within that severity. `None` when
 /// nothing above `Info` was logged.
-pub(crate) fn error_summary(frames: &[LogFrame]) -> Option<String> {
+///
+/// Generic over the borrow so the owned frames a one-shot run produces and the
+/// `Arc`-shared frames the diagnostic tail holds both go straight in.
+pub(crate) fn error_summary<T: Borrow<LogFrame>>(frames: &[T]) -> Option<String> {
     let level = frames
         .iter()
-        .map(|frame| frame.level)
+        .map(|frame| Borrow::<LogFrame>::borrow(frame).level)
         .filter(|level| *level >= LogLevel::Warning)
         .max()?;
     frames
         .iter()
         .rev()
+        .map(Borrow::<LogFrame>::borrow)
         .find(|frame| frame.level == level)
         .map(|frame| frame.message.clone())
 }
 
-pub(crate) fn format_tail(frames: &[LogFrame]) -> String {
+pub(crate) fn format_tail<T: Borrow<LogFrame>>(frames: &[T]) -> String {
     frames
         .iter()
-        .map(|frame| frame.raw.as_str())
+        .map(|frame| Borrow::<LogFrame>::borrow(frame).raw.as_str())
         .collect::<Vec<_>>()
         .join("\n")
 }
@@ -650,7 +693,9 @@ mod tests {
         let mut frames = collect(parser.push_at(stream, line.to_owned(), observed(at)));
         frames.extend(parser.finish().into_iter().flatten());
         assert_eq!(frames.len(), 1, "expected exactly one frame for {line:?}");
-        frames.remove(0)
+        let frame = frames.remove(0);
+        assert_eq!(frame.at, observed(at).timestamp_millis());
+        frame
     }
 
     #[test]
@@ -1021,18 +1066,27 @@ mod tests {
         assert_eq!(error_summary(&frames).as_deref(), Some("stdout second"));
     }
 
+    /// A held record also fixes its clock: `at` is the instant the root line was
+    /// observed, not the instant the last continuation arrived.
     #[test]
     fn aggregates_multi_line_records_within_one_stream() {
         let mut parser = LogParser::new(CoreKind::ClashRust, 1);
-        let at = observed("2026-07-29T00:17:27+08:00");
+        let root_at = observed("2026-07-29T00:17:27+08:00");
+        let continuation_at = observed("2026-07-29T00:17:29+08:00");
+        let root =
+            "Error: invalid config: couldn't not parse config content mixed-port: not-a-port";
+        assert!(collect(parser.push_at(LogStream::Stderr, root.to_owned(), root_at)).is_empty());
         for line in [
-            "Error: invalid config: couldn't not parse config content mixed-port: not-a-port",
             "proxies: [[[",
             ": did not find expected node content at line 3 column 1, while parsing a flow node",
         ] {
-            assert!(collect(parser.push_at(LogStream::Stderr, line.to_owned(), at)).is_empty());
+            assert!(
+                collect(parser.push_at(LogStream::Stderr, line.to_owned(), continuation_at))
+                    .is_empty()
+            );
         }
         let frame = collect(parser.finish()).remove(0);
+        assert_eq!(frame.at, root_at.timestamp_millis());
         assert_eq!(frame.level, LogLevel::Error);
         assert!(!frame.truncated);
         assert_eq!(
@@ -1077,6 +1131,154 @@ mod tests {
         assert!(frame.message.starts_with("boom\nstack frame 0\n"));
         assert!(frame.message.contains("stack frame 15"));
         assert!(!frame.message.contains("stack frame 16"));
+    }
+
+    /// A single enormous line is bounded here rather than at each consumer, and
+    /// what the diagnostic paths read is the already-bounded text. The two
+    /// instantiations of the borrow — owned frames and the `Arc`s the tail holds
+    /// — are both exercised.
+    #[test]
+    fn an_oversized_root_is_bounded_for_every_diagnostic_consumer() {
+        let frame = parse_one(
+            CoreKind::Meow,
+            LogStream::Stderr,
+            &format!("warning: {}", "x".repeat(MAX_LOG_TEXT_BYTES * 2)),
+            "2026-07-29T00:17:27+08:00",
+        );
+        assert_eq!(frame.message.len(), MAX_LOG_TEXT_BYTES);
+        assert_eq!(frame.raw.len(), MAX_LOG_TEXT_BYTES);
+        assert!(frame.truncated);
+
+        assert_eq!(
+            error_summary(std::slice::from_ref(&frame))
+                .expect("a warning is above Info")
+                .len(),
+            MAX_LOG_TEXT_BYTES
+        );
+        assert_eq!(
+            format_tail(&[std::sync::Arc::new(frame)]).len(),
+            MAX_LOG_TEXT_BYTES
+        );
+    }
+
+    /// Continuations are appended up to the budget rather than concatenated and
+    /// then cut, and the prefix that survives never splits a character.
+    #[test]
+    fn a_continuation_is_appended_only_as_far_as_it_fits() {
+        let mut parser = LogParser::new(CoreKind::ClashRust, 1);
+        let root_at = observed("2026-07-29T00:17:27+08:00");
+        assert!(
+            collect(parser.push_at(LogStream::Stderr, "Error: root".to_owned(), root_at))
+                .is_empty()
+        );
+        // Three bytes per char, so the budget never lands on a boundary and the
+        // walk-back actually runs.
+        let continuation = "€".repeat(MAX_LOG_TEXT_BYTES);
+        assert!(
+            collect(parser.push_at(
+                LogStream::Stderr,
+                continuation.clone(),
+                observed("2026-07-29T00:17:28+08:00"),
+            ))
+            .is_empty()
+        );
+
+        let frame = collect(parser.finish()).remove(0);
+        let appended = frame
+            .message
+            .strip_prefix("Error: root\n")
+            .expect("the root and its separator survive");
+        assert!(continuation.starts_with(appended));
+        assert!(
+            frame.message.len() < MAX_LOG_TEXT_BYTES,
+            "the boundary walk did not run"
+        );
+        assert!(frame.raw.len() < MAX_LOG_TEXT_BYTES);
+        assert!(frame.truncated);
+        assert_eq!(frame.at, root_at.timestamp_millis());
+    }
+
+    /// The append budget at its edges. `raw` and `message` run out at different
+    /// points — `raw` also carries the header — so these cases are reached in
+    /// production by one of the two while the other still has room.
+    #[test]
+    fn the_append_budget_never_writes_a_separator_it_cannot_follow() {
+        let filled = |shortfall: usize| "x".repeat(MAX_LOG_TEXT_BYTES - shortfall);
+
+        // Already at the cap, or with room for the separator alone.
+        for shortfall in [0, 1] {
+            let mut text = filled(shortfall);
+            assert!(append_bounded(&mut text, "y", MAX_LOG_TEXT_BYTES));
+            assert_eq!(text, filled(shortfall), "shortfall = {shortfall}");
+        }
+
+        // Room for the separator and two bytes, but the next character is three.
+        let mut split = filled(3);
+        assert!(append_bounded(&mut split, "€", MAX_LOG_TEXT_BYTES));
+        assert_eq!(split, filled(3));
+
+        // A partial line, and a whole one that exactly exhausts the budget.
+        let mut partial = filled(2);
+        assert!(append_bounded(&mut partial, "abc", MAX_LOG_TEXT_BYTES));
+        assert!(partial.ends_with("\na"));
+        assert_eq!(partial.len(), MAX_LOG_TEXT_BYTES);
+
+        let mut exact = filled(4);
+        assert!(!append_bounded(&mut exact, "abc", MAX_LOG_TEXT_BYTES));
+        assert!(exact.ends_with("\nabc"));
+        assert_eq!(exact.len(), MAX_LOG_TEXT_BYTES);
+
+        // An empty continuation is fully represented by the separator itself.
+        let mut blank = filled(1);
+        assert!(!append_bounded(&mut blank, "", MAX_LOG_TEXT_BYTES));
+        assert_eq!(blank.len(), MAX_LOG_TEXT_BYTES);
+        assert!(blank.ends_with('\n'));
+    }
+
+    #[test]
+    fn oversized_metadata_and_fields_are_bounded_at_the_parser() {
+        let huge = "x".repeat(MAX_LOG_FIELD_TEXT_BYTES * 2);
+        let mut line = format!(
+            r#"time="{}" level=info msg="metadata" {}="{}""#,
+            "z".repeat(MAX_LOG_TIMESTAMP_RAW_BYTES * 2),
+            huge,
+            huge,
+        );
+        for index in 0..MAX_LOG_FIELDS {
+            line.push_str(&format!(" field{index}=value"));
+        }
+        let structured = parse_one(
+            CoreKind::Mihomo,
+            LogStream::Stdout,
+            &line,
+            "2026-07-29T00:17:27+08:00",
+        );
+        assert_eq!(
+            structured.timestamp.as_ref().unwrap().raw.len(),
+            MAX_LOG_TIMESTAMP_RAW_BYTES
+        );
+        assert_eq!(structured.fields.len(), MAX_LOG_FIELDS);
+        assert_eq!(structured.fields[0].key.len(), MAX_LOG_FIELD_TEXT_BYTES);
+        assert_eq!(structured.fields[0].value.len(), MAX_LOG_FIELD_TEXT_BYTES);
+        assert!(structured.truncated);
+
+        let targeted = parse_one(
+            CoreKind::Meow,
+            LogStream::Stdout,
+            &format!(
+                "{} INFO {}: message",
+                "z".repeat(MAX_LOG_TIMESTAMP_RAW_BYTES * 2),
+                "t".repeat(MAX_LOG_TARGET_BYTES * 2),
+            ),
+            "2026-07-29T00:17:27+08:00",
+        );
+        assert_eq!(targeted.target.unwrap().len(), MAX_LOG_TARGET_BYTES);
+        assert_eq!(
+            targeted.timestamp.as_ref().unwrap().raw.len(),
+            MAX_LOG_TIMESTAMP_RAW_BYTES
+        );
+        assert_eq!(targeted.message, "message");
+        assert!(targeted.truncated);
     }
 
     #[test]

--- a/crates/nyanpasu-core-manager/src/log.rs
+++ b/crates/nyanpasu-core-manager/src/log.rs
@@ -16,7 +16,8 @@ const MAX_LOGICAL_FRAME_BYTES: usize = 16 * 1024;
 
 /// Normalized severity. Go's `fatal` and `panic` both terminate the process, so
 /// they collapse into `Fatal`; the original spelling survives in [`LogFrame::raw`].
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
 pub enum LogLevel {
     Trace,
     Debug,
@@ -26,13 +27,14 @@ pub enum LogLevel {
     Fatal,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
 pub enum LogStream {
     Stdout,
     Stderr,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 pub struct LogTimestamp {
     /// Exactly as the core printed it.
     pub raw: String,
@@ -43,7 +45,7 @@ pub struct LogTimestamp {
     pub inferred: bool,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 pub struct LogFrame {
     pub epoch: u64,
     pub kind: CoreKind,

--- a/crates/nyanpasu-core-manager/src/log_sink.rs
+++ b/crates/nyanpasu-core-manager/src/log_sink.rs
@@ -21,6 +21,8 @@
 //!   `RuntimeConfigStore`, which pays the full stage/fsync/replace price because
 //!   it holds authoritative configuration.
 
+use std::borrow::Cow;
+
 use camino::{Utf8Path, Utf8PathBuf};
 use clash_api::LogField;
 use serde::Serialize;
@@ -36,7 +38,7 @@ use tokio_util::sync::CancellationToken;
 use crate::{
     error::Error,
     kind::CoreKind,
-    log::{LogFrame, LogLevel, LogStream, LogTimestamp},
+    log::{LogFrame, LogLevel, LogStream},
     // `crate::runtime_store`, not `crate::config::runtime_store`: `lib.rs:19`
     // re-exports it and `manager/mod.rs:26` already spells it this way.
     runtime_store::validate_directory_metadata,
@@ -57,6 +59,11 @@ const FILE_SUFFIX: &str = ".jsonl";
 /// is what actually makes "a rotated file overshoots by at most one record" a
 /// statement with a number behind it.
 const MAX_TEXT_BYTES: usize = 16 * 1024;
+const MAX_TARGET_BYTES: usize = 2048;
+const MAX_TS_RAW_BYTES: usize = 256;
+const MAX_FIELDS: usize = 64;
+const MAX_FIELD_TEXT_BYTES: usize = 1024;
+const MAX_BATCH_RECORDS: usize = 256;
 
 /// Rotation knobs, mirrored from `ManagerOptions` so the writer does not carry
 /// the whole option bag.
@@ -64,6 +71,23 @@ const MAX_TEXT_BYTES: usize = 16 * 1024;
 pub(crate) struct SinkOptions {
     pub max_bytes: u64,
     pub max_files: usize,
+}
+
+pub(crate) struct SinkHandle {
+    cancel: CancellationToken,
+    task: tokio::task::JoinHandle<()>,
+}
+
+impl SinkHandle {
+    pub(crate) async fn shutdown(self) {
+        self.cancel.cancel();
+        if tokio::time::timeout(std::time::Duration::from_secs(5), self.task)
+            .await
+            .is_err()
+        {
+            tracing::warn!("timed out waiting for the core log sink to shut down");
+        }
+    }
 }
 
 /// A `"log"` line. The fields are borrowed from the frame so the two capped
@@ -77,13 +101,20 @@ struct LogRecord<'a> {
     kind: CoreKind,
     stream: LogStream,
     level: LogLevel,
-    timestamp: Option<&'a LogTimestamp>,
+    timestamp: Option<RecordTimestamp<'a>>,
     target: Option<&'a str>,
     message: &'a str,
-    fields: &'a [LogField],
+    fields: Cow<'a, [LogField]>,
     raw: &'a str,
     /// The frame's own flag, OR-ed with whichever cap this record hit.
     truncated: bool,
+}
+
+#[derive(Serialize)]
+struct RecordTimestamp<'a> {
+    raw: &'a str,
+    unix_ms: Option<i64>,
+    inferred: bool,
 }
 
 /// A `"gap"` line: the writer fell behind and the broadcast dropped `dropped`
@@ -97,8 +128,30 @@ struct GapRecord {
 
 impl<'a> LogRecord<'a> {
     fn new(frame: &'a LogFrame, at: i64) -> Self {
-        let (message, message_cut) = clamp(&frame.message);
-        let (raw, raw_cut) = clamp(&frame.raw);
+        let (message, message_cut) = clamp(&frame.message, MAX_TEXT_BYTES);
+        let (raw, raw_cut) = clamp(&frame.raw, MAX_TEXT_BYTES);
+        let (target, target_cut) = match frame.target.as_deref() {
+            Some(target) => {
+                let (target, cut) = clamp(target, MAX_TARGET_BYTES);
+                (Some(target), cut)
+            }
+            None => (None, false),
+        };
+        let (timestamp, timestamp_cut) = match frame.timestamp.as_ref() {
+            Some(timestamp) => {
+                let (raw, cut) = clamp(&timestamp.raw, MAX_TS_RAW_BYTES);
+                (
+                    Some(RecordTimestamp {
+                        raw,
+                        unix_ms: timestamp.unix_ms,
+                        inferred: timestamp.inferred,
+                    }),
+                    cut,
+                )
+            }
+            None => (None, false),
+        };
+        let (fields, fields_cut) = project_fields(&frame.fields);
         Self {
             t: "log",
             at,
@@ -106,12 +159,17 @@ impl<'a> LogRecord<'a> {
             kind: frame.kind,
             stream: frame.stream,
             level: frame.level,
-            timestamp: frame.timestamp.as_ref(),
-            target: frame.target.as_deref(),
+            timestamp,
+            target,
             message,
-            fields: &frame.fields,
+            fields,
             raw,
-            truncated: frame.truncated || message_cut || raw_cut,
+            truncated: frame.truncated
+                || message_cut
+                || raw_cut
+                || target_cut
+                || timestamp_cut
+                || fields_cut,
         }
     }
 }
@@ -128,15 +186,35 @@ impl GapRecord {
 
 /// Cuts at the last char boundary at or below the limit, so the result is still
 /// a `str` and still serializes as valid JSON.
-fn clamp(text: &str) -> (&str, bool) {
-    if text.len() <= MAX_TEXT_BYTES {
+fn clamp(text: &str, max_bytes: usize) -> (&str, bool) {
+    if text.len() <= max_bytes {
         return (text, false);
     }
-    let mut end = MAX_TEXT_BYTES;
+    let mut end = max_bytes;
     while !text.is_char_boundary(end) {
         end -= 1;
     }
     (&text[..end], true)
+}
+
+fn project_fields(fields: &[LogField]) -> (Cow<'_, [LogField]>, bool) {
+    let kept = &fields[..fields.len().min(MAX_FIELDS)];
+    let exceeds_budget = fields.len() > MAX_FIELDS
+        || kept.iter().any(|field| {
+            field.key.len() > MAX_FIELD_TEXT_BYTES || field.value.len() > MAX_FIELD_TEXT_BYTES
+        });
+    if !exceeds_budget {
+        return (Cow::Borrowed(fields), false);
+    }
+
+    let fields = kept
+        .iter()
+        .map(|field| LogField {
+            key: clamp(&field.key, MAX_FIELD_TEXT_BYTES).0.to_owned(),
+            value: clamp(&field.value, MAX_FIELD_TEXT_BYTES).0.to_owned(),
+        })
+        .collect();
+    (Cow::Owned(fields), true)
 }
 
 /// Creates and hardens `{parent}/logs`, returning its path.
@@ -175,15 +253,19 @@ pub(crate) async fn prepare_dir(parent: &Utf8Path) -> Result<Utf8PathBuf, Error>
 /// Opening before spawning is deliberate: a directory that cannot be written is
 /// a `CoreManager::new` failure, not a task that dies quietly three seconds
 /// later.
+///
+/// Dropping the manager without calling `shutdown()` abandons at most the final
+/// batch. This is diagnostic data and best-effort by design; `shutdown()` is
+/// the graceful path.
 pub(crate) async fn spawn(
     dir: Utf8PathBuf,
     options: SinkOptions,
     logs: Receiver<LogFrame>,
     cancel: CancellationToken,
-) -> Result<(), Error> {
+) -> Result<SinkHandle, Error> {
     let writer = Writer::open(dir, options).await?;
-    tokio::spawn(run(writer, logs, cancel));
-    Ok(())
+    let task = tokio::spawn(run(writer, logs, cancel.clone()));
+    Ok(SinkHandle { cancel, task })
 }
 
 /// Drains the broadcast in batches until the token is cancelled or the last
@@ -197,9 +279,12 @@ async fn run(mut writer: Writer, mut logs: Receiver<LogFrame>, cancel: Cancellat
         batch.clear();
         let first = tokio::select! {
             _ = cancel.cancelled() => {
-                drain(&mut logs, &mut batch);
+                let closed = drain(&mut logs, &mut batch);
                 writer.write(&batch).await;
-                break;
+                if closed || batch.len() < MAX_BATCH_RECORDS {
+                    break;
+                }
+                continue;
             }
             received = logs.recv() => received,
         };
@@ -232,7 +317,7 @@ enum Entry {
 /// Appends everything already buffered. `true` means the channel is closed and
 /// the caller must stop after writing what it has.
 fn drain(logs: &mut Receiver<LogFrame>, batch: &mut Vec<Entry>) -> bool {
-    loop {
+    while batch.len() < MAX_BATCH_RECORDS {
         match logs.try_recv() {
             Ok(frame) => batch.push(Entry::Log(frame)),
             Err(TryRecvError::Lagged(dropped)) => batch.push(Entry::Gap(dropped)),
@@ -240,6 +325,7 @@ fn drain(logs: &mut Receiver<LogFrame>, batch: &mut Vec<Entry>) -> bool {
             Err(TryRecvError::Closed) => return true,
         }
     }
+    false
 }
 
 struct Writer {
@@ -257,18 +343,15 @@ impl Writer {
         // record. One file also means one run, which is a useful boundary when
         // somebody hands you a log directory.
         let seq = next_seq(&dir).await?;
+        prune_dir(&dir, options.max_files - 1).await;
         let file = create(&dir, seq).await?;
-        let writer = Self {
+        Ok(Self {
             dir,
             options,
             file,
             written: 0,
             seq,
-        };
-        // A previous run may have died holding more files than the retention
-        // limit allows.
-        writer.prune().await;
-        Ok(writer)
+        })
     }
 
     /// Serializes and appends one batch, rotating whenever the active file has
@@ -332,12 +415,12 @@ impl Writer {
 
     async fn rotate(&mut self) {
         let seq = self.seq + 1;
+        prune_dir(&self.dir, self.options.max_files - 1).await;
         match create(&self.dir, seq).await {
             Ok(file) => {
                 self.file = file;
                 self.seq = seq;
                 self.written = 0;
-                self.prune().await;
             }
             // Keep writing into the oversized file rather than losing the
             // stream; the next record's pre-check retries.
@@ -346,23 +429,23 @@ impl Writer {
             }
         }
     }
+}
 
-    /// Deletes everything past the newest `max_files`, the active file included
-    /// in the count. A delete that fails — a file held open by an editor, which
-    /// Windows refuses to unlink — is logged and retried on the next rollover.
-    async fn prune(&self) {
-        let existing = match read_seqs(&self.dir).await {
-            Ok(seqs) => seqs,
-            Err(error) => {
-                tracing::warn!("failed to list the core log directory: {error}");
-                return;
-            }
-        };
-        for seq in prune_targets(existing, self.options.max_files) {
-            let path = self.dir.join(file_name(seq));
-            if let Err(error) = tokio::fs::remove_file(&path).await {
-                tracing::warn!("failed to prune the rotated core log file {path}: {error}");
-            }
+/// Deletes everything past the newest `keep` files. A delete that fails — a
+/// file held open by an editor, which Windows refuses to unlink — is logged and
+/// retried on the next rollover.
+async fn prune_dir(dir: &Utf8Path, keep: usize) {
+    let existing = match read_seqs(dir).await {
+        Ok(seqs) => seqs,
+        Err(error) => {
+            tracing::warn!("failed to list the core log directory: {error}");
+            return;
+        }
+    };
+    for seq in prune_targets(existing, keep) {
+        let path = dir.join(file_name(seq));
+        if let Err(error) = tokio::fs::remove_file(&path).await {
+            tracing::warn!("failed to prune the rotated core log file {path}: {error}");
         }
     }
 }
@@ -422,7 +505,7 @@ fn prune_targets(mut seqs: Vec<u64>, max_files: usize) -> Vec<u64> {
 mod tests {
     use super::*;
 
-    use crate::kind::CoreKind;
+    use crate::{kind::CoreKind, log::LogTimestamp};
 
     fn temp_dir() -> (tempfile::TempDir, Utf8PathBuf) {
         let guard = tempfile::tempdir().unwrap();
@@ -573,10 +656,42 @@ mod tests {
         // Three bytes per char, so the limit never lands on a boundary and the
         // walk-back actually runs.
         let text = "€".repeat(MAX_TEXT_BYTES);
-        let (cut, truncated) = clamp(&text);
+        let (cut, truncated) = clamp(&text, MAX_TEXT_BYTES);
         assert!(truncated);
         assert!(cut.len() < MAX_TEXT_BYTES, "the boundary walk did not run");
         assert!(text.starts_with(cut));
+    }
+
+    #[test]
+    fn oversized_metadata_is_capped_and_flagged_truncated() {
+        let huge = "x".repeat(MAX_FIELD_TEXT_BYTES * 2);
+        let mut oversized = frame("oversized metadata");
+        oversized.target = Some("t".repeat(MAX_TARGET_BYTES * 2));
+        oversized.timestamp.as_mut().unwrap().raw = "z".repeat(MAX_TS_RAW_BYTES * 2);
+        oversized.fields = (0..=MAX_FIELDS)
+            .map(|index| LogField {
+                key: format!("{index}{huge}"),
+                value: huge.clone(),
+            })
+            .collect();
+
+        let value = record(&oversized);
+
+        assert_eq!(value["target"].as_str().unwrap().len(), MAX_TARGET_BYTES);
+        assert_eq!(
+            value["timestamp"]["raw"].as_str().unwrap().len(),
+            MAX_TS_RAW_BYTES
+        );
+        assert_eq!(value["fields"].as_array().unwrap().len(), MAX_FIELDS);
+        assert_eq!(
+            value["fields"][0]["key"].as_str().unwrap().len(),
+            MAX_FIELD_TEXT_BYTES
+        );
+        assert_eq!(
+            value["fields"][0]["value"].as_str().unwrap().len(),
+            MAX_FIELD_TEXT_BYTES
+        );
+        assert_eq!(value["truncated"], true);
     }
 
     #[test]
@@ -727,6 +842,50 @@ mod tests {
         assert_eq!(records[0]["dropped"], 3);
         assert_eq!(records[1]["message"], "line 3");
         assert_eq!(records[2]["message"], "line 4");
+    }
+
+    #[tokio::test]
+    async fn bounded_batches_preserve_every_record_until_the_channel_closes() {
+        let (_guard, dir) = temp_dir();
+        let (log_tx, logs) = tokio::sync::broadcast::channel(512);
+        for index in 0..300 {
+            log_tx.send(frame(&format!("line {index}"))).unwrap();
+        }
+        drop(log_tx);
+
+        let writer = Writer::open(dir.clone(), options(1024 * 1024, 5))
+            .await
+            .unwrap();
+        run(writer, logs, CancellationToken::new()).await;
+
+        let records = lines(&dir.join(file_name(1)));
+        assert_eq!(records.len(), 300);
+        assert!(records.iter().all(|record| record["t"] == "log"));
+    }
+
+    #[tokio::test]
+    async fn graceful_sink_shutdown_drains_every_buffered_frame() {
+        let (_guard, dir) = temp_dir();
+        let (log_tx, logs) = tokio::sync::broadcast::channel(16);
+        let handle = spawn(
+            dir.clone(),
+            options(1024 * 1024, 5),
+            logs,
+            CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+        for index in 0..8 {
+            log_tx.send(frame(&format!("line {index}"))).unwrap();
+        }
+
+        handle.shutdown().await;
+
+        let records = lines(&dir.join(file_name(1)));
+        assert_eq!(records.len(), 8);
+        for (index, record) in records.iter().enumerate() {
+            assert_eq!(record["message"], format!("line {index}"));
+        }
     }
 
     /// The subdirectory has to be hardened explicitly: the parent's DACL is

--- a/crates/nyanpasu-core-manager/src/log_sink.rs
+++ b/crates/nyanpasu-core-manager/src/log_sink.rs
@@ -1,0 +1,753 @@
+//! Durable JSONL archive of the manager's core-log stream.
+//!
+//! One rolling file per writer run in `{runtime_dir}/logs/`, rotated by size and
+//! retained by count. The writer is an ordinary [`broadcast`] subscriber, so it
+//! never touches the supervision loop that produces the frames
+//! (`instance.rs`'s `publish_log_frame`, which runs inline on that loop): a slow
+//! disk costs this task its own backlog and nothing else.
+//!
+//! The on-disk contract, in full:
+//!
+//! - append-only, line-delimited JSON, one object per line, never rewritten and
+//!   never renamed;
+//! - every record carries `t` (`"log"` or `"gap"`) and `at`, the writer-observed
+//!   unix-millisecond instant. `at` is the only sortable clock: a frame whose
+//!   header did not parse has no timestamp at all, and clash premium's and
+//!   clash-rs's are inferred;
+//! - a crash can only truncate the **last** line, because each batch is one
+//!   `write_all`. A reader splits on `\n`, parses each line, and ignores a
+//!   trailing line that does not parse;
+//! - there is no `fsync`. This is diagnostic data, deliberately unlike
+//!   `RuntimeConfigStore`, which pays the full stage/fsync/replace price because
+//!   it holds authoritative configuration.
+
+use camino::{Utf8Path, Utf8PathBuf};
+use clash_api::LogField;
+use serde::Serialize;
+use tokio::{
+    io::AsyncWriteExt,
+    sync::broadcast::{
+        Receiver,
+        error::{RecvError, TryRecvError},
+    },
+};
+use tokio_util::sync::CancellationToken;
+
+use crate::{
+    error::Error,
+    kind::CoreKind,
+    log::{LogFrame, LogLevel, LogStream, LogTimestamp},
+    // `crate::runtime_store`, not `crate::config::runtime_store`: `lib.rs:19`
+    // re-exports it and `manager/mod.rs:26` already spells it this way.
+    runtime_store::validate_directory_metadata,
+    state::now_ms,
+};
+
+/// Subdirectory of the manager's runtime directory. Deliberately not a sibling
+/// of the epoch artifacts: `cleanup_epoch` and `artifact_epochs` scan the
+/// runtime directory by filename prefix, and a log file's useful life starts
+/// exactly where an epoch artifact's ends.
+const LOG_DIR_NAME: &str = "logs";
+
+const FILE_PREFIX: &str = "core-";
+const FILE_SUFFIX: &str = ".jsonl";
+
+/// Per-record cap on the two free-text fields. The parser's 16 KiB budget bounds
+/// only continuation growth, so a single enormous line still arrives whole; this
+/// is what actually makes "a rotated file overshoots by at most one record" a
+/// statement with a number behind it.
+const MAX_TEXT_BYTES: usize = 16 * 1024;
+
+/// Rotation knobs, mirrored from `ManagerOptions` so the writer does not carry
+/// the whole option bag.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct SinkOptions {
+    pub max_bytes: u64,
+    pub max_files: usize,
+}
+
+/// A `"log"` line. The fields are borrowed from the frame so the two capped
+/// texts can be sliced instead of cloned; every key is always present, including
+/// the nulls, so a reader never has to branch on the schema.
+#[derive(Serialize)]
+struct LogRecord<'a> {
+    t: &'static str,
+    at: i64,
+    epoch: u64,
+    kind: CoreKind,
+    stream: LogStream,
+    level: LogLevel,
+    timestamp: Option<&'a LogTimestamp>,
+    target: Option<&'a str>,
+    message: &'a str,
+    fields: &'a [LogField],
+    raw: &'a str,
+    /// The frame's own flag, OR-ed with whichever cap this record hit.
+    truncated: bool,
+}
+
+/// A `"gap"` line: the writer fell behind and the broadcast dropped `dropped`
+/// frames on its behalf. Writing it turns a silent hole into a visible one.
+#[derive(Serialize)]
+struct GapRecord {
+    t: &'static str,
+    at: i64,
+    dropped: u64,
+}
+
+impl<'a> LogRecord<'a> {
+    fn new(frame: &'a LogFrame, at: i64) -> Self {
+        let (message, message_cut) = clamp(&frame.message);
+        let (raw, raw_cut) = clamp(&frame.raw);
+        Self {
+            t: "log",
+            at,
+            epoch: frame.epoch,
+            kind: frame.kind,
+            stream: frame.stream,
+            level: frame.level,
+            timestamp: frame.timestamp.as_ref(),
+            target: frame.target.as_deref(),
+            message,
+            fields: &frame.fields,
+            raw,
+            truncated: frame.truncated || message_cut || raw_cut,
+        }
+    }
+}
+
+impl GapRecord {
+    fn new(dropped: u64, at: i64) -> Self {
+        Self {
+            t: "gap",
+            at,
+            dropped,
+        }
+    }
+}
+
+/// Cuts at the last char boundary at or below the limit, so the result is still
+/// a `str` and still serializes as valid JSON.
+fn clamp(text: &str) -> (&str, bool) {
+    if text.len() <= MAX_TEXT_BYTES {
+        return (text, false);
+    }
+    let mut end = MAX_TEXT_BYTES;
+    while !text.is_char_boundary(end) {
+        end -= 1;
+    }
+    (&text[..end], true)
+}
+
+/// Creates and hardens `{parent}/logs`, returning its path.
+///
+/// The DACL is applied here rather than inherited: the parent grants
+/// `OICI` inheritance, but an inherited descriptor does not carry
+/// `SE_DACL_PROTECTED`, which is exactly what `verify_windows_directory_acl`
+/// requires. A directory this fails on is a construction failure, the same class
+/// as a runtime directory that cannot be hardened.
+pub(crate) async fn prepare_dir(parent: &Utf8Path) -> Result<Utf8PathBuf, Error> {
+    let dir = parent.join(LOG_DIR_NAME);
+    match tokio::fs::symlink_metadata(&dir).await {
+        Ok(metadata) => validate_directory_metadata(&dir, &metadata)?,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            tokio::fs::create_dir_all(&dir).await?;
+        }
+        Err(error) => return Err(error.into()),
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        tokio::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700)).await?;
+    }
+    #[cfg(windows)]
+    {
+        nyanpasu_utils::io::atomic_fs::harden_windows_directory_acl(&dir)?;
+        nyanpasu_utils::io::atomic_fs::verify_windows_directory_acl(&dir)?;
+    }
+
+    Ok(dir)
+}
+
+/// Opens the first file and hands the writer to a background task.
+///
+/// Opening before spawning is deliberate: a directory that cannot be written is
+/// a `CoreManager::new` failure, not a task that dies quietly three seconds
+/// later.
+pub(crate) async fn spawn(
+    dir: Utf8PathBuf,
+    options: SinkOptions,
+    logs: Receiver<LogFrame>,
+    cancel: CancellationToken,
+) -> Result<(), Error> {
+    let writer = Writer::open(dir, options).await?;
+    tokio::spawn(run(writer, logs, cancel));
+    Ok(())
+}
+
+/// Drains the broadcast in batches until the token is cancelled or the last
+/// sender is gone. One `recv().await` for the first frame, then `try_recv()`
+/// until empty: a start-up burst costs one write instead of one per line.
+async fn run(mut writer: Writer, mut logs: Receiver<LogFrame>, cancel: CancellationToken) {
+    let mut batch = Vec::new();
+    loop {
+        // Cleared before the select, never after: the cancellation arm writes
+        // this same buffer, and a stale batch there would be written twice.
+        batch.clear();
+        let first = tokio::select! {
+            _ = cancel.cancelled() => {
+                drain(&mut logs, &mut batch);
+                writer.write(&batch).await;
+                break;
+            }
+            received = logs.recv() => received,
+        };
+        let closed = match first {
+            Ok(frame) => {
+                batch.push(Entry::Log(frame));
+                false
+            }
+            Err(RecvError::Lagged(dropped)) => {
+                batch.push(Entry::Gap(dropped));
+                false
+            }
+            Err(RecvError::Closed) => true,
+        };
+        // Short-circuits deliberately: `Closed` from `recv` already means the
+        // ring is empty, so there is nothing left for `drain` to find.
+        let closed = closed || drain(&mut logs, &mut batch);
+        writer.write(&batch).await;
+        if closed {
+            break;
+        }
+    }
+}
+
+enum Entry {
+    Log(LogFrame),
+    Gap(u64),
+}
+
+/// Appends everything already buffered. `true` means the channel is closed and
+/// the caller must stop after writing what it has.
+fn drain(logs: &mut Receiver<LogFrame>, batch: &mut Vec<Entry>) -> bool {
+    loop {
+        match logs.try_recv() {
+            Ok(frame) => batch.push(Entry::Log(frame)),
+            Err(TryRecvError::Lagged(dropped)) => batch.push(Entry::Gap(dropped)),
+            Err(TryRecvError::Empty) => return false,
+            Err(TryRecvError::Closed) => return true,
+        }
+    }
+}
+
+struct Writer {
+    dir: Utf8PathBuf,
+    options: SinkOptions,
+    file: tokio::fs::File,
+    written: u64,
+    seq: u64,
+}
+
+impl Writer {
+    async fn open(dir: Utf8PathBuf, options: SinkOptions) -> Result<Self, Error> {
+        // A new file per run, never an append: a crash can leave the previous
+        // file's last line half-written, and appending would glue it to a fresh
+        // record. One file also means one run, which is a useful boundary when
+        // somebody hands you a log directory.
+        let seq = next_seq(&dir).await?;
+        let file = create(&dir, seq).await?;
+        let writer = Self {
+            dir,
+            options,
+            file,
+            written: 0,
+            seq,
+        };
+        // A previous run may have died holding more files than the retention
+        // limit allows.
+        writer.prune().await;
+        Ok(writer)
+    }
+
+    /// Serializes and appends one batch, rotating whenever the active file has
+    /// already crossed the limit. The check runs per record, not per batch, so
+    /// a burst that arrives as one batch still cannot produce a file more than
+    /// one record past `max_bytes` — a record being bounded by MAX_TEXT_BYTES
+    /// on each of its two free-text fields. Errors are logged and swallowed:
+    /// losing diagnostic output must never take down a manager that is
+    /// otherwise healthy.
+    async fn write(&mut self, batch: &[Entry]) {
+        if batch.is_empty() {
+            return;
+        }
+        let at = now_ms();
+        let mut buffer = Vec::new();
+        for entry in batch {
+            // Rotate before the record that would land past the limit,
+            // counting both what is on disk and what is still buffered for the
+            // active file.
+            if self.written + buffer.len() as u64 >= self.options.max_bytes {
+                self.flush_pending(&mut buffer).await;
+                self.rotate().await;
+            }
+            let mark = buffer.len();
+            let result = match entry {
+                Entry::Log(frame) => serde_json::to_writer(&mut buffer, &LogRecord::new(frame, at)),
+                Entry::Gap(dropped) => {
+                    serde_json::to_writer(&mut buffer, &GapRecord::new(*dropped, at))
+                }
+            };
+            if let Err(error) = result {
+                buffer.truncate(mark);
+                tracing::error!("failed to serialize a core log record: {error}");
+                continue;
+            }
+            buffer.push(b'\n');
+        }
+        self.flush_pending(&mut buffer).await;
+    }
+
+    /// Appends whatever is buffered to the active file and clears the buffer.
+    /// On failure the pending records are dropped (logged), matching the
+    /// policy that disk trouble never backs up into the manager.
+    async fn flush_pending(&mut self, buffer: &mut Vec<u8>) {
+        if buffer.is_empty() {
+            return;
+        }
+        if let Err(error) = self.file.write_all(buffer).await {
+            tracing::error!("failed to write core log records: {error}");
+            buffer.clear();
+            return;
+        }
+        // tokio's File buffers, so without this the bytes are not on their way
+        // to the OS and the file is not tailable.
+        if let Err(error) = self.file.flush().await {
+            tracing::error!("failed to flush core log records: {error}");
+        }
+        self.written += buffer.len() as u64;
+        buffer.clear();
+    }
+
+    async fn rotate(&mut self) {
+        let seq = self.seq + 1;
+        match create(&self.dir, seq).await {
+            Ok(file) => {
+                self.file = file;
+                self.seq = seq;
+                self.written = 0;
+                self.prune().await;
+            }
+            // Keep writing into the oversized file rather than losing the
+            // stream; the next record's pre-check retries.
+            Err(error) => {
+                tracing::error!("failed to roll over the core log file: {error}");
+            }
+        }
+    }
+
+    /// Deletes everything past the newest `max_files`, the active file included
+    /// in the count. A delete that fails — a file held open by an editor, which
+    /// Windows refuses to unlink — is logged and retried on the next rollover.
+    async fn prune(&self) {
+        let existing = match read_seqs(&self.dir).await {
+            Ok(seqs) => seqs,
+            Err(error) => {
+                tracing::warn!("failed to list the core log directory: {error}");
+                return;
+            }
+        };
+        for seq in prune_targets(existing, self.options.max_files) {
+            let path = self.dir.join(file_name(seq));
+            if let Err(error) = tokio::fs::remove_file(&path).await {
+                tracing::warn!("failed to prune the rotated core log file {path}: {error}");
+            }
+        }
+    }
+}
+
+async fn create(dir: &Utf8Path, seq: u64) -> Result<tokio::fs::File, Error> {
+    let mut options = tokio::fs::OpenOptions::new();
+    options.create(true).append(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    Ok(options.open(dir.join(file_name(seq))).await?)
+}
+
+fn file_name(seq: u64) -> String {
+    format!("{FILE_PREFIX}{seq:06}{FILE_SUFFIX}")
+}
+
+/// `None` for anything this writer did not create, so an unrelated file in the
+/// directory is never a rotation candidate.
+fn file_seq(name: &str) -> Option<u64> {
+    name.strip_prefix(FILE_PREFIX)
+        .and_then(|rest| rest.strip_suffix(FILE_SUFFIX))
+        .filter(|digits| !digits.is_empty() && digits.bytes().all(|byte| byte.is_ascii_digit()))
+        .and_then(|digits| digits.parse().ok())
+}
+
+async fn read_seqs(dir: &Utf8Path) -> Result<Vec<u64>, std::io::Error> {
+    let mut seqs = Vec::new();
+    let mut entries = tokio::fs::read_dir(dir).await?;
+    while let Some(entry) = entries.next_entry().await? {
+        // Bound before borrowing, the same shape `cleanup_epoch` uses: the
+        // `OsString` has to outlive the `&str` taken out of it.
+        let name = entry.file_name();
+        if let Some(seq) = name.to_str().and_then(file_seq) {
+            seqs.push(seq);
+        }
+    }
+    Ok(seqs)
+}
+
+async fn next_seq(dir: &Utf8Path) -> Result<u64, Error> {
+    let seqs = read_seqs(dir).await?;
+    Ok(seqs.into_iter().max().unwrap_or(0) + 1)
+}
+
+/// Newest `max_files` survive; the rest are returned oldest-last. Ordering is
+/// numeric, not lexicographic: the zero padding is six wide for readability and
+/// stops agreeing with string order at a million files.
+fn prune_targets(mut seqs: Vec<u64>, max_files: usize) -> Vec<u64> {
+    seqs.sort_unstable_by_key(|seq| std::cmp::Reverse(*seq));
+    seqs.into_iter().skip(max_files).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::kind::CoreKind;
+
+    fn temp_dir() -> (tempfile::TempDir, Utf8PathBuf) {
+        let guard = tempfile::tempdir().unwrap();
+        let path = Utf8PathBuf::from_path_buf(guard.path().to_path_buf()).unwrap();
+        (guard, path)
+    }
+
+    fn options(max_bytes: u64, max_files: usize) -> SinkOptions {
+        SinkOptions {
+            max_bytes,
+            max_files,
+        }
+    }
+
+    fn frame(message: &str) -> LogFrame {
+        LogFrame {
+            epoch: 7,
+            kind: CoreKind::Mihomo,
+            stream: LogStream::Stdout,
+            timestamp: Some(LogTimestamp {
+                raw: "2026-07-29T00:16:22.646059400+08:00".to_owned(),
+                unix_ms: Some(1_753_719_382_646),
+                inferred: false,
+            }),
+            level: LogLevel::Info,
+            target: None,
+            message: message.to_owned(),
+            fields: vec![LogField {
+                key: "request".to_owned(),
+                value: "7".to_owned(),
+            }],
+            raw: format!("time=\"...\" level=info msg=\"{message}\""),
+            truncated: false,
+        }
+    }
+
+    fn touch(dir: &Utf8Path, seq: u64) {
+        std::fs::write(dir.join(file_name(seq)), b"{}\n").unwrap();
+    }
+
+    fn names(dir: &Utf8Path) -> Vec<String> {
+        let mut names = std::fs::read_dir(dir)
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name().to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+        names.sort();
+        names
+    }
+
+    fn lines(path: &Utf8Path) -> Vec<serde_json::Value> {
+        std::fs::read_to_string(path)
+            .unwrap()
+            .lines()
+            .map(|line| serde_json::from_str(line).expect("every line is one JSON object"))
+            .collect()
+    }
+
+    fn record(frame: &LogFrame) -> serde_json::Value {
+        serde_json::to_value(LogRecord::new(frame, 1_700_000_000_000)).unwrap()
+    }
+
+    #[test]
+    fn sequence_names_round_trip_and_reject_everything_else() {
+        assert_eq!(file_name(7), "core-000007.jsonl");
+        assert_eq!(file_name(1_234_567), "core-1234567.jsonl");
+        assert_eq!(file_seq("core-000007.jsonl"), Some(7));
+        assert_eq!(file_seq("core-1234567.jsonl"), Some(1_234_567));
+        for alien in [
+            "core-.jsonl",
+            "core-abc.jsonl",
+            "core--1.jsonl",
+            "core-7.jsonl.tmp",
+            "core-7.pid",
+            "config-7.yaml",
+            ".manager.lock",
+        ] {
+            assert_eq!(file_seq(alien), None, "{alien}");
+        }
+    }
+
+    #[tokio::test]
+    async fn the_next_sequence_is_one_past_the_highest_existing_file() {
+        let (_guard, dir) = temp_dir();
+        assert_eq!(next_seq(&dir).await.unwrap(), 1);
+        touch(&dir, 2);
+        touch(&dir, 10);
+        std::fs::write(dir.join("core-7.pid"), b"").unwrap();
+        assert_eq!(next_seq(&dir).await.unwrap(), 11);
+    }
+
+    #[test]
+    fn pruning_keeps_the_newest_files_by_number_rather_than_by_name() {
+        assert_eq!(prune_targets(vec![8, 9, 10, 11, 12], 3), [9, 8]);
+        assert_eq!(prune_targets(vec![1, 2], 5), Vec::<u64>::new());
+        // Six-wide padding stops agreeing with string order here, which is the
+        // whole reason the comparison is numeric.
+        assert_eq!(prune_targets(vec![999_999, 1_000_000, 5], 2), [5]);
+    }
+
+    #[test]
+    fn a_log_record_carries_the_observed_time_and_the_whole_frame() {
+        let value = record(&frame("startup frame"));
+        assert_eq!(value["t"], "log");
+        assert_eq!(value["at"], 1_700_000_000_000_i64);
+        assert_eq!(value["epoch"], 7);
+        assert_eq!(value["kind"], "mihomo");
+        assert_eq!(value["stream"], "stdout");
+        assert_eq!(value["level"], "info");
+        assert_eq!(value["timestamp"]["unix_ms"], 1_753_719_382_646_i64);
+        assert_eq!(value["timestamp"]["inferred"], false);
+        assert_eq!(value["target"], serde_json::Value::Null);
+        assert_eq!(value["message"], "startup frame");
+        assert_eq!(value["fields"][0]["key"], "request");
+        assert_eq!(value["truncated"], false);
+        assert!(value["raw"].as_str().unwrap().contains("startup frame"));
+    }
+
+    /// A frame whose header did not parse has no clock of its own, which is the
+    /// reason `at` exists. The key is still present, so a reader never branches.
+    #[test]
+    fn a_degraded_frame_keeps_a_null_timestamp_and_still_carries_at() {
+        let mut degraded = frame("unparsed line");
+        degraded.timestamp = None;
+        let value = record(&degraded);
+        assert_eq!(value["timestamp"], serde_json::Value::Null);
+        assert_eq!(value["at"], 1_700_000_000_000_i64);
+    }
+
+    /// The parser's 16 KiB budget bounds continuations, not the root line, so an
+    /// enormous single line reaches the sink whole. Both texts are cut and the
+    /// record says so.
+    #[test]
+    fn an_oversized_record_is_capped_and_flagged_truncated() {
+        let huge = "x".repeat(MAX_TEXT_BYTES * 2);
+        let mut oversized = frame("ignored");
+        oversized.message = huge.clone();
+        oversized.raw = huge;
+        let value = record(&oversized);
+        assert_eq!(value["message"].as_str().unwrap().len(), MAX_TEXT_BYTES);
+        assert_eq!(value["raw"].as_str().unwrap().len(), MAX_TEXT_BYTES);
+        assert_eq!(value["truncated"], true);
+    }
+
+    /// Multi-byte text must not be cut mid-character, or the line stops being
+    /// JSON at all.
+    #[test]
+    fn capping_cuts_on_a_character_boundary() {
+        // Three bytes per char, so the limit never lands on a boundary and the
+        // walk-back actually runs.
+        let text = "€".repeat(MAX_TEXT_BYTES);
+        let (cut, truncated) = clamp(&text);
+        assert!(truncated);
+        assert!(cut.len() < MAX_TEXT_BYTES, "the boundary walk did not run");
+        assert!(text.starts_with(cut));
+    }
+
+    #[test]
+    fn a_gap_record_reports_the_dropped_count() {
+        let value = serde_json::to_value(GapRecord::new(128, 1_700_000_000_000)).unwrap();
+        assert_eq!(value["t"], "gap");
+        assert_eq!(value["dropped"], 128);
+        assert_eq!(value["at"], 1_700_000_000_000_i64);
+    }
+
+    #[tokio::test]
+    async fn writing_past_the_size_limit_rotates_and_overshoots_by_at_most_one_record() {
+        let (_guard, dir) = temp_dir();
+        let mut writer = Writer::open(dir.clone(), options(512, 9)).await.unwrap();
+        let one = serde_json::to_vec(&LogRecord::new(&frame("rotate me"), now_ms()))
+            .unwrap()
+            .len() as u64
+            + 1;
+        assert!(one < 512, "the fixture record must fit under the limit");
+        // One record per write until the roll happens, so the assertion below
+        // holds whatever the fixture serializes to.
+        let mut writes = 0;
+        while names(&dir).len() == 1 {
+            writer.write(&[Entry::Log(frame("rotate me"))]).await;
+            writes += 1;
+            assert!(writes < 100, "the writer never rotated");
+        }
+        drop(writer);
+
+        assert_eq!(names(&dir), ["core-000001.jsonl", "core-000002.jsonl"]);
+        let first = std::fs::metadata(dir.join(file_name(1))).unwrap().len();
+        assert!(first >= 512, "rotated too early at {first}");
+        assert!(
+            first < 512 + one,
+            "overshot by more than one record: {first}"
+        );
+    }
+
+    #[tokio::test]
+    async fn rotation_prunes_the_oldest_files_beyond_the_retention_limit() {
+        let (_guard, dir) = temp_dir();
+        let mut writer = Writer::open(dir.clone(), options(1, 2)).await.unwrap();
+        for _ in 0..4 {
+            writer.write(&[Entry::Log(frame("roll"))]).await;
+        }
+        drop(writer);
+
+        // max_bytes = 1 means every write after the first starts by rotating
+        // (the pre-record check sees a full file); only the newest two survive.
+        assert_eq!(names(&dir), ["core-000003.jsonl", "core-000004.jsonl"]);
+    }
+
+    /// One oversized batch must not land in one oversized file: the limit is
+    /// checked per record, so a burst is split across files and every file
+    /// stays within one record of the limit.
+    #[tokio::test]
+    async fn a_batch_spanning_the_limit_rotates_mid_batch() {
+        let (_guard, dir) = temp_dir();
+        let mut writer = Writer::open(dir.clone(), options(512, 16)).await.unwrap();
+        let one = serde_json::to_vec(&LogRecord::new(&frame("burst"), now_ms()))
+            .unwrap()
+            .len() as u64
+            + 1;
+        assert!(one < 512, "the fixture record must fit under the limit");
+        let batch = (0..20)
+            .map(|_| Entry::Log(frame("burst")))
+            .collect::<Vec<_>>();
+        writer.write(&batch).await;
+        drop(writer);
+
+        let all = names(&dir);
+        assert!(all.len() > 1, "one file swallowed the whole burst");
+        let mut total = 0;
+        for name in &all {
+            let path = dir.join(name.as_str());
+            total += lines(&path).len();
+            let size = std::fs::metadata(&path).unwrap().len();
+            assert!(
+                size < 512 + one,
+                "{name} overshot by more than one record: {size}"
+            );
+        }
+        assert_eq!(total, 20, "records were lost in rotation");
+    }
+
+    #[tokio::test]
+    async fn startup_prunes_files_left_behind_by_a_previous_run() {
+        let (_guard, dir) = temp_dir();
+        for seq in 1..=6 {
+            touch(&dir, seq);
+        }
+        let writer = Writer::open(dir.clone(), options(4096, 3)).await.unwrap();
+        drop(writer);
+
+        // The freshly opened core-000007 counts toward the retention budget.
+        assert_eq!(
+            names(&dir),
+            [
+                "core-000005.jsonl",
+                "core-000006.jsonl",
+                "core-000007.jsonl"
+            ]
+        );
+    }
+
+    /// A crash can leave the previous file's last line half-written; appending
+    /// would splice it onto a fresh record.
+    #[tokio::test]
+    async fn a_restarted_writer_opens_a_new_file_instead_of_appending() {
+        let (_guard, dir) = temp_dir();
+        let mut first = Writer::open(dir.clone(), options(4096, 5)).await.unwrap();
+        first.write(&[Entry::Log(frame("first run"))]).await;
+        drop(first);
+
+        let mut second = Writer::open(dir.clone(), options(4096, 5)).await.unwrap();
+        second.write(&[Entry::Log(frame("second run"))]).await;
+        drop(second);
+
+        assert_eq!(names(&dir), ["core-000001.jsonl", "core-000002.jsonl"]);
+        let one = lines(&dir.join(file_name(1)));
+        assert_eq!(one.len(), 1);
+        assert_eq!(one[0]["message"], "first run");
+        let two = lines(&dir.join(file_name(2)));
+        assert_eq!(two.len(), 1);
+        assert_eq!(two[0]["message"], "second run");
+    }
+
+    /// Deterministic by construction: the receiver exists before anything is
+    /// sent, the ring holds two, five go in, and the sender is dropped — so
+    /// `run` sees exactly `Lagged(3)`, then the two survivors, then `Closed`.
+    #[tokio::test]
+    async fn a_lagging_writer_records_the_gap_before_the_surviving_frames() {
+        let (_guard, dir) = temp_dir();
+        let (log_tx, logs) = tokio::sync::broadcast::channel(2);
+        for index in 0..5 {
+            log_tx.send(frame(&format!("line {index}"))).unwrap();
+        }
+        drop(log_tx);
+
+        let writer = Writer::open(dir.clone(), options(1024 * 1024, 5))
+            .await
+            .unwrap();
+        run(writer, logs, CancellationToken::new()).await;
+
+        let records = lines(&dir.join(file_name(1)));
+        assert_eq!(records.len(), 3);
+        assert_eq!(records[0]["t"], "gap");
+        assert_eq!(records[0]["dropped"], 3);
+        assert_eq!(records[1]["message"], "line 3");
+        assert_eq!(records[2]["message"], "line 4");
+    }
+
+    /// The subdirectory has to be hardened explicitly: the parent's DACL is
+    /// inheritable, but an inherited descriptor does not carry
+    /// `SE_DACL_PROTECTED`, which is what the verifier demands.
+    #[tokio::test]
+    async fn the_log_directory_is_hardened_like_the_runtime_directory() {
+        let (_guard, dir) = temp_dir();
+        let logs = prepare_dir(&dir).await.unwrap();
+        assert_eq!(logs, dir.join("logs"));
+        assert!(logs.is_dir());
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(&logs).unwrap().permissions().mode();
+            assert_eq!(mode & 0o777, 0o700);
+        }
+        #[cfg(windows)]
+        {
+            nyanpasu_utils::io::atomic_fs::verify_windows_directory_acl(&logs).unwrap();
+        }
+    }
+}

--- a/crates/nyanpasu-core-manager/src/log_sink.rs
+++ b/crates/nyanpasu-core-manager/src/log_sink.rs
@@ -10,10 +10,11 @@
 //!
 //! - append-only, line-delimited JSON, one object per line, never rewritten and
 //!   never renamed;
-//! - every record carries `t` (`"log"` or `"gap"`) and `at`, the writer-observed
-//!   unix-millisecond instant. `at` is the only sortable clock: a frame whose
-//!   header did not parse has no timestamp at all, and clash premium's and
-//!   clash-rs's are inferred;
+//! - every record carries `t` (`"log"` or `"gap"`) and `at`, a unix-millisecond
+//!   instant. On a log record it is the parser's observation of the record's
+//!   root line; on a gap record it is the writer's own. `at` is the only
+//!   sortable clock: a frame whose header did not parse has no timestamp at all,
+//!   and clash premium's and clash-rs's are inferred;
 //! - a crash can only truncate the **last** line, because each batch is one
 //!   `write_all`. A reader splits on `\n`, parses each line, and ignores a
 //!   trailing line that does not parse;
@@ -21,10 +22,9 @@
 //!   `RuntimeConfigStore`, which pays the full stage/fsync/replace price because
 //!   it holds authoritative configuration.
 
-use std::borrow::Cow;
+use std::sync::Arc;
 
 use camino::{Utf8Path, Utf8PathBuf};
-use clash_api::LogField;
 use serde::Serialize;
 use tokio::{
     io::AsyncWriteExt,
@@ -37,8 +37,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::{
     error::Error,
-    kind::CoreKind,
-    log::{LogFrame, LogLevel, LogStream},
+    log::LogFrame,
     // `crate::runtime_store`, not `crate::config::runtime_store`: `lib.rs:19`
     // re-exports it and `manager/mod.rs:26` already spells it this way.
     runtime_store::validate_directory_metadata,
@@ -54,15 +53,6 @@ const LOG_DIR_NAME: &str = "logs";
 const FILE_PREFIX: &str = "core-";
 const FILE_SUFFIX: &str = ".jsonl";
 
-/// Per-record cap on the two free-text fields. The parser's 16 KiB budget bounds
-/// only continuation growth, so a single enormous line still arrives whole; this
-/// is what actually makes "a rotated file overshoots by at most one record" a
-/// statement with a number behind it.
-const MAX_TEXT_BYTES: usize = 16 * 1024;
-const MAX_TARGET_BYTES: usize = 2048;
-const MAX_TS_RAW_BYTES: usize = 256;
-const MAX_FIELDS: usize = 64;
-const MAX_FIELD_TEXT_BYTES: usize = 1024;
 const MAX_BATCH_RECORDS: usize = 256;
 
 /// Rotation knobs, mirrored from `ManagerOptions` so the writer does not carry
@@ -94,88 +84,36 @@ impl SinkHandle {
     }
 }
 
-/// A `"log"` line. The fields are borrowed from the frame so the two capped
-/// texts can be sliced instead of cloned; every key is always present, including
-/// the nulls, so a reader never has to branch on the schema.
+/// A `"log"` line: the frame verbatim, behind the one key that discriminates a
+/// record's type.
+///
+/// The frame is written in place rather than projected, so the disk schema *is*
+/// [`LogFrame`]'s field order and every key stays present, nulls included — a
+/// reader never has to branch on the schema. `t` is reserved by this envelope:
+/// a frame field of that name would produce a duplicate JSON key, which the
+/// envelope test below is there to catch.
 #[derive(Serialize)]
 struct LogRecord<'a> {
     t: &'static str,
-    at: i64,
-    epoch: u64,
-    kind: CoreKind,
-    stream: LogStream,
-    level: LogLevel,
-    timestamp: Option<RecordTimestamp<'a>>,
-    target: Option<&'a str>,
-    message: &'a str,
-    fields: Cow<'a, [LogField]>,
-    raw: &'a str,
-    /// The frame's own flag, OR-ed with whichever cap this record hit.
-    truncated: bool,
+    #[serde(flatten)]
+    frame: &'a LogFrame,
 }
 
-#[derive(Serialize)]
-struct RecordTimestamp<'a> {
-    raw: &'a str,
-    unix_ms: Option<i64>,
-    inferred: bool,
+impl<'a> LogRecord<'a> {
+    fn new(frame: &'a LogFrame) -> Self {
+        Self { t: "log", frame }
+    }
 }
 
 /// A `"gap"` line: the writer fell behind and the broadcast dropped `dropped`
 /// frames on its behalf. Writing it turns a silent hole into a visible one.
+/// Unlike a log record's, its `at` is the writer's own observation — there is no
+/// frame behind it to have been parsed.
 #[derive(Serialize)]
 struct GapRecord {
     t: &'static str,
     at: i64,
     dropped: u64,
-}
-
-impl<'a> LogRecord<'a> {
-    fn new(frame: &'a LogFrame, at: i64) -> Self {
-        let (message, message_cut) = clamp(&frame.message, MAX_TEXT_BYTES);
-        let (raw, raw_cut) = clamp(&frame.raw, MAX_TEXT_BYTES);
-        let (target, target_cut) = match frame.target.as_deref() {
-            Some(target) => {
-                let (target, cut) = clamp(target, MAX_TARGET_BYTES);
-                (Some(target), cut)
-            }
-            None => (None, false),
-        };
-        let (timestamp, timestamp_cut) = match frame.timestamp.as_ref() {
-            Some(timestamp) => {
-                let (raw, cut) = clamp(&timestamp.raw, MAX_TS_RAW_BYTES);
-                (
-                    Some(RecordTimestamp {
-                        raw,
-                        unix_ms: timestamp.unix_ms,
-                        inferred: timestamp.inferred,
-                    }),
-                    cut,
-                )
-            }
-            None => (None, false),
-        };
-        let (fields, fields_cut) = project_fields(&frame.fields);
-        Self {
-            t: "log",
-            at,
-            epoch: frame.epoch,
-            kind: frame.kind,
-            stream: frame.stream,
-            level: frame.level,
-            timestamp,
-            target,
-            message,
-            fields,
-            raw,
-            truncated: frame.truncated
-                || message_cut
-                || raw_cut
-                || target_cut
-                || timestamp_cut
-                || fields_cut,
-        }
-    }
 }
 
 impl GapRecord {
@@ -186,39 +124,6 @@ impl GapRecord {
             dropped,
         }
     }
-}
-
-/// Cuts at the last char boundary at or below the limit, so the result is still
-/// a `str` and still serializes as valid JSON.
-fn clamp(text: &str, max_bytes: usize) -> (&str, bool) {
-    if text.len() <= max_bytes {
-        return (text, false);
-    }
-    let mut end = max_bytes;
-    while !text.is_char_boundary(end) {
-        end -= 1;
-    }
-    (&text[..end], true)
-}
-
-fn project_fields(fields: &[LogField]) -> (Cow<'_, [LogField]>, bool) {
-    let kept = &fields[..fields.len().min(MAX_FIELDS)];
-    let exceeds_budget = fields.len() > MAX_FIELDS
-        || kept.iter().any(|field| {
-            field.key.len() > MAX_FIELD_TEXT_BYTES || field.value.len() > MAX_FIELD_TEXT_BYTES
-        });
-    if !exceeds_budget {
-        return (Cow::Borrowed(fields), false);
-    }
-
-    let fields = kept
-        .iter()
-        .map(|field| LogField {
-            key: clamp(&field.key, MAX_FIELD_TEXT_BYTES).0.to_owned(),
-            value: clamp(&field.value, MAX_FIELD_TEXT_BYTES).0.to_owned(),
-        })
-        .collect();
-    (Cow::Owned(fields), true)
 }
 
 /// Creates and hardens `{parent}/logs`, returning its path.
@@ -264,7 +169,7 @@ pub(crate) async fn prepare_dir(parent: &Utf8Path) -> Result<Utf8PathBuf, Error>
 pub(crate) async fn spawn(
     dir: Utf8PathBuf,
     options: SinkOptions,
-    logs: Receiver<LogFrame>,
+    logs: Receiver<Arc<LogFrame>>,
     cancel: CancellationToken,
 ) -> Result<SinkHandle, Error> {
     let writer = Writer::open(dir, options).await?;
@@ -275,7 +180,7 @@ pub(crate) async fn spawn(
 /// Drains the broadcast in batches until the token is cancelled or the last
 /// sender is gone. One `recv().await` for the first frame, then `try_recv()`
 /// until empty: a start-up burst costs one write instead of one per line.
-async fn run(mut writer: Writer, mut logs: Receiver<LogFrame>, cancel: CancellationToken) {
+async fn run(mut writer: Writer, mut logs: Receiver<Arc<LogFrame>>, cancel: CancellationToken) {
     let mut batch = Vec::new();
     loop {
         // Cleared before the select, never after: the cancellation arm writes
@@ -314,13 +219,13 @@ async fn run(mut writer: Writer, mut logs: Receiver<LogFrame>, cancel: Cancellat
 }
 
 enum Entry {
-    Log(LogFrame),
+    Log(Arc<LogFrame>),
     Gap(u64),
 }
 
 /// Appends everything already buffered. `true` means the channel is closed and
 /// the caller must stop after writing what it has.
-fn drain(logs: &mut Receiver<LogFrame>, batch: &mut Vec<Entry>) -> bool {
+fn drain(logs: &mut Receiver<Arc<LogFrame>>, batch: &mut Vec<Entry>) -> bool {
     while batch.len() < MAX_BATCH_RECORDS {
         match logs.try_recv() {
             Ok(frame) => batch.push(Entry::Log(frame)),
@@ -361,10 +266,13 @@ impl Writer {
     /// Serializes and appends one batch, rotating whenever the active file has
     /// already crossed the limit. The check runs per record, not per batch, so
     /// a burst that arrives as one batch still cannot produce a file more than
-    /// one record past `max_bytes` — a record being bounded by MAX_TEXT_BYTES
-    /// on each of its two free-text fields. Errors are logged and swallowed:
-    /// losing diagnostic output must never take down a manager that is
-    /// otherwise healthy.
+    /// one record past `max_bytes` — a record being bounded by the caps the
+    /// manager's parser applied before it ever reached this channel. That holds
+    /// for as long as rollover keeps succeeding: `rotate` deliberately keeps
+    /// writing into the oversized file when it cannot open a new one, so
+    /// repeated failures overshoot by a record each. Errors are logged and
+    /// swallowed: losing diagnostic output must never take down a manager that
+    /// is otherwise healthy.
     async fn write(&mut self, batch: &[Entry]) {
         if batch.is_empty() {
             return;
@@ -381,7 +289,7 @@ impl Writer {
             }
             let mark = buffer.len();
             let result = match entry {
-                Entry::Log(frame) => serde_json::to_writer(&mut buffer, &LogRecord::new(frame, at)),
+                Entry::Log(frame) => serde_json::to_writer(&mut buffer, &LogRecord::new(frame)),
                 Entry::Gap(dropped) => {
                     serde_json::to_writer(&mut buffer, &GapRecord::new(*dropped, at))
                 }
@@ -521,7 +429,10 @@ fn prune_targets(mut seqs: Vec<u64>, max_files: usize) -> Vec<u64> {
 mod tests {
     use super::*;
 
-    use crate::{kind::CoreKind, log::LogTimestamp};
+    use crate::{
+        kind::CoreKind,
+        log::{LogField, LogLevel, LogStream, LogTimestamp},
+    };
 
     fn temp_dir() -> (tempfile::TempDir, Utf8PathBuf) {
         let guard = tempfile::tempdir().unwrap();
@@ -538,15 +449,16 @@ mod tests {
 
     fn frame(message: &str) -> LogFrame {
         LogFrame {
+            at: 1_700_000_000_000,
             epoch: 7,
             kind: CoreKind::Mihomo,
             stream: LogStream::Stdout,
+            level: LogLevel::Info,
             timestamp: Some(LogTimestamp {
                 raw: "2026-07-29T00:16:22.646059400+08:00".to_owned(),
                 unix_ms: Some(1_753_719_382_646),
                 inferred: false,
             }),
-            level: LogLevel::Info,
             target: None,
             message: message.to_owned(),
             fields: vec![LogField {
@@ -556,6 +468,10 @@ mod tests {
             raw: format!("time=\"...\" level=info msg=\"{message}\""),
             truncated: false,
         }
+    }
+
+    fn entry(message: &str) -> Entry {
+        Entry::Log(Arc::new(frame(message)))
     }
 
     fn touch(dir: &Utf8Path, seq: u64) {
@@ -580,7 +496,7 @@ mod tests {
     }
 
     fn record(frame: &LogFrame) -> serde_json::Value {
-        serde_json::to_value(LogRecord::new(frame, 1_700_000_000_000)).unwrap()
+        serde_json::to_value(LogRecord::new(frame)).unwrap()
     }
 
     #[test]
@@ -621,9 +537,49 @@ mod tests {
         assert_eq!(prune_targets(vec![999_999, 1_000_000, 5], 2), [5]);
     }
 
+    /// The envelope adds exactly one key and flattens the frame beside it. The
+    /// duplicate-key check is the reason `t` is reserved: a frame field of that
+    /// name would produce a line no reader could interpret, and serde would not
+    /// complain.
     #[test]
-    fn a_log_record_carries_the_observed_time_and_the_whole_frame() {
-        let value = record(&frame("startup frame"));
+    fn a_log_record_is_the_whole_frame_behind_a_single_tag() {
+        let frame = frame("startup frame");
+        let encoded = serde_json::to_string(&LogRecord::new(&frame)).unwrap();
+        assert_eq!(
+            encoded.matches(r#""t":"#).count(),
+            1,
+            "the envelope tag must be the only `t` key: {encoded}"
+        );
+        // The key order this pins is the order the archive has always written.
+        // Flattening the frame is a source-level change only: existing files
+        // stay readable and new lines sit beside them unmigrated.
+        assert!(
+            encoded.starts_with(concat!(
+                r#"{"t":"log","at":1700000000000,"epoch":7,"kind":"mihomo","#,
+                r#""stream":"stdout","level":"info","timestamp":{"#,
+            )),
+            "the on-disk key order moved: {encoded}"
+        );
+        assert!(
+            encoded.ends_with(concat!(
+                r#""target":null,"message":"startup frame","#,
+                r#""fields":[{"key":"request","value":"7"}],"#,
+                r#""raw":"time=\"...\" level=info msg=\"startup frame\"","#,
+                r#""truncated":false}"#
+            )),
+            "the on-disk key order moved: {encoded}"
+        );
+
+        let value: serde_json::Value = serde_json::from_str(&encoded).unwrap();
+        let flattened = serde_json::to_value(&frame).unwrap();
+        for (key, expected) in flattened.as_object().unwrap() {
+            assert_eq!(&value[key], expected, "flattened field {key}");
+        }
+        assert_eq!(
+            value.as_object().unwrap().len(),
+            flattened.as_object().unwrap().len() + 1
+        );
+
         assert_eq!(value["t"], "log");
         assert_eq!(value["at"], 1_700_000_000_000_i64);
         assert_eq!(value["epoch"], 7);
@@ -640,7 +596,8 @@ mod tests {
     }
 
     /// A frame whose header did not parse has no clock of its own, which is the
-    /// reason `at` exists. The key is still present, so a reader never branches.
+    /// reason the parser stamps `at`. The key is still present, so a reader
+    /// never branches.
     #[test]
     fn a_degraded_frame_keeps_a_null_timestamp_and_still_carries_at() {
         let mut degraded = frame("unparsed line");
@@ -648,66 +605,6 @@ mod tests {
         let value = record(&degraded);
         assert_eq!(value["timestamp"], serde_json::Value::Null);
         assert_eq!(value["at"], 1_700_000_000_000_i64);
-    }
-
-    /// The parser's 16 KiB budget bounds continuations, not the root line, so an
-    /// enormous single line reaches the sink whole. Both texts are cut and the
-    /// record says so.
-    #[test]
-    fn an_oversized_record_is_capped_and_flagged_truncated() {
-        let huge = "x".repeat(MAX_TEXT_BYTES * 2);
-        let mut oversized = frame("ignored");
-        oversized.message = huge.clone();
-        oversized.raw = huge;
-        let value = record(&oversized);
-        assert_eq!(value["message"].as_str().unwrap().len(), MAX_TEXT_BYTES);
-        assert_eq!(value["raw"].as_str().unwrap().len(), MAX_TEXT_BYTES);
-        assert_eq!(value["truncated"], true);
-    }
-
-    /// Multi-byte text must not be cut mid-character, or the line stops being
-    /// JSON at all.
-    #[test]
-    fn capping_cuts_on_a_character_boundary() {
-        // Three bytes per char, so the limit never lands on a boundary and the
-        // walk-back actually runs.
-        let text = "€".repeat(MAX_TEXT_BYTES);
-        let (cut, truncated) = clamp(&text, MAX_TEXT_BYTES);
-        assert!(truncated);
-        assert!(cut.len() < MAX_TEXT_BYTES, "the boundary walk did not run");
-        assert!(text.starts_with(cut));
-    }
-
-    #[test]
-    fn oversized_metadata_is_capped_and_flagged_truncated() {
-        let huge = "x".repeat(MAX_FIELD_TEXT_BYTES * 2);
-        let mut oversized = frame("oversized metadata");
-        oversized.target = Some("t".repeat(MAX_TARGET_BYTES * 2));
-        oversized.timestamp.as_mut().unwrap().raw = "z".repeat(MAX_TS_RAW_BYTES * 2);
-        oversized.fields = (0..=MAX_FIELDS)
-            .map(|index| LogField {
-                key: format!("{index}{huge}"),
-                value: huge.clone(),
-            })
-            .collect();
-
-        let value = record(&oversized);
-
-        assert_eq!(value["target"].as_str().unwrap().len(), MAX_TARGET_BYTES);
-        assert_eq!(
-            value["timestamp"]["raw"].as_str().unwrap().len(),
-            MAX_TS_RAW_BYTES
-        );
-        assert_eq!(value["fields"].as_array().unwrap().len(), MAX_FIELDS);
-        assert_eq!(
-            value["fields"][0]["key"].as_str().unwrap().len(),
-            MAX_FIELD_TEXT_BYTES
-        );
-        assert_eq!(
-            value["fields"][0]["value"].as_str().unwrap().len(),
-            MAX_FIELD_TEXT_BYTES
-        );
-        assert_eq!(value["truncated"], true);
     }
 
     #[test]
@@ -722,7 +619,8 @@ mod tests {
     async fn writing_past_the_size_limit_rotates_and_overshoots_by_at_most_one_record() {
         let (_guard, dir) = temp_dir();
         let mut writer = Writer::open(dir.clone(), options(512, 9)).await.unwrap();
-        let one = serde_json::to_vec(&LogRecord::new(&frame("rotate me"), now_ms()))
+        let rotate_me = frame("rotate me");
+        let one = serde_json::to_vec(&LogRecord::new(&rotate_me))
             .unwrap()
             .len() as u64
             + 1;
@@ -731,7 +629,7 @@ mod tests {
         // holds whatever the fixture serializes to.
         let mut writes = 0;
         while names(&dir).len() == 1 {
-            writer.write(&[Entry::Log(frame("rotate me"))]).await;
+            writer.write(&[entry("rotate me")]).await;
             writes += 1;
             assert!(writes < 100, "the writer never rotated");
         }
@@ -751,7 +649,7 @@ mod tests {
         let (_guard, dir) = temp_dir();
         let mut writer = Writer::open(dir.clone(), options(1, 2)).await.unwrap();
         for _ in 0..4 {
-            writer.write(&[Entry::Log(frame("roll"))]).await;
+            writer.write(&[entry("roll")]).await;
         }
         drop(writer);
 
@@ -766,7 +664,7 @@ mod tests {
         let mut writer = Writer::open(dir.clone(), options(1, 1)).await.unwrap();
         for index in 0..4 {
             let message = format!("line {index}");
-            writer.write(&[Entry::Log(frame(&message))]).await;
+            writer.write(&[entry(&message)]).await;
 
             let newest = dir.join(file_name(writer.seq));
             assert!(newest.exists(), "the active file disappeared");
@@ -789,14 +687,10 @@ mod tests {
     async fn a_batch_spanning_the_limit_rotates_mid_batch() {
         let (_guard, dir) = temp_dir();
         let mut writer = Writer::open(dir.clone(), options(512, 16)).await.unwrap();
-        let one = serde_json::to_vec(&LogRecord::new(&frame("burst"), now_ms()))
-            .unwrap()
-            .len() as u64
-            + 1;
+        let burst = frame("burst");
+        let one = serde_json::to_vec(&LogRecord::new(&burst)).unwrap().len() as u64 + 1;
         assert!(one < 512, "the fixture record must fit under the limit");
-        let batch = (0..20)
-            .map(|_| Entry::Log(frame("burst")))
-            .collect::<Vec<_>>();
+        let batch = (0..20).map(|_| entry("burst")).collect::<Vec<_>>();
         writer.write(&batch).await;
         drop(writer);
 
@@ -841,11 +735,11 @@ mod tests {
     async fn a_restarted_writer_opens_a_new_file_instead_of_appending() {
         let (_guard, dir) = temp_dir();
         let mut first = Writer::open(dir.clone(), options(4096, 5)).await.unwrap();
-        first.write(&[Entry::Log(frame("first run"))]).await;
+        first.write(&[entry("first run")]).await;
         drop(first);
 
         let mut second = Writer::open(dir.clone(), options(4096, 5)).await.unwrap();
-        second.write(&[Entry::Log(frame("second run"))]).await;
+        second.write(&[entry("second run")]).await;
         drop(second);
 
         assert_eq!(names(&dir), ["core-000001.jsonl", "core-000002.jsonl"]);
@@ -865,7 +759,9 @@ mod tests {
         let (_guard, dir) = temp_dir();
         let (log_tx, logs) = tokio::sync::broadcast::channel(2);
         for index in 0..5 {
-            log_tx.send(frame(&format!("line {index}"))).unwrap();
+            log_tx
+                .send(Arc::new(frame(&format!("line {index}"))))
+                .unwrap();
         }
         drop(log_tx);
 
@@ -887,7 +783,9 @@ mod tests {
         let (_guard, dir) = temp_dir();
         let (log_tx, logs) = tokio::sync::broadcast::channel(512);
         for index in 0..300 {
-            log_tx.send(frame(&format!("line {index}"))).unwrap();
+            log_tx
+                .send(Arc::new(frame(&format!("line {index}"))))
+                .unwrap();
         }
         drop(log_tx);
 
@@ -914,7 +812,9 @@ mod tests {
         .await
         .unwrap();
         for index in 0..8 {
-            log_tx.send(frame(&format!("line {index}"))).unwrap();
+            log_tx
+                .send(Arc::new(frame(&format!("line {index}"))))
+                .unwrap();
         }
 
         handle.shutdown().await;

--- a/crates/nyanpasu-core-manager/src/log_sink.rs
+++ b/crates/nyanpasu-core-manager/src/log_sink.rs
@@ -79,13 +79,17 @@ pub(crate) struct SinkHandle {
 }
 
 impl SinkHandle {
-    pub(crate) async fn shutdown(self) {
+    /// An aborted writer can cut the final batch mid-write, the same contract
+    /// as a crash; readers already discard a truncated last line.
+    pub(crate) async fn shutdown(mut self) {
         self.cancel.cancel();
-        if tokio::time::timeout(std::time::Duration::from_secs(5), self.task)
-            .await
-            .is_err()
-        {
-            tracing::warn!("timed out waiting for the core log sink to shut down");
+        match tokio::time::timeout(std::time::Duration::from_secs(5), &mut self.task).await {
+            Ok(_) => {}
+            Err(_) => {
+                tracing::warn!("timed out waiting for the core log sink to shut down");
+                self.task.abort();
+                let _ = self.task.await;
+            }
         }
     }
 }
@@ -343,7 +347,7 @@ impl Writer {
         // record. One file also means one run, which is a useful boundary when
         // somebody hands you a log directory.
         let seq = next_seq(&dir).await?;
-        prune_dir(&dir, options.max_files - 1).await;
+        prune_dir(&dir, options.max_files.saturating_sub(1), None).await;
         let file = create(&dir, seq).await?;
         Ok(Self {
             dir,
@@ -413,14 +417,23 @@ impl Writer {
         buffer.clear();
     }
 
+    /// A single-file budget briefly permits the old and new files to coexist:
+    /// the active file is never deleted, and retention converges after the
+    /// successful switch closes it.
     async fn rotate(&mut self) {
         let seq = self.seq + 1;
-        prune_dir(&self.dir, self.options.max_files - 1).await;
+        prune_dir(
+            &self.dir,
+            self.options.max_files.saturating_sub(1),
+            Some(self.seq),
+        )
+        .await;
         match create(&self.dir, seq).await {
             Ok(file) => {
                 self.file = file;
                 self.seq = seq;
                 self.written = 0;
+                prune_dir(&self.dir, self.options.max_files, Some(self.seq)).await;
             }
             // Keep writing into the oversized file rather than losing the
             // stream; the next record's pre-check retries.
@@ -431,10 +444,10 @@ impl Writer {
     }
 }
 
-/// Deletes everything past the newest `keep` files. A delete that fails — a
-/// file held open by an editor, which Windows refuses to unlink — is logged and
-/// retried on the next rollover.
-async fn prune_dir(dir: &Utf8Path, keep: usize) {
+/// Deletes everything past the newest `keep` files except `protect`. A delete
+/// that fails — a file held open by an editor, which Windows refuses to unlink
+/// — is logged and retried on the next rollover.
+async fn prune_dir(dir: &Utf8Path, keep: usize, protect: Option<u64>) {
     let existing = match read_seqs(dir).await {
         Ok(seqs) => seqs,
         Err(error) => {
@@ -442,7 +455,10 @@ async fn prune_dir(dir: &Utf8Path, keep: usize) {
             return;
         }
     };
-    for seq in prune_targets(existing, keep) {
+    for seq in prune_targets(existing, keep)
+        .into_iter()
+        .filter(|seq| Some(*seq) != protect)
+    {
         let path = dir.join(file_name(seq));
         if let Err(error) = tokio::fs::remove_file(&path).await {
             tracing::warn!("failed to prune the rotated core log file {path}: {error}");
@@ -742,6 +758,28 @@ mod tests {
         // max_bytes = 1 means every write after the first starts by rotating
         // (the pre-record check sees a full file); only the newest two survive.
         assert_eq!(names(&dir), ["core-000003.jsonl", "core-000004.jsonl"]);
+    }
+
+    #[tokio::test]
+    async fn a_single_file_budget_never_deletes_the_active_file() {
+        let (_guard, dir) = temp_dir();
+        let mut writer = Writer::open(dir.clone(), options(1, 1)).await.unwrap();
+        for index in 0..4 {
+            let message = format!("line {index}");
+            writer.write(&[Entry::Log(frame(&message))]).await;
+
+            let newest = dir.join(file_name(writer.seq));
+            assert!(newest.exists(), "the active file disappeared");
+            assert_eq!(lines(&newest).last().unwrap()["message"], message);
+        }
+        assert!(writer.seq >= 3, "the writer did not rotate at least twice");
+        drop(writer);
+
+        let remaining = names(&dir);
+        assert_eq!(remaining.len(), 1);
+        let records = lines(&dir.join(&remaining[0]));
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0]["message"], "line 3");
     }
 
     /// One oversized batch must not land in one oversized file: the limit is

--- a/crates/nyanpasu-core-manager/src/manager/mod.rs
+++ b/crates/nyanpasu-core-manager/src/manager/mod.rs
@@ -539,8 +539,10 @@ impl CoreManager {
     /// Like [`Self::stop`], shutdown intentionally bypasses the quarantine
     /// gate and never treats an unrelated uncertain epoch as recovered.
     pub async fn shutdown(&self) -> Result<(), Error> {
+        // Held through sink finalization so no control-plane operation can interleave
+        // between core stop and archive teardown.
+        let mut ctrl = self.inner.ctrl.lock().await;
         let result: Result<(), Error> = async {
-            let mut ctrl = self.inner.ctrl.lock().await;
             if let Some(active) = ctrl.current.take() {
                 let Active {
                     instance,

--- a/crates/nyanpasu-core-manager/src/manager/mod.rs
+++ b/crates/nyanpasu-core-manager/src/manager/mod.rs
@@ -108,7 +108,7 @@ struct Inner {
     status_tx: watch::Sender<CoreStatus>,
     /// Outlives every epoch, so callers can subscribe before the first start and
     /// keep receiving across restarts and core switches.
-    log_tx: broadcast::Sender<LogFrame>,
+    log_tx: broadcast::Sender<Arc<LogFrame>>,
     epoch: AtomicU64,
     version_cache: VersionCache,
     /// `Some` while the JSONL sink is running. `None` means the caller turned it
@@ -293,7 +293,7 @@ impl CoreManager {
         self.inner.status_tx.subscribe()
     }
 
-    pub fn subscribe_logs(&self) -> broadcast::Receiver<LogFrame> {
+    pub fn subscribe_logs(&self) -> broadcast::Receiver<Arc<LogFrame>> {
         self.inner.log_tx.subscribe()
     }
 

--- a/crates/nyanpasu-core-manager/src/manager/mod.rs
+++ b/crates/nyanpasu-core-manager/src/manager/mod.rs
@@ -539,53 +539,57 @@ impl CoreManager {
     /// Like [`Self::stop`], shutdown intentionally bypasses the quarantine
     /// gate and never treats an unrelated uncertain epoch as recovered.
     pub async fn shutdown(&self) -> Result<(), Error> {
-        let mut ctrl = self.inner.ctrl.lock().await;
-        if let Some(active) = ctrl.current.take() {
-            let Active {
-                instance,
-                forwarder,
-                source_spec,
-                revision,
-                capabilities,
-                runtime_features,
-                ..
-            } = active;
-            abort_and_await(forwarder).await;
-            let epoch = instance.epoch();
-            self.inner.publish(
-                CoreState::Stopping { epoch },
-                Some(spec_summary(&source_spec, capabilities, runtime_features)),
-                Some(instance.controller().host.clone()),
-                Some(revision),
-            );
-            if let Err(error) = instance
-                .stop_and_confirm_dead(self.inner.options.stop_timeout)
-                .await
-            {
-                if matches!(error, Error::StopUnconfirmed(_)) {
-                    return Err(self.latch_quarantine(&mut ctrl, epoch, error));
+        let result: Result<(), Error> = async {
+            let mut ctrl = self.inner.ctrl.lock().await;
+            if let Some(active) = ctrl.current.take() {
+                let Active {
+                    instance,
+                    forwarder,
+                    source_spec,
+                    revision,
+                    capabilities,
+                    runtime_features,
+                    ..
+                } = active;
+                abort_and_await(forwarder).await;
+                let epoch = instance.epoch();
+                self.inner.publish(
+                    CoreState::Stopping { epoch },
+                    Some(spec_summary(&source_spec, capabilities, runtime_features)),
+                    Some(instance.controller().host.clone()),
+                    Some(revision),
+                );
+                if let Err(error) = instance
+                    .stop_and_confirm_dead(self.inner.options.stop_timeout)
+                    .await
+                {
+                    if matches!(error, Error::StopUnconfirmed(_)) {
+                        return Err(self.latch_quarantine(&mut ctrl, epoch, error));
+                    }
+                    self.publish_terminal_error(&error);
+                    return Err(error);
                 }
-                self.publish_terminal_error(&error);
-                return Err(error);
+                if let Err(error) = self.inner.store.cleanup_epoch(epoch).await {
+                    self.publish_terminal_error(&error);
+                    return Err(error);
+                }
+                self.inner.publish(
+                    CoreState::Stopped {
+                        reason: Some(StopReason::User),
+                    },
+                    None,
+                    None,
+                    None,
+                );
             }
-            if let Err(error) = self.inner.store.cleanup_epoch(epoch).await {
-                self.publish_terminal_error(&error);
-                return Err(error);
-            }
-            self.inner.publish(
-                CoreState::Stopped {
-                    reason: Some(StopReason::User),
-                },
-                None,
-                None,
-                None,
-            );
+            Ok(())
         }
+        .await;
         let log_sink = self.inner.log_sink.lock().await.take();
         if let Some(log_sink) = log_sink {
             log_sink.shutdown().await;
         }
-        Ok(())
+        result
     }
 
     fn next_epoch(&self) -> u64 {

--- a/crates/nyanpasu-core-manager/src/manager/mod.rs
+++ b/crates/nyanpasu-core-manager/src/manager/mod.rs
@@ -115,6 +115,10 @@ struct Inner {
     /// off, and there is deliberately no path to report — nothing will ever
     /// appear there.
     log_dir: Option<camino::Utf8PathBuf>,
+    /// Dropping the manager without calling `shutdown()` abandons at most the
+    /// final batch. This is diagnostic data and best-effort by design;
+    /// `shutdown()` is the graceful path.
+    log_sink: tokio::sync::Mutex<Option<log_sink::SinkHandle>>,
     // Declared last so ordinary Inner destruction drops instances/tasks before
     // releasing directory ownership.
     _runtime_lock: RuntimeDirectoryLock,
@@ -252,21 +256,21 @@ impl CoreManager {
         let (log_tx, _) = broadcast::channel(LOG_CHANNEL_CAPACITY);
         // Subscribed here rather than inside the task, and before any instance
         // can exist, so the sink cannot miss the start-up burst.
-        let log_dir = if options.log_sink_enabled {
+        let (log_dir, log_sink) = if options.log_sink_enabled {
             let dir = log_sink::prepare_dir(store.dir()).await?;
-            log_sink::spawn(
+            let handle = log_sink::spawn(
                 dir.clone(),
                 SinkOptions {
                     max_bytes: options.log_max_bytes,
                     max_files: options.log_max_files,
                 },
                 log_tx.subscribe(),
-                options.cancel_token.clone(),
+                options.cancel_token.child_token(),
             )
             .await?;
-            Some(dir)
+            (Some(dir), Some(handle))
         } else {
-            None
+            (None, None)
         };
         Ok(Self {
             inner: Arc::new(Inner {
@@ -279,6 +283,7 @@ impl CoreManager {
                 epoch: AtomicU64::new(max_epoch),
                 version_cache: VersionCache::default(),
                 log_dir,
+                log_sink: tokio::sync::Mutex::new(log_sink),
                 _runtime_lock: runtime_lock,
             }),
         })
@@ -575,6 +580,10 @@ impl CoreManager {
                 None,
                 None,
             );
+        }
+        let log_sink = self.inner.log_sink.lock().await.take();
+        if let Some(log_sink) = log_sink {
+            log_sink.shutdown().await;
         }
         Ok(())
     }

--- a/crates/nyanpasu-core-manager/src/manager/mod.rs
+++ b/crates/nyanpasu-core-manager/src/manager/mod.rs
@@ -22,6 +22,7 @@ use crate::{
     error::Error,
     instance::Instance,
     log::{LOG_CHANNEL_CAPACITY, LogFrame},
+    log_sink::{self, SinkOptions},
     probe::ProbeHandle,
     runtime_store::{RuntimeConfigStore, RuntimeDirectoryLock, StagedRuntimeConfig},
     spec::{CoreSpec, InstanceSpec, LocalIpcPolicy, ManagerOptions, ResolvedController},
@@ -110,6 +111,10 @@ struct Inner {
     log_tx: broadcast::Sender<LogFrame>,
     epoch: AtomicU64,
     version_cache: VersionCache,
+    /// `Some` while the JSONL sink is running. `None` means the caller turned it
+    /// off, and there is deliberately no path to report — nothing will ever
+    /// appear there.
+    log_dir: Option<camino::Utf8PathBuf>,
     // Declared last so ordinary Inner destruction drops instances/tasks before
     // releasing directory ownership.
     _runtime_lock: RuntimeDirectoryLock,
@@ -229,8 +234,40 @@ impl CoreManager {
                 )));
             }
         }
+        // Validated whether or not the sink is enabled, for the same reason the
+        // controller template above is validated under every policy:
+        // construction is the caller's last chance to hear about it.
+        if options.log_max_bytes == 0 {
+            return Err(Error::InvalidManagerOptions(
+                "log_max_bytes must be greater than zero".into(),
+            ));
+        }
+        if options.log_max_files == 0 {
+            return Err(Error::InvalidManagerOptions(
+                "log_max_files must be greater than zero".into(),
+            ));
+        }
         let max_epoch = sweep_orphans(&store).await?;
         let (status_tx, _) = watch::channel(CoreStatus::initial());
+        let (log_tx, _) = broadcast::channel(LOG_CHANNEL_CAPACITY);
+        // Subscribed here rather than inside the task, and before any instance
+        // can exist, so the sink cannot miss the start-up burst.
+        let log_dir = if options.log_sink_enabled {
+            let dir = log_sink::prepare_dir(store.dir()).await?;
+            log_sink::spawn(
+                dir.clone(),
+                SinkOptions {
+                    max_bytes: options.log_max_bytes,
+                    max_files: options.log_max_files,
+                },
+                log_tx.subscribe(),
+                options.cancel_token.clone(),
+            )
+            .await?;
+            Some(dir)
+        } else {
+            None
+        };
         Ok(Self {
             inner: Arc::new(Inner {
                 options,
@@ -238,9 +275,10 @@ impl CoreManager {
                 store,
                 ctrl: tokio::sync::Mutex::default(),
                 status_tx,
-                log_tx: broadcast::channel(LOG_CHANNEL_CAPACITY).0,
+                log_tx,
                 epoch: AtomicU64::new(max_epoch),
                 version_cache: VersionCache::default(),
+                log_dir,
                 _runtime_lock: runtime_lock,
             }),
         })
@@ -252,6 +290,14 @@ impl CoreManager {
 
     pub fn subscribe_logs(&self) -> broadcast::Receiver<LogFrame> {
         self.inner.log_tx.subscribe()
+    }
+
+    /// Where the JSONL core-log archive is written, or `None` when the sink is
+    /// disabled. Constant for the manager's lifetime, which is why it is an
+    /// accessor and not a field on the status snapshot: putting it there would
+    /// republish an unchanging string on every transition.
+    pub fn log_dir(&self) -> Option<&camino::Utf8Path> {
+        self.inner.log_dir.as_deref()
     }
 
     pub fn status(&self) -> CoreStatus {

--- a/crates/nyanpasu-core-manager/src/spec.rs
+++ b/crates/nyanpasu-core-manager/src/spec.rs
@@ -91,6 +91,16 @@ pub struct ManagerOptions {
     pub reconcile_timeout: Duration,
     pub stop_timeout: Duration,
     pub cancel_token: CancellationToken,
+    /// Write core logs as JSONL under `{runtime_dir}/logs/`. Off means the
+    /// directory is never created and nothing is written; an embedder with its
+    /// own log stack subscribes to the frames directly instead.
+    pub log_sink_enabled: bool,
+    /// Rotate the active core-log file once it reaches this size. Soft: a file
+    /// overshoots by at most the one record that crossed the line.
+    pub log_max_bytes: u64,
+    /// How many core-log files to keep, the active one included. With
+    /// `log_max_bytes` this is the directory's hard disk budget.
+    pub log_max_files: usize,
 }
 
 impl Default for ManagerOptions {
@@ -107,6 +117,12 @@ impl Default for ManagerOptions {
             reconcile_timeout: Duration::from_secs(30),
             stop_timeout: Duration::from_secs(10),
             cancel_token: CancellationToken::new(),
+            log_sink_enabled: true,
+            // 4 MiB x 5 = a 20 MiB ceiling — tighter than the service's own
+            // tracing-appender policy, which keeps 7 daily files of unbounded
+            // size. At roughly 300-600 B per record a file covers 7k-14k lines.
+            log_max_bytes: 4 * 1024 * 1024,
+            log_max_files: 5,
         }
     }
 }
@@ -132,12 +148,16 @@ mod tests {
 
     /// The compatibility pin for S10: `ManagerOptions::default()` must keep the
     /// removed passthrough behavior — the source config's HTTP controller,
-    /// never rewritten.
+    /// never rewritten. The log-sink defaults are pinned beside it because they
+    /// set a disk budget every embedder inherits without asking.
     #[test]
     fn manager_options_default_to_the_non_rewriting_policy() {
         let o = ManagerOptions::default();
         assert_eq!(o.local_ipc_policy, LocalIpcPolicy::Disable);
         assert!(o.controller_template.is_none());
         assert!(o.runtime_dir.is_none());
+        assert!(o.log_sink_enabled);
+        assert_eq!(o.log_max_bytes, 4 * 1024 * 1024);
+        assert_eq!(o.log_max_files, 5);
     }
 }

--- a/crates/nyanpasu-core-manager/tests/manager_orchestration.rs
+++ b/crates/nyanpasu-core-manager/tests/manager_orchestration.rs
@@ -246,6 +246,63 @@ async fn log_subscription_observes_startup_frames() {
     manager.shutdown().await.expect("shutdown");
 }
 
+/// The other half of the frame contract: what the broadcast delivers also
+/// reaches disk. Reads through `log_dir()` rather than rebuilding the path,
+/// because the store canonicalizes and Windows hands back a `\\?\` prefix.
+#[tokio::test]
+async fn core_logs_are_archived_under_the_manager_log_directory() {
+    let (_guard, dir) = common::utf8_tempdir();
+    let port = common::free_port();
+    let config = common::write_config(
+        &dir,
+        &format!(
+            "external-controller: 127.0.0.1:{port}\nx-fake-core:\n  stdout-lines:\n    - 'time=\"2026-07-29T00:16:22.646059400+08:00\" level=info msg=\"archived frame\"'\n"
+        ),
+    );
+    let manager = manager(&dir).await;
+    let log_dir = manager
+        .log_dir()
+        .expect("the sink is on by default")
+        .to_owned();
+    manager
+        .start(common::mihomo_spec(&dir, config))
+        .await
+        .expect("start");
+
+    // The sink is an independent subscriber, so it lands the frame slightly
+    // after `subscribe_logs` would: poll rather than assume.
+    let record = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            if let Some(record) = read_archived(&log_dir, "archived frame") {
+                break record;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    })
+    .await
+    .expect("the frame was never archived");
+
+    assert_eq!(record["t"], "log");
+    assert_eq!(record["epoch"], 1);
+    assert_eq!(record["kind"], "mihomo");
+    assert_eq!(record["stream"], "stdout");
+    assert_eq!(record["level"], "info");
+    assert!(record["at"].as_i64().expect("at is always present") > 0);
+    manager.shutdown().await.expect("shutdown");
+}
+
+fn read_archived(log_dir: &camino::Utf8Path, message: &str) -> Option<serde_json::Value> {
+    std::fs::read_dir(log_dir)
+        .ok()?
+        .filter_map(|entry| std::fs::read_to_string(entry.ok()?.path()).ok())
+        .flat_map(|body| {
+            body.lines()
+                .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
+                .collect::<Vec<_>>()
+        })
+        .find(|record| record["message"] == message)
+}
+
 #[tokio::test]
 async fn stop_requires_a_running_core() {
     let (_guard, dir) = common::utf8_tempdir();

--- a/crates/nyanpasu-core-manager/tests/orphan_recovery.rs
+++ b/crates/nyanpasu-core-manager/tests/orphan_recovery.rs
@@ -129,7 +129,12 @@ async fn hard_killed_manager_is_reaped_and_all_epoch_artifacts_are_swept() {
     while let Some(entry) = entries.next_entry().await.unwrap() {
         leftovers.push(entry.file_name().to_string_lossy().into_owned());
     }
-    assert_eq!(leftovers, [".manager.lock"], "unswept artifacts");
+    // `logs` is the JSONL sink's directory, created by the recovery manager
+    // above; it holds no epoch artifacts and the sweep must leave it alone.
+    // Sorted because directory order is not a guarantee once there is more than
+    // one entry.
+    leftovers.sort();
+    assert_eq!(leftovers, [".manager.lock", "logs"], "unswept artifacts");
 
     manager
         .start(common::mihomo_spec(&dir, config))

--- a/crates/nyanpasu-core-metadata/Cargo.toml
+++ b/crates/nyanpasu-core-metadata/Cargo.toml
@@ -12,3 +12,6 @@ schemars = { version = "1", features = ["derive"] }
 semver = { version = "1", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 specta = { version = "^2.0.0-rc.25", features = ["derive"] }
+
+[dev-dependencies]
+serde_json = "1"

--- a/crates/nyanpasu-core-metadata/src/dist.rs
+++ b/crates/nyanpasu-core-metadata/src/dist.rs
@@ -1,0 +1,224 @@
+//! Identity of a *distributed* core artifact, as the resource layer knows it.
+//!
+//! [`ClashCoreKind`] is the behavioral axis alone — the family whose console
+//! layout and config semantics the service dispatches on. Which build of that
+//! family is installed (release channel, compile variant, anything a future
+//! manifest invents) is a separate, open question, and this module mirrors how
+//! the resources manifest answers it: a variant's semantic identity is its exact
+//! tag set, not a fixed list of columns.
+
+use std::collections::BTreeSet;
+
+use serde::{Deserialize, Serialize};
+use specta::Type;
+
+use crate::ClashCoreKind;
+
+/// One variant tag, mirroring the manifest's `ResourceTag.id`: `group:value`
+/// with a single colon, or a bare `value` with no group.
+///
+/// The vocabulary is open by construction. Manifests are fetched at runtime and
+/// evolve faster than this crate ships, so an unknown tag must decode, compare,
+/// hash, sort and round-trip rather than fail. Normalization (trim, ASCII
+/// lowercase) happens on construction *and* on decode, which is what lets
+/// equality stay plain string equality.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Type, Serialize, Deserialize)]
+#[serde(from = "String")]
+#[specta(transparent)]
+pub struct VariantTag(String);
+
+impl VariantTag {
+    /// The one tag group the service itself has a name for. Values inside it
+    /// stay open, and compile-variant groups (`goamd64`, …) are deliberately not
+    /// named here: that vocabulary belongs to the manifest and is still settling.
+    pub const GROUP_CHANNEL: &'static str = "channel";
+
+    pub fn new(tag: impl AsRef<str>) -> Self {
+        Self(tag.as_ref().trim().to_ascii_lowercase())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// The part before the first `:`, if the tag is grouped.
+    pub fn group(&self) -> Option<&str> {
+        self.0.split_once(':').map(|(group, _)| group)
+    }
+
+    /// The part after the first `:`, or the whole tag when it carries no group.
+    pub fn value(&self) -> &str {
+        self.0
+            .split_once(':')
+            .map_or(self.0.as_str(), |(_, value)| value)
+    }
+}
+
+impl From<String> for VariantTag {
+    fn from(tag: String) -> Self {
+        Self::new(tag)
+    }
+}
+
+impl std::fmt::Display for VariantTag {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// Which distributed artifact is installed: the closed behavioral family plus
+/// the manifest's open variant identity.
+///
+/// A runtime identity handshake, not a mirror of the manifest schema —
+/// registries, mirrors, checksums and version plans stay in the manifest layer.
+/// It is also deliberately not what a [`crate::LogFrame`] carries: console
+/// output can only ever evidence the family.
+///
+/// The canonical `tag_key` is not carried and not re-derived. That key is the
+/// manifest generator's own normalization, and reimplementing it here would give
+/// two algorithms one chance each to drift; comparing tag sets needs neither.
+#[derive(Debug, Clone, PartialEq, Eq, Type, Serialize, Deserialize)]
+pub struct CoreDistribution {
+    pub kind: ClashCoreKind,
+    /// The manifest variant's stable alias (`ResourceVariant.id`), e.g.
+    /// `"alpha-goamd64-v2"`. A display and reference handle only — the semantic
+    /// identity is [`Self::tags`], exactly as in the manifest.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[specta(optional)]
+    pub variant: Option<String>,
+    /// The variant's exact tag set. Sorted and deduplicated by construction, so
+    /// equality is order-independent the way the manifest's `tag_key` is. Empty
+    /// means untagged or unknown provenance.
+    #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
+    #[specta(optional)]
+    pub tags: BTreeSet<VariantTag>,
+}
+
+impl CoreDistribution {
+    pub fn new(kind: ClashCoreKind) -> Self {
+        Self {
+            kind,
+            variant: None,
+            tags: BTreeSet::new(),
+        }
+    }
+
+    /// The first tag value in `group`, in sorted tag order.
+    pub fn tag_value(&self, group: &str) -> Option<&str> {
+        self.tags
+            .iter()
+            .find(|tag| tag.group() == Some(group))
+            .map(VariantTag::value)
+    }
+
+    /// Convenience for the one well-known group.
+    pub fn channel(&self) -> Option<&str> {
+        self.tag_value(VariantTag::GROUP_CHANNEL)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tag(value: &str) -> VariantTag {
+        VariantTag::new(value)
+    }
+
+    #[test]
+    fn tags_normalize_on_construction_and_on_decode() {
+        assert_eq!(tag("  Channel:ALPHA  ").as_str(), "channel:alpha");
+        assert_eq!(
+            serde_json::from_str::<VariantTag>(r#""  Channel:ALPHA  ""#).unwrap(),
+            tag("channel:alpha")
+        );
+        // Transparent on the wire: a tag is a string, not a wrapper object.
+        assert_eq!(
+            serde_json::to_string(&tag("channel:alpha")).unwrap(),
+            r#""channel:alpha""#
+        );
+    }
+
+    #[test]
+    fn tags_split_on_the_first_colon_only() {
+        let grouped = tag("channel:alpha");
+        assert_eq!(grouped.group(), Some("channel"));
+        assert_eq!(grouped.value(), "alpha");
+
+        let bare = tag("portable");
+        assert_eq!(bare.group(), None);
+        assert_eq!(bare.value(), "portable");
+
+        let nested = tag("future:one:two");
+        assert_eq!(nested.group(), Some("future"));
+        assert_eq!(nested.value(), "one:two");
+    }
+
+    /// The whole point of the open vocabulary: a group this crate has never
+    /// heard of has to survive a decode/encode cycle unchanged.
+    #[test]
+    fn an_unknown_tag_group_round_trips_instead_of_failing() {
+        let decoded = serde_json::from_str::<BTreeSet<VariantTag>>(
+            r#"["vendor:zeta","future:neon","vendor:zeta"]"#,
+        )
+        .unwrap();
+        assert_eq!(decoded.len(), 2, "the set deduplicates on decode");
+        assert!(decoded.contains(&tag("future:neon")));
+        assert_eq!(
+            serde_json::to_string(&decoded).unwrap(),
+            r#"["future:neon","vendor:zeta"]"#
+        );
+    }
+
+    #[test]
+    fn a_distribution_encodes_its_three_states() {
+        let untagged = CoreDistribution::new(ClashCoreKind::Mihomo);
+        assert_eq!(
+            serde_json::to_string(&untagged).unwrap(),
+            r#"{"kind":"mihomo"}"#,
+            "an empty tag set and a missing alias are both omitted"
+        );
+        assert_eq!(
+            serde_json::from_str::<CoreDistribution>(r#"{"kind":"mihomo"}"#).unwrap(),
+            untagged
+        );
+
+        let full = CoreDistribution {
+            kind: ClashCoreKind::Mihomo,
+            variant: Some("alpha-goamd64-v2".to_owned()),
+            tags: BTreeSet::from([tag("channel:alpha"), tag("goamd64:v2")]),
+        };
+        let encoded = serde_json::to_string(&full).unwrap();
+        assert_eq!(
+            encoded,
+            r#"{"kind":"mihomo","variant":"alpha-goamd64-v2","tags":["channel:alpha","goamd64:v2"]}"#
+        );
+        assert_eq!(
+            serde_json::from_str::<CoreDistribution>(&encoded).unwrap(),
+            full
+        );
+
+        let unknown =
+            serde_json::from_str::<CoreDistribution>(r#"{"kind":"clash-rs","tags":["Future:X"]}"#)
+                .unwrap();
+        assert_eq!(unknown.kind, ClashCoreKind::ClashRust);
+        assert!(unknown.tags.contains(&tag("future:x")));
+    }
+
+    #[test]
+    fn a_distribution_answers_channel_and_arbitrary_group_queries() {
+        let distribution = CoreDistribution {
+            kind: ClashCoreKind::Mihomo,
+            variant: Some("alpha-goamd64-v3".to_owned()),
+            tags: BTreeSet::from([tag("channel:alpha"), tag("goamd64:v3"), tag("portable")]),
+        };
+
+        assert_eq!(distribution.channel(), Some("alpha"));
+        assert_eq!(distribution.tag_value("goamd64"), Some("v3"));
+        assert_eq!(distribution.tag_value("missing"), None);
+        // An ungrouped tag belongs to no group and answers no group query.
+        assert_eq!(distribution.tag_value("portable"), None);
+
+        assert_eq!(CoreDistribution::new(ClashCoreKind::Meow).channel(), None);
+    }
+}

--- a/crates/nyanpasu-core-metadata/src/lib.rs
+++ b/crates/nyanpasu-core-metadata/src/lib.rs
@@ -1,8 +1,12 @@
+mod dist;
 mod feature;
 mod kind;
+mod log;
 
+pub use dist::{CoreDistribution, VariantTag};
 pub use feature::{
     clash::{Feature, FeatureSupport},
     *,
 };
 pub use kind::*;
+pub use log::{LogField, LogFrame, LogLevel, LogStream, LogTimestamp};

--- a/crates/nyanpasu-core-metadata/src/log.rs
+++ b/crates/nyanpasu-core-metadata/src/log.rs
@@ -1,0 +1,86 @@
+//! The canonical shape of one normalized core console record.
+//!
+//! Lives here rather than in the core manager because three layers need the
+//! same type: the parser that produces it, the JSONL archive that flattens it
+//! onto disk, and the IPC event that pushes it to a client. Every representation
+//! that used to project this shape has been retired.
+
+use serde::{Deserialize, Serialize};
+use specta::Type;
+
+use crate::ClashCoreKind;
+
+/// Normalized severity. Go's `fatal` and `panic` both terminate the process, so
+/// they collapse into `Fatal`; the original spelling survives in
+/// [`LogFrame::raw`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Type, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum LogLevel {
+    Trace,
+    Debug,
+    Info,
+    Warning,
+    Error,
+    Fatal,
+}
+
+/// Which console stream a record arrived on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Type, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum LogStream {
+    Stdout,
+    Stderr,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Type, Serialize, Deserialize)]
+pub struct LogTimestamp {
+    /// Exactly as the core printed it.
+    pub raw: String,
+    /// Unix milliseconds, when the printed instant resolves to one.
+    pub unix_ms: Option<i64>,
+    /// The date or the zone offset came from the observation instant because the
+    /// core did not print one (clash premium and clash-rs).
+    pub inferred: bool,
+}
+
+/// One structured field the core printed beside its message.
+#[derive(Debug, Clone, PartialEq, Eq, Type, Serialize, Deserialize)]
+pub struct LogField {
+    pub key: String,
+    pub value: String,
+}
+
+/// One normalized core console record.
+///
+/// Bounded on every free-text field — but that is a *provenance* invariant, held
+/// by the parser that builds these, not a property of the type. Nothing stops a
+/// decoded or hand-built frame from carrying an arbitrarily long message.
+///
+/// The field order is the on-disk JSONL order: the archive flattens this struct
+/// straight into its envelope.
+#[derive(Debug, Clone, PartialEq, Eq, Type, Serialize, Deserialize)]
+pub struct LogFrame {
+    /// Unix milliseconds at which the parser observed the record's **root**
+    /// line. Always present, which is what makes a stream of frames sortable: a
+    /// line whose header did not parse has no clock of its own, and clash
+    /// premium's and clash-rs's are inferred. A multi-line record keeps the
+    /// instant of the line that opened it.
+    pub at: i64,
+    pub epoch: u64,
+    pub kind: ClashCoreKind,
+    pub stream: LogStream,
+    pub level: LogLevel,
+    pub timestamp: Option<LogTimestamp>,
+    /// clash premium's `[Tag]` prefix (a message convention, not a field), meow's
+    /// tracing target, or clash-rs's `file:line`.
+    pub target: Option<String>,
+    pub message: String,
+    /// Filled only where field boundaries are decidable, which today means
+    /// mihomo's quoted logfmt.
+    pub fields: Vec<LogField>,
+    /// The whole logical record with ANSI removed, continuations included.
+    pub raw: String,
+    /// Content was dropped at the parser boundary, either because continuations
+    /// stopped fitting or because a single value exceeded its cap.
+    pub truncated: bool,
+}

--- a/crates/nyanpasu-service-runtime/Cargo.toml
+++ b/crates/nyanpasu-service-runtime/Cargo.toml
@@ -30,6 +30,7 @@ nyanpasu-utils = {
   path = "../nyanpasu-utils",
   default-features = false,
   features = [
+    "atomic_fs",
     "dirs",
     "network",
     "os",
@@ -56,7 +57,6 @@ constcat = "0.6.0"
 ctrlc = { version = "3", features = ["termination"] }
 dunce = "1.0.5"
 futures-util = { workspace = true }
-indexmap = { version = "2", features = ["serde"] }
 oneshot = "0.2"
 parking_lot = "0.12"
 semver = "1"

--- a/crates/nyanpasu-service-runtime/src/logging.rs
+++ b/crates/nyanpasu-service-runtime/src/logging.rs
@@ -169,6 +169,20 @@ mod tests {
         assert!(error.to_string().contains("not a plain directory"));
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn a_symlink_is_rejected_as_the_service_log_directory() {
+        let guard = tempfile::tempdir().unwrap();
+        let real = guard.path().join("real");
+        let path = guard.path().join("logs");
+        fs::create_dir(&real).unwrap();
+        std::os::unix::fs::symlink(&real, &path).unwrap();
+
+        let error = ensure_plain_dir(&path).unwrap_err();
+
+        assert!(error.to_string().contains("not a plain directory"));
+    }
+
     /// The directory `/status` advertises must not be world-readable. The
     /// Windows half also pins why the call is explicit: `verify` rejects an
     /// inherited DACL, so a directory that merely sits inside a protected

--- a/crates/nyanpasu-service-runtime/src/logging.rs
+++ b/crates/nyanpasu-service-runtime/src/logging.rs
@@ -26,8 +26,9 @@ pub fn init(debug: bool, write_file: bool) -> anyhow::Result<()> {
     if write_file {
         let log_dir = crate::utils::dirs::service_logs_dir();
         if !log_dir.exists() {
-            let _ = fs::create_dir_all(&log_dir);
+            fs::create_dir_all(&log_dir)?;
         }
+        harden_log_dir(&log_dir)?;
     }
     let (log_level, log_max_files) = {
         (
@@ -97,4 +98,66 @@ pub fn init(debug: bool, write_file: bool) -> anyhow::Result<()> {
     };
 
     Ok(())
+}
+
+/// Restrict the service log directory to the account the service runs under,
+/// the way the manager's runtime directory already is.
+///
+/// `/status` publishes this path from L3 onward, and advertising a location is
+/// a good moment to be sure of its permissions. On Windows the DACL is set
+/// explicitly rather than inherited: an inherited descriptor does not carry
+/// `SE_DACL_PROTECTED`, which is exactly what the verifier requires.
+///
+/// The writer is unaffected — the DACL grants SYSTEM full access and the
+/// service runs elevated. Readers are affected, deliberately: see
+/// `LogPathsInfo`'s rustdoc.
+fn harden_log_dir(dir: &std::path::Path) -> Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(dir, fs::Permissions::from_mode(0o700))
+            .map_err(|error| anyhow!("failed to protect the service log directory: {error}"))?;
+    }
+    #[cfg(windows)]
+    {
+        use nyanpasu_utils::io::atomic_fs::{
+            harden_windows_directory_acl, verify_windows_directory_acl,
+        };
+        harden_windows_directory_acl(dir)
+            .map_err(|error| anyhow!("failed to protect the service log directory: {error}"))?;
+        verify_windows_directory_acl(dir)
+            .map_err(|error| anyhow!("the service log directory is not protected: {error}"))?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The directory `/status` advertises must not be world-readable. The
+    /// Windows half also pins why the call is explicit: `verify` rejects an
+    /// inherited DACL, so a directory that merely sits inside a protected
+    /// parent would fail this.
+    #[test]
+    fn the_service_log_directory_is_owner_only() {
+        let guard = tempfile::tempdir().unwrap();
+        let dir = guard.path().join("logs");
+        fs::create_dir_all(&dir).unwrap();
+
+        harden_log_dir(&dir).unwrap();
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                fs::metadata(&dir).unwrap().permissions().mode() & 0o777,
+                0o700
+            );
+        }
+        #[cfg(windows)]
+        {
+            nyanpasu_utils::io::atomic_fs::verify_windows_directory_acl(&dir).unwrap();
+        }
+    }
 }

--- a/crates/nyanpasu-service-runtime/src/logging.rs
+++ b/crates/nyanpasu-service-runtime/src/logging.rs
@@ -1,5 +1,5 @@
 use anyhow::{Result, anyhow};
-use std::{fs, io::IsTerminal, sync::OnceLock};
+use std::{fs, io::IsTerminal, path::Path, sync::OnceLock};
 use tracing::level_filters::LevelFilter;
 use tracing_appender::{
     non_blocking::{NonBlocking, WorkerGuard},
@@ -25,9 +25,7 @@ fn get_file_appender(max_files: usize) -> Result<(NonBlocking, WorkerGuard)> {
 pub fn init(debug: bool, write_file: bool) -> anyhow::Result<()> {
     if write_file {
         let log_dir = crate::utils::dirs::service_logs_dir();
-        if !log_dir.exists() {
-            fs::create_dir_all(&log_dir)?;
-        }
+        ensure_plain_dir(&log_dir)?;
         harden_log_dir(&log_dir)?;
     }
     let (log_level, log_max_files) = {
@@ -100,6 +98,27 @@ pub fn init(debug: bool, write_file: bool) -> anyhow::Result<()> {
     Ok(())
 }
 
+fn ensure_plain_dir(dir: &Path) -> Result<()> {
+    match fs::symlink_metadata(dir) {
+        Ok(metadata)
+            if metadata.file_type().is_symlink()
+                || nyanpasu_utils::io::atomic_fs::is_reparse_point(&metadata)
+                || !metadata.is_dir() =>
+        {
+            Err(anyhow!(
+                "service log path is not a plain directory: {}",
+                dir.display()
+            ))
+        }
+        Ok(_) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            fs::create_dir_all(dir)?;
+            Ok(())
+        }
+        Err(error) => Err(error.into()),
+    }
+}
+
 /// Restrict the service log directory to the account the service runs under,
 /// the way the manager's runtime directory already is.
 ///
@@ -111,6 +130,10 @@ pub fn init(debug: bool, write_file: bool) -> anyhow::Result<()> {
 /// The writer is unaffected — the DACL grants SYSTEM full access and the
 /// service runs elevated. Readers are affected, deliberately: see
 /// `LogPathsInfo`'s rustdoc.
+///
+/// Ownership of a pre-existing directory is not verified here: the shared
+/// helpers accept the current owner. Tightening that requires a
+/// `nyanpasu-utils` change and is tracked as a follow-up.
 fn harden_log_dir(dir: &std::path::Path) -> Result<()> {
     #[cfg(unix)]
     {
@@ -134,6 +157,17 @@ fn harden_log_dir(dir: &std::path::Path) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn a_regular_file_is_rejected_as_the_service_log_directory() {
+        let guard = tempfile::tempdir().unwrap();
+        let path = guard.path().join("logs");
+        fs::write(&path, b"not a directory").unwrap();
+
+        let error = ensure_plain_dir(&path).unwrap_err();
+
+        assert!(error.to_string().contains("not a plain directory"));
+    }
 
     /// The directory `/status` advertises must not be world-readable. The
     /// Windows half also pins why the call is explicit: `verify` rejects an

--- a/crates/nyanpasu-service-runtime/src/server/events.rs
+++ b/crates/nyanpasu-service-runtime/src/server/events.rs
@@ -57,6 +57,10 @@ impl EventHub {
         let _ = self.log_tx.send(event);
     }
 
+    pub(crate) fn has_log_subscribers(&self) -> bool {
+        self.log_tx.receiver_count() > 0
+    }
+
     pub fn subscribe_logs(&self) -> broadcast::Receiver<Event> {
         self.log_tx.subscribe()
     }
@@ -238,9 +242,11 @@ mod tests {
         let _status = hub.subscribe();
         assert_eq!(hub.receiver_count(), 1);
         assert_eq!(hub.log_receiver_count(), 0);
+        assert!(!hub.has_log_subscribers());
         let _logs = hub.subscribe_logs();
         assert_eq!(hub.receiver_count(), 1);
         assert_eq!(hub.log_receiver_count(), 1);
+        assert!(hub.has_log_subscribers());
     }
 
     /// The point of the whole stage: a log burst big enough to overrun its own

--- a/crates/nyanpasu-service-runtime/src/server/events.rs
+++ b/crates/nyanpasu-service-runtime/src/server/events.rs
@@ -13,17 +13,6 @@ const EVENT_CHANNEL_CAPACITY: usize = 256;
 /// a record the resident ceiling is a few hundred KiB.
 const LOG_EVENT_CHANNEL_CAPACITY: usize = 1024;
 
-/// Tracing target for ws-lag diagnostics. Log lines with this target must
-/// never be forwarded into the EventHub: a lag warning that re-enters the
-/// ring it just overflowed would let many slow connections feed each other
-/// a log storm (feedback ratio ~ connections / capacity).
-pub(crate) const WS_LAG_LOG_TARGET: &str = "nyanpasu_service::ws::lag";
-
-/// Filter applied by the log-forwarding subscriber before `EventHub::send`.
-pub(crate) fn should_forward_to_hub(target: &str) -> bool {
-    target != WS_LAG_LOG_TARGET
-}
-
 /// Fan-out point for ws events. Cloning shares both channels.
 ///
 /// Two rings, not one, because a subscriber that falls behind must be able to
@@ -53,8 +42,7 @@ impl EventHub {
     /// Fan out an event: synchronous and never awaits; only brief internal
     /// channel locking. It is unaffected by slow subscribers. `send` fails only
     /// when nobody is subscribed, which is the normal idle state, so the result
-    /// is dropped. It must never be logged: the log-forwarding subscriber calls
-    /// this from inside the tracing writer.
+    /// is dropped.
     pub fn send(&self, event: Event) {
         let _ = self.tx.send(event);
     }
@@ -65,8 +53,6 @@ impl EventHub {
 
     /// Fan out one [`Event::CoreLog`]. Same contract as [`Self::send`] —
     /// synchronous, never awaits, and a failure just means nobody is listening.
-    /// Kept non-logging for the same reason: a log line about the log stream is
-    /// the one thing that can feed itself.
     pub fn send_log(&self, event: Event) {
         let _ = self.log_tx.send(event);
     }
@@ -132,16 +118,18 @@ mod tests {
 
     #[tokio::test]
     async fn lag_recovery_with_feedback_reaches_the_tail() {
-        // Models the production hazard: recovering from Lagged itself feeds one
-        // more event back into a full ring (the warn log). The resubscribe jump
-        // must land at the tail with no residual Lagged and no spin.
+        // Models a subscriber that fell behind: the resubscribe jump must land
+        // at the tail with no residual Lagged and no spin. The feedback this
+        // once guarded against — a lag warning re-entering the ring it had just
+        // overflowed — is structurally gone, because no tracing output becomes
+        // an event any more.
         let hub = EventHub::new();
         let mut lagged = hub.subscribe();
         for _ in 0..(EVENT_CHANNEL_CAPACITY * 2) {
             hub.send(state_event(CoreState::Running));
         }
         assert!(matches!(lagged.try_recv(), Err(TryRecvError::Lagged(_))));
-        // The ws handler's recovery sequence: warn (feeds back into the hub)…
+        // One more event arrives during recovery…
         hub.send(state_event(CoreState::Running)); // stand-in for the warn log event
         // …then jump to the tail.
         let mut recovered = lagged.resubscribe();
@@ -166,12 +154,6 @@ mod tests {
     #[test]
     fn sending_without_subscribers_is_not_an_error() {
         EventHub::new().send(state_event(CoreState::Running));
-    }
-
-    #[test]
-    fn lag_diagnostics_are_never_forwarded_to_the_hub() {
-        assert!(!should_forward_to_hub(WS_LAG_LOG_TARGET));
-        assert!(should_forward_to_hub("nyanpasu_service::server"));
     }
 
     /// The ws handler frames events with simd_json; the bytes on the socket

--- a/crates/nyanpasu-service-runtime/src/server/events.rs
+++ b/crates/nyanpasu-service-runtime/src/server/events.rs
@@ -5,6 +5,14 @@ use tokio::sync::broadcast;
 /// this is told how many it lost instead of stalling the broadcast.
 const EVENT_CHANNEL_CAPACITY: usize = 256;
 
+/// Core log frames buffered per subscriber. Four times the status ring, and the
+/// reason is not a traffic estimate: the two streams fail differently. Dropping
+/// a status frame costs a full snapshot resend, so that ring is sized to be
+/// cheap to resynchronise; dropping a log line costs nothing, so this one is
+/// sized to swallow a core's start-up burst outright. At roughly 200-400 bytes
+/// a record the resident ceiling is a few hundred KiB.
+const LOG_EVENT_CHANNEL_CAPACITY: usize = 1024;
+
 /// Tracing target for ws-lag diagnostics. Log lines with this target must
 /// never be forwarded into the EventHub: a lag warning that re-enters the
 /// ring it just overflowed would let many slow connections feed each other
@@ -16,10 +24,16 @@ pub(crate) fn should_forward_to_hub(target: &str) -> bool {
     target != WS_LAG_LOG_TARGET
 }
 
-/// Fan-out point for ws events. Cloning shares the one channel.
+/// Fan-out point for ws events. Cloning shares both channels.
+///
+/// Two rings, not one, because a subscriber that falls behind must be able to
+/// lose a log line without paying for a status resynchronisation. Sharing one
+/// ring makes the two indistinguishable, so every loss has to be handled as if
+/// it were the expensive kind.
 #[derive(Clone)]
 pub struct EventHub {
     tx: broadcast::Sender<Event>,
+    log_tx: broadcast::Sender<Event>,
 }
 
 impl Default for EventHub {
@@ -32,6 +46,7 @@ impl EventHub {
     pub fn new() -> Self {
         Self {
             tx: broadcast::channel(EVENT_CHANNEL_CAPACITY).0,
+            log_tx: broadcast::channel(LOG_EVENT_CHANNEL_CAPACITY).0,
         }
     }
 
@@ -48,16 +63,36 @@ impl EventHub {
         self.tx.subscribe()
     }
 
+    /// Fan out one [`Event::CoreLog`]. Same contract as [`Self::send`] —
+    /// synchronous, never awaits, and a failure just means nobody is listening.
+    /// Kept non-logging for the same reason: a log line about the log stream is
+    /// the one thing that can feed itself.
+    pub fn send_log(&self, event: Event) {
+        let _ = self.log_tx.send(event);
+    }
+
+    pub fn subscribe_logs(&self) -> broadcast::Receiver<Event> {
+        self.log_tx.subscribe()
+    }
+
     #[cfg(test)]
     fn receiver_count(&self) -> usize {
         self.tx.receiver_count()
+    }
+
+    #[cfg(test)]
+    fn log_receiver_count(&self) -> usize {
+        self.log_tx.receiver_count()
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use nyanpasu_ipc::api::status::{CoreInfos, CoreState, CoreStateDetail};
+    use nyanpasu_ipc::api::{
+        status::{CoreInfos, CoreState, CoreStateDetail},
+        ws::events::{CoreLogField, CoreLogInfo, CoreLogKind, CoreLogLevel, CoreLogStream},
+    };
     use tokio::sync::broadcast::error::TryRecvError;
 
     fn state_event(state: CoreState) -> Event {
@@ -175,5 +210,81 @@ mod tests {
                 r#""detail":{"Stopped":{"reason":null}}}}"#
             )
         );
+    }
+
+    fn core_log_event() -> Event {
+        Event::new_core_log(CoreLogInfo {
+            epoch: 1,
+            kind: CoreLogKind::Mihomo,
+            stream: CoreLogStream::Stdout,
+            level: CoreLogLevel::Info,
+            at: 1_700_000_000_000,
+            timestamp_ms: Some(1_753_719_382_646),
+            target: None,
+            message: "hello core".to_owned(),
+            fields: vec![CoreLogField {
+                key: "request".to_owned(),
+                value: "7".to_owned(),
+            }],
+            truncated: false,
+        })
+    }
+
+    /// Byte-for-byte the literal `nyanpasu_ipc`'s `the_core_log_event_is_pinned`
+    /// asserts against `serde_json`. The service writes the socket with
+    /// `simd_json` and the client decodes with `serde_json`; the two must agree.
+    #[test]
+    fn ws_core_log_frames_are_pinned() {
+        let frame = simd_json::to_vec(&core_log_event()).unwrap();
+        assert_eq!(
+            String::from_utf8(frame).unwrap(),
+            concat!(
+                r#"{"CoreLog":{"epoch":1,"kind":"mihomo","stream":"stdout","level":"info","#,
+                r#""at":1700000000000,"timestamp_ms":1753719382646,"target":null,"#,
+                r#""message":"hello core","fields":[{"key":"request","value":"7"}],"#,
+                r#""truncated":false}}"#
+            )
+        );
+    }
+
+    /// The two rings are separate objects, so a subscriber to one is not a
+    /// subscriber to the other. Without this, `send_log` would reach the status
+    /// stream and the split would be decorative.
+    #[test]
+    fn the_two_rings_have_independent_subscribers() {
+        let hub = EventHub::new();
+        let _status = hub.subscribe();
+        assert_eq!(hub.receiver_count(), 1);
+        assert_eq!(hub.log_receiver_count(), 0);
+        let _logs = hub.subscribe_logs();
+        assert_eq!(hub.receiver_count(), 1);
+        assert_eq!(hub.log_receiver_count(), 1);
+    }
+
+    /// The point of the whole stage: a log burst big enough to overrun its own
+    /// ring several times over leaves the status subscriber untouched. On one
+    /// ring this same burst would have forced a `Lagged`, and the ws handler
+    /// answers a status `Lagged` with a full snapshot resend — so a chatty core
+    /// would have driven a resynchronisation loop.
+    #[tokio::test]
+    async fn a_log_burst_never_lags_the_status_ring() {
+        let hub = EventHub::new();
+        let mut status = hub.subscribe();
+        let mut logs = hub.subscribe_logs();
+        hub.send(state_event(CoreState::Running));
+        // Twice the ring, matching the convention the two tests above use.
+        for _ in 0..(LOG_EVENT_CHANNEL_CAPACITY * 2) {
+            hub.send_log(core_log_event());
+        }
+
+        // The status subscriber still sees its one event, in order, un-lagged.
+        assert!(matches!(
+            status.try_recv().unwrap(),
+            Event::CoreStateChanged(CoreState::Running)
+        ));
+        assert!(matches!(status.try_recv(), Err(TryRecvError::Empty)));
+        // The log subscriber is the only one that paid, and it paid in log
+        // frames — which is free, by design.
+        assert!(matches!(logs.try_recv(), Err(TryRecvError::Lagged(_))));
     }
 }

--- a/crates/nyanpasu-service-runtime/src/server/events.rs
+++ b/crates/nyanpasu-service-runtime/src/server/events.rs
@@ -1,3 +1,6 @@
+use std::sync::Arc;
+
+use nyanpasu_core_manager::LogFrame;
 use nyanpasu_ipc::api::ws::events::Event;
 use tokio::sync::broadcast;
 
@@ -22,7 +25,9 @@ const LOG_EVENT_CHANNEL_CAPACITY: usize = 1024;
 #[derive(Clone)]
 pub struct EventHub {
     tx: broadcast::Sender<Event>,
-    log_tx: broadcast::Sender<Event>,
+    /// Frames, not events: the ring holds what the manager produced, and the
+    /// `Event` wrapper is built per connection at send time.
+    log_tx: broadcast::Sender<Arc<LogFrame>>,
 }
 
 impl Default for EventHub {
@@ -51,17 +56,17 @@ impl EventHub {
         self.tx.subscribe()
     }
 
-    /// Fan out one [`Event::CoreLog`]. Same contract as [`Self::send`] —
+    /// Fan out one core log frame. Same contract as [`Self::send`] —
     /// synchronous, never awaits, and a failure just means nobody is listening.
-    pub fn send_log(&self, event: Event) {
-        let _ = self.log_tx.send(event);
+    pub fn send_log(&self, frame: Arc<LogFrame>) {
+        let _ = self.log_tx.send(frame);
     }
 
     pub(crate) fn has_log_subscribers(&self) -> bool {
         self.log_tx.receiver_count() > 0
     }
 
-    pub fn subscribe_logs(&self) -> broadcast::Receiver<Event> {
+    pub fn subscribe_logs(&self) -> broadcast::Receiver<Arc<LogFrame>> {
         self.log_tx.subscribe()
     }
 
@@ -79,10 +84,8 @@ impl EventHub {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use nyanpasu_ipc::api::{
-        status::{CoreInfos, CoreState, CoreStateDetail},
-        ws::events::{CoreLogField, CoreLogInfo, CoreLogKind, CoreLogLevel, CoreLogStream},
-    };
+    use nyanpasu_core_manager::{CoreKind, LogField, LogLevel, LogStream, LogTimestamp};
+    use nyanpasu_ipc::api::status::{CoreInfos, CoreState, CoreStateDetail};
     use tokio::sync::broadcast::error::TryRecvError;
 
     fn state_event(state: CoreState) -> Event {
@@ -198,20 +201,26 @@ mod tests {
         );
     }
 
-    fn core_log_event() -> Event {
-        Event::new_core_log(CoreLogInfo {
-            epoch: 1,
-            kind: CoreLogKind::Mihomo,
-            stream: CoreLogStream::Stdout,
-            level: CoreLogLevel::Info,
+    fn core_log_frame() -> Arc<LogFrame> {
+        Arc::new(LogFrame {
             at: 1_700_000_000_000,
-            timestamp_ms: Some(1_753_719_382_646),
+            epoch: 1,
+            kind: CoreKind::Mihomo,
+            stream: LogStream::Stdout,
+            level: LogLevel::Info,
+            timestamp: Some(LogTimestamp {
+                raw: "2026-07-29T00:16:22.646059400+08:00".to_owned(),
+                unix_ms: Some(1_753_719_382_646),
+                inferred: false,
+            }),
             target: None,
             message: "hello core".to_owned(),
-            fields: vec![CoreLogField {
+            fields: vec![LogField {
                 key: "request".to_owned(),
                 value: "7".to_owned(),
             }],
+            raw: "time=\"2026-07-29T00:16:22.646059400+08:00\" level=info msg=\"hello core\" request=7"
+                .to_owned(),
             truncated: false,
         })
     }
@@ -221,14 +230,16 @@ mod tests {
     /// `simd_json` and the client decodes with `serde_json`; the two must agree.
     #[test]
     fn ws_core_log_frames_are_pinned() {
-        let frame = simd_json::to_vec(&core_log_event()).unwrap();
+        let payload = simd_json::to_vec(&Event::new_core_log(core_log_frame())).unwrap();
         assert_eq!(
-            String::from_utf8(frame).unwrap(),
+            String::from_utf8(payload).unwrap(),
             concat!(
-                r#"{"CoreLog":{"epoch":1,"kind":"mihomo","stream":"stdout","level":"info","#,
-                r#""at":1700000000000,"timestamp_ms":1753719382646,"target":null,"#,
+                r#"{"CoreLog":{"at":1700000000000,"epoch":1,"kind":"mihomo","stream":"stdout","#,
+                r#""level":"info","timestamp":{"raw":"2026-07-29T00:16:22.646059400+08:00","#,
+                r#""unix_ms":1753719382646,"inferred":false},"target":null,"#,
                 r#""message":"hello core","fields":[{"key":"request","value":"7"}],"#,
-                r#""truncated":false}}"#
+                r#""raw":"time=\"2026-07-29T00:16:22.646059400+08:00\" level=info "#,
+                r#"msg=\"hello core\" request=7","truncated":false}}"#
             )
         );
     }
@@ -243,10 +254,18 @@ mod tests {
         assert_eq!(hub.receiver_count(), 1);
         assert_eq!(hub.log_receiver_count(), 0);
         assert!(!hub.has_log_subscribers());
-        let _logs = hub.subscribe_logs();
+        let mut logs = hub.subscribe_logs();
         assert_eq!(hub.receiver_count(), 1);
         assert_eq!(hub.log_receiver_count(), 1);
         assert!(hub.has_log_subscribers());
+
+        // The ring shares the manager's allocation rather than copying it.
+        let frame = core_log_frame();
+        hub.send_log(Arc::clone(&frame));
+        assert!(Arc::ptr_eq(
+            &frame,
+            &logs.try_recv().expect("the frame arrives")
+        ));
     }
 
     /// The point of the whole stage: a log burst big enough to overrun its own
@@ -262,7 +281,7 @@ mod tests {
         hub.send(state_event(CoreState::Running));
         // Twice the ring, matching the convention the two tests above use.
         for _ in 0..(LOG_EVENT_CHANNEL_CAPACITY * 2) {
-            hub.send_log(core_log_event());
+            hub.send_log(core_log_frame());
         }
 
         // The status subscriber still sees its one event, in order, un-lagged.

--- a/crates/nyanpasu-service-runtime/src/server/logger.rs
+++ b/crates/nyanpasu-service-runtime/src/server/logger.rs
@@ -4,32 +4,25 @@ use std::{
 };
 
 use bounded_vec_deque::BoundedVecDeque;
-use indexmap::IndexMap;
 use parking_lot::Mutex;
 use tracing_subscriber::fmt::MakeWriter;
 
 const LOG_BUFFER_CAPACITY: usize = 100;
 
-pub type LoggerSubscriber = Box<dyn Fn(TracingLogging) + Send + Sync + 'static>;
-
+/// The in-memory tail `/logs/retrieve` and `/logs/inspect` serve, and the
+/// `MakeWriter` that fills it.
+///
+/// It used to fan every tracing event out to the event hub as well, which is
+/// how the service's own logs reached the socket. That path is gone: the logs
+/// are files, and `/status` reports where.
 pub struct Logger<'n> {
     buffer: Arc<Mutex<BoundedVecDeque<Cow<'n, str>>>>,
-    subscriber: Arc<OnceLock<LoggerSubscriber>>,
-}
-
-#[derive(Debug, serde::Deserialize)]
-pub struct TracingLogging {
-    pub level: String,
-    pub timestamp: String,
-    #[serde(flatten)]
-    pub fields: IndexMap<String, serde_json::Value>,
 }
 
 impl Clone for Logger<'_> {
     fn clone(&self) -> Self {
         Logger {
             buffer: self.buffer.clone(),
-            subscriber: self.subscriber.clone(),
         }
     }
 }
@@ -38,20 +31,12 @@ impl<'n> Logger<'n> {
     pub fn new() -> Self {
         Logger {
             buffer: Arc::new(Mutex::new(BoundedVecDeque::new(LOG_BUFFER_CAPACITY))),
-            subscriber: Arc::new(OnceLock::new()),
         }
     }
 
     pub fn global() -> &'static Logger<'static> {
         static INSTANCE: OnceLock<Logger> = OnceLock::new();
         INSTANCE.get_or_init(Logger::new)
-    }
-
-    pub fn set_subscriber(
-        &self,
-        subscriber: Box<dyn Fn(TracingLogging) + Send + Sync + 'static>,
-    ) -> bool {
-        self.subscriber.set(subscriber).is_ok()
     }
 
     /// Retrieve all logs in the buffer
@@ -78,18 +63,7 @@ impl<'n> Default for Logger<'n> {
 impl std::io::Write for Logger<'_> {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
         let msg = String::from_utf8_lossy(buf);
-        let forward = self.subscriber.get().and_then(|subscriber| {
-            serde_json::from_str::<TracingLogging>(&msg)
-                .ok()
-                .map(|logging| (subscriber, logging))
-        });
         self.buffer.lock().push_back(Cow::Owned(msg.into_owned()));
-        // Outside the lock: the subscriber now fans out to the event hub inline
-        // instead of spawning, so holding the buffer mutex across it would block
-        // every other log writer — and would deadlock outright if it ever logged.
-        if let Some((subscriber, logging)) = forward {
-            subscriber(logging);
-        }
         Ok(buf.len())
     }
 
@@ -104,7 +78,6 @@ impl<'a> MakeWriter<'a> for Logger<'static> {
     fn make_writer(&'a self) -> Self::Writer {
         Logger {
             buffer: self.buffer.clone(),
-            subscriber: self.subscriber.clone(),
         }
     }
 }

--- a/crates/nyanpasu-service-runtime/src/server/manager_bridge.rs
+++ b/crates/nyanpasu-service-runtime/src/server/manager_bridge.rs
@@ -8,8 +8,8 @@ use camino::{Utf8Path, Utf8PathBuf};
 use nyanpasu_core_manager::{
     ApplyOutcome, ConfigRevision, CoreKind, CoreManager as Manager, CoreSpec,
     CoreState as ManagerCoreState, CoreStatus, Error as ManagerError, HealthState, HealthStatus,
-    Host, InstanceOptions, InstanceSpec, LocalIpcPolicy, LogFrame, LogLevel, LogStream,
-    ManagerOptions, RevisionId,
+    Host, InstanceOptions, InstanceSpec, LocalIpcPolicy, LogFrame, LogLevel, ManagerOptions,
+    RevisionId,
 };
 use nyanpasu_ipc::api::{
     R, RBuilder,
@@ -19,9 +19,7 @@ use nyanpasu_ipc::api::{
         ConfigRevisionInfo, CoreControllerInfo, CoreHealthInfo, CoreHealthState, CoreInfos,
         CoreState, CoreStateDetail, RevisionIdInfo,
     },
-    ws::events::{
-        CoreLogField, CoreLogInfo, CoreLogKind, CoreLogLevel, CoreLogStream, Event as WsEvent,
-    },
+    ws::events::Event as WsEvent,
 };
 use nyanpasu_utils::core::{ClashCoreType, CoreType};
 use serde::{Serialize, de::DeserializeOwned};
@@ -31,13 +29,6 @@ use tracing::instrument;
 use super::{consts::RuntimeInfos, events::EventHub};
 
 const CORE_LOG_TARGET: &str = "nyanpasu_service::core";
-
-// These mirror `nyanpasu-core-manager`'s private `log_sink` caps; keep the
-// numbers in sync.
-const MAX_CORE_LOG_TEXT_BYTES: usize = 16 * 1024;
-const MAX_CORE_LOG_TARGET_BYTES: usize = 2048;
-const MAX_CORE_LOG_FIELDS: usize = 64;
-const MAX_CORE_LOG_FIELD_TEXT_BYTES: usize = 1024;
 
 /// Concurrent `/core/check` operations a service will run. Each one spawns a
 /// core binary, so this is a resource bound, not a fairness knob: two lets an
@@ -174,18 +165,16 @@ impl CoreManagerService {
             loop {
                 match logs.recv().await {
                     Ok(frame) => {
-                        // The projection borrows, so `forward_log` still takes
-                        // the frame by value and moves its 16 KiB `raw` instead
-                        // of the stream paying to clone it.
+                        // Nothing is mapped, clamped or copied here: the frame
+                        // the parser bounded is the frame the ws ring gets.
+                        // Tracing borrows it first so the subscription's own
+                        // reference can then be moved on rather than cloned.
                         // A subscriber connecting mid-frame misses that frame,
                         // consistent with the stream's no-replay semantics.
+                        forward_log(&frame);
                         if hub.has_log_subscribers() {
-                            hub.send_log(WsEvent::new_core_log(core_log_info(
-                                &frame,
-                                chrono::Utc::now().timestamp_millis(),
-                            )));
+                            hub.send_log(frame);
                         }
-                        forward_log(frame);
                     }
                     Err(RecvError::Lagged(skipped)) => {
                         tracing::warn!("core log bridge dropped {skipped} frames")
@@ -745,12 +734,12 @@ fn project_core_infos(status: &CoreStatus, requested_core: Option<CoreType>) -> 
 /// level as a field. That also retires a real defect — the level used to come
 /// from the *pipe*, so every stderr line was reported as an error however
 /// harmless it was.
-fn forward_log(frame: LogFrame) {
+fn forward_log(frame: &LogFrame) {
     let kind = frame.kind;
     let epoch = frame.epoch;
     let stream = frame.stream;
     let core_level = frame.level;
-    let raw = frame.raw;
+    let raw = &frame.raw;
     match core_level {
         LogLevel::Trace => {
             tracing::trace!(target: CORE_LOG_TARGET, ?core_level, ?stream, %kind, epoch, "{raw}")
@@ -759,87 +748,6 @@ fn forward_log(frame: LogFrame) {
             tracing::debug!(target: CORE_LOG_TARGET, ?core_level, ?stream, %kind, epoch, "{raw}")
         }
     }
-}
-
-/// The wire projection of one normalized core log frame.
-///
-/// Takes `&LogFrame` so the caller can still hand the owned frame to
-/// [`forward_log`], which moves `raw` — the largest field and the one the
-/// stream deliberately does not carry.
-///
-/// `at` is a parameter rather than a `now()` call inside so the mapping is
-/// testable. It is stamped service-side, at conversion time: the manager's
-/// frame may carry no timestamp at all (a line whose header did not parse) or
-/// an inferred one, so this is the only clock every record is guaranteed to
-/// have.
-fn core_log_info(frame: &LogFrame, at: i64) -> CoreLogInfo {
-    let (message, message_cut) = clamp_core_log_text(&frame.message, MAX_CORE_LOG_TEXT_BYTES);
-    let (target, target_cut) = match frame.target.as_deref() {
-        Some(target) => {
-            let (target, cut) = clamp_core_log_text(target, MAX_CORE_LOG_TARGET_BYTES);
-            (Some(target.to_owned()), cut)
-        }
-        None => (None, false),
-    };
-    let mut fields_cut = frame.fields.len() > MAX_CORE_LOG_FIELDS;
-    let fields = frame
-        .fields
-        .iter()
-        .take(MAX_CORE_LOG_FIELDS)
-        .map(|field| {
-            let (key, key_cut) = clamp_core_log_text(&field.key, MAX_CORE_LOG_FIELD_TEXT_BYTES);
-            let (value, value_cut) =
-                clamp_core_log_text(&field.value, MAX_CORE_LOG_FIELD_TEXT_BYTES);
-            fields_cut |= key_cut || value_cut;
-            CoreLogField {
-                key: key.to_owned(),
-                value: value.to_owned(),
-            }
-        })
-        .collect();
-    CoreLogInfo {
-        epoch: frame.epoch,
-        kind: match frame.kind {
-            CoreKind::Mihomo => CoreLogKind::Mihomo,
-            CoreKind::ClashRust => CoreLogKind::ClashRust,
-            CoreKind::ClashPremium => CoreLogKind::ClashPremium,
-            CoreKind::Meow => CoreLogKind::Meow,
-        },
-        stream: match frame.stream {
-            LogStream::Stdout => CoreLogStream::Stdout,
-            LogStream::Stderr => CoreLogStream::Stderr,
-        },
-        level: match frame.level {
-            LogLevel::Trace => CoreLogLevel::Trace,
-            LogLevel::Debug => CoreLogLevel::Debug,
-            LogLevel::Info => CoreLogLevel::Info,
-            LogLevel::Warning => CoreLogLevel::Warning,
-            LogLevel::Error => CoreLogLevel::Error,
-            LogLevel::Fatal => CoreLogLevel::Fatal,
-        },
-        at,
-        timestamp_ms: frame
-            .timestamp
-            .as_ref()
-            .and_then(|timestamp| timestamp.unix_ms),
-        target,
-        message: message.to_owned(),
-        // Read field by field rather than through `clash_api::LogField`:
-        // clash-api is not a dependency of this crate and must not become one.
-        fields,
-        truncated: frame.truncated || message_cut || target_cut || fields_cut,
-    }
-}
-
-fn clamp_core_log_text(text: &str, max_bytes: usize) -> (&str, bool) {
-    if text.len() <= max_bytes {
-        return (text, false);
-    }
-    let mut end = max_bytes;
-    while !text.is_char_boundary(end) {
-        end -= 1;
-    }
-    (&text[..end], true)
 }
 
 // TODO: support system path search via a config or flag
@@ -1748,98 +1656,6 @@ mod tests {
         assert!(infos.health.is_none());
         assert!(infos.revision.is_none());
         assert!(infos.config_path.is_none());
-    }
-
-    fn log_frame() -> LogFrame {
-        LogFrame {
-            epoch: 7,
-            kind: CoreKind::Mihomo,
-            stream: LogStream::Stdout,
-            timestamp: Some(nyanpasu_core_manager::LogTimestamp {
-                raw: "2026-07-29T00:16:22.646059400+08:00".to_owned(),
-                unix_ms: Some(1_753_719_382_646),
-                inferred: false,
-            }),
-            level: LogLevel::Warning,
-            target: Some("dns".to_owned()),
-            message: "message body".to_owned(),
-            fields: Vec::new(),
-            raw: "the whole logical record".to_owned(),
-            truncated: true,
-        }
-    }
-
-    /// Every field the stream carries, and — just as deliberately — `raw` is
-    /// not one of them: it is the archive's job, and it can reach 16 KiB.
-    #[test]
-    fn the_core_log_projection_carries_every_streamed_field() {
-        let info = core_log_info(&log_frame(), 1_700_000_000_000);
-        assert_eq!(info.epoch, 7);
-        assert_eq!(info.kind, CoreLogKind::Mihomo);
-        assert_eq!(info.stream, CoreLogStream::Stdout);
-        assert_eq!(info.level, CoreLogLevel::Warning);
-        assert_eq!(info.at, 1_700_000_000_000);
-        assert_eq!(info.timestamp_ms, Some(1_753_719_382_646));
-        assert_eq!(info.target.as_deref(), Some("dns"));
-        assert_eq!(info.message, "message body");
-        assert!(info.truncated);
-        // The projection borrows, so the frame is still whole for `forward_log`.
-        let frame = log_frame();
-        let _ = core_log_info(&frame, 0);
-        assert_eq!(frame.raw, "the whole logical record");
-    }
-
-    #[test]
-    fn core_log_projection_caps_oversized_values_and_preserves_normal_frames() {
-        let mut normal = log_frame();
-        normal.truncated = false;
-        normal.fields = serde_json::from_value(serde_json::json!([{
-            "key": "request",
-            "value": "7"
-        }]))
-        .unwrap();
-        let normal_info = core_log_info(&normal, 1);
-        assert_eq!(normal_info.target.as_deref(), Some("dns"));
-        assert_eq!(normal_info.message, "message body");
-        assert_eq!(normal_info.fields[0].key, "request");
-        assert_eq!(normal_info.fields[0].value, "7");
-        assert!(!normal_info.truncated);
-
-        let huge = "x".repeat(MAX_CORE_LOG_FIELD_TEXT_BYTES * 2);
-        let mut oversized = log_frame();
-        oversized.truncated = false;
-        oversized.message = "m".repeat(MAX_CORE_LOG_TEXT_BYTES * 2);
-        oversized.target = Some("t".repeat(MAX_CORE_LOG_TARGET_BYTES * 2));
-        oversized.fields = (0..=MAX_CORE_LOG_FIELDS)
-            .map(|index| {
-                serde_json::from_value(serde_json::json!({
-                    "key": format!("{index}{huge}"),
-                    "value": huge.clone(),
-                }))
-                .unwrap()
-            })
-            .collect();
-
-        let info = core_log_info(&oversized, 2);
-        assert_eq!(info.message.len(), MAX_CORE_LOG_TEXT_BYTES);
-        assert_eq!(info.target.unwrap().len(), MAX_CORE_LOG_TARGET_BYTES);
-        assert_eq!(info.fields.len(), MAX_CORE_LOG_FIELDS);
-        assert_eq!(info.fields[0].key.len(), MAX_CORE_LOG_FIELD_TEXT_BYTES);
-        assert_eq!(info.fields[0].value.len(), MAX_CORE_LOG_FIELD_TEXT_BYTES);
-        assert!(info.truncated);
-    }
-
-    /// A line whose header did not parse has no clock of its own, which is
-    /// exactly why `at` is stamped service-side and is never optional.
-    #[test]
-    fn a_frame_without_a_parsed_header_carries_no_core_timestamp() {
-        let mut degraded = log_frame();
-        degraded.timestamp = None;
-        degraded.target = None;
-        let info = core_log_info(&degraded, 1_700_000_000_002);
-        assert_eq!(info.timestamp_ms, None);
-        assert_eq!(info.target, None);
-        assert_eq!(info.at, 1_700_000_000_002);
     }
 }
 

--- a/crates/nyanpasu-service-runtime/src/server/manager_bridge.rs
+++ b/crates/nyanpasu-service-runtime/src/server/manager_bridge.rs
@@ -32,6 +32,13 @@ use super::{consts::RuntimeInfos, events::EventHub};
 
 const CORE_LOG_TARGET: &str = "nyanpasu_service::core";
 
+// These mirror `nyanpasu-core-manager`'s private `log_sink` caps; keep the
+// numbers in sync.
+const MAX_CORE_LOG_TEXT_BYTES: usize = 16 * 1024;
+const MAX_CORE_LOG_TARGET_BYTES: usize = 2048;
+const MAX_CORE_LOG_FIELDS: usize = 64;
+const MAX_CORE_LOG_FIELD_TEXT_BYTES: usize = 1024;
+
 /// Concurrent `/core/check` operations a service will run. Each one spawns a
 /// core binary, so this is a resource bound, not a fairness knob: two lets an
 /// honest client fire a second check while the first is running, and refuses
@@ -170,10 +177,14 @@ impl CoreManagerService {
                         // The projection borrows, so `forward_log` still takes
                         // the frame by value and moves its 16 KiB `raw` instead
                         // of the stream paying to clone it.
-                        hub.send_log(WsEvent::new_core_log(core_log_info(
-                            &frame,
-                            chrono::Utc::now().timestamp_millis(),
-                        )));
+                        // A subscriber connecting mid-frame misses that frame,
+                        // consistent with the stream's no-replay semantics.
+                        if hub.has_log_subscribers() {
+                            hub.send_log(WsEvent::new_core_log(core_log_info(
+                                &frame,
+                                chrono::Utc::now().timestamp_millis(),
+                            )));
+                        }
                         forward_log(frame);
                     }
                     Err(RecvError::Lagged(skipped)) => {
@@ -762,6 +773,30 @@ fn forward_log(frame: LogFrame) {
 /// an inferred one, so this is the only clock every record is guaranteed to
 /// have.
 fn core_log_info(frame: &LogFrame, at: i64) -> CoreLogInfo {
+    let (message, message_cut) = clamp_core_log_text(&frame.message, MAX_CORE_LOG_TEXT_BYTES);
+    let (target, target_cut) = match frame.target.as_deref() {
+        Some(target) => {
+            let (target, cut) = clamp_core_log_text(target, MAX_CORE_LOG_TARGET_BYTES);
+            (Some(target.to_owned()), cut)
+        }
+        None => (None, false),
+    };
+    let mut fields_cut = frame.fields.len() > MAX_CORE_LOG_FIELDS;
+    let fields = frame
+        .fields
+        .iter()
+        .take(MAX_CORE_LOG_FIELDS)
+        .map(|field| {
+            let (key, key_cut) = clamp_core_log_text(&field.key, MAX_CORE_LOG_FIELD_TEXT_BYTES);
+            let (value, value_cut) =
+                clamp_core_log_text(&field.value, MAX_CORE_LOG_FIELD_TEXT_BYTES);
+            fields_cut |= key_cut || value_cut;
+            CoreLogField {
+                key: key.to_owned(),
+                value: value.to_owned(),
+            }
+        })
+        .collect();
     CoreLogInfo {
         epoch: frame.epoch,
         kind: match frame.kind {
@@ -787,20 +822,24 @@ fn core_log_info(frame: &LogFrame, at: i64) -> CoreLogInfo {
             .timestamp
             .as_ref()
             .and_then(|timestamp| timestamp.unix_ms),
-        target: frame.target.clone(),
-        message: frame.message.clone(),
+        target,
+        message: message.to_owned(),
         // Read field by field rather than through `clash_api::LogField`:
         // clash-api is not a dependency of this crate and must not become one.
-        fields: frame
-            .fields
-            .iter()
-            .map(|field| CoreLogField {
-                key: field.key.clone(),
-                value: field.value.clone(),
-            })
-            .collect(),
-        truncated: frame.truncated,
+        fields,
+        truncated: frame.truncated || message_cut || target_cut || fields_cut,
     }
+}
+
+fn clamp_core_log_text(text: &str, max_bytes: usize) -> (&str, bool) {
+    if text.len() <= max_bytes {
+        return (text, false);
+    }
+    let mut end = max_bytes;
+    while !text.is_char_boundary(end) {
+        end -= 1;
+    }
+    (&text[..end], true)
 }
 
 // TODO: support system path search via a config or flag
@@ -1748,6 +1787,46 @@ mod tests {
         let frame = log_frame();
         let _ = core_log_info(&frame, 0);
         assert_eq!(frame.raw, "the whole logical record");
+    }
+
+    #[test]
+    fn core_log_projection_caps_oversized_values_and_preserves_normal_frames() {
+        let mut normal = log_frame();
+        normal.truncated = false;
+        normal.fields = serde_json::from_value(serde_json::json!([{
+            "key": "request",
+            "value": "7"
+        }]))
+        .unwrap();
+        let normal_info = core_log_info(&normal, 1);
+        assert_eq!(normal_info.target.as_deref(), Some("dns"));
+        assert_eq!(normal_info.message, "message body");
+        assert_eq!(normal_info.fields[0].key, "request");
+        assert_eq!(normal_info.fields[0].value, "7");
+        assert!(!normal_info.truncated);
+
+        let huge = "x".repeat(MAX_CORE_LOG_FIELD_TEXT_BYTES * 2);
+        let mut oversized = log_frame();
+        oversized.truncated = false;
+        oversized.message = "m".repeat(MAX_CORE_LOG_TEXT_BYTES * 2);
+        oversized.target = Some("t".repeat(MAX_CORE_LOG_TARGET_BYTES * 2));
+        oversized.fields = (0..=MAX_CORE_LOG_FIELDS)
+            .map(|index| {
+                serde_json::from_value(serde_json::json!({
+                    "key": format!("{index}{huge}"),
+                    "value": huge.clone(),
+                }))
+                .unwrap()
+            })
+            .collect();
+
+        let info = core_log_info(&oversized, 2);
+        assert_eq!(info.message.len(), MAX_CORE_LOG_TEXT_BYTES);
+        assert_eq!(info.target.unwrap().len(), MAX_CORE_LOG_TARGET_BYTES);
+        assert_eq!(info.fields.len(), MAX_CORE_LOG_FIELDS);
+        assert_eq!(info.fields[0].key.len(), MAX_CORE_LOG_FIELD_TEXT_BYTES);
+        assert_eq!(info.fields[0].value.len(), MAX_CORE_LOG_FIELD_TEXT_BYTES);
+        assert!(info.truncated);
     }
 
     /// A line whose header did not parse has no clock of its own, which is

--- a/crates/nyanpasu-service-runtime/src/server/manager_bridge.rs
+++ b/crates/nyanpasu-service-runtime/src/server/manager_bridge.rs
@@ -351,6 +351,16 @@ impl CoreManagerService {
         )
     }
 
+    /// Where the manager archives core logs, or `None` when its sink is off.
+    /// Constant for the manager's lifetime, so it is read on demand rather than
+    /// carried in the status snapshot.
+    pub fn core_log_dir(&self) -> Option<PathBuf> {
+        self.inner
+            .manager
+            .log_dir()
+            .map(|dir| dir.as_std_path().to_path_buf())
+    }
+
     /// Publish the wire-type echo the bridge projects into status snapshots.
     ///
     /// `Some` commits a new type, `None` republishes the current one; either way
@@ -454,9 +464,9 @@ async fn status_bridge(
                 // state cannot express (Starting, Restarting, and the
                 // Stopping/Switching arrivals the guards below drop). Emitting
                 // it here rather than after the guards is what keeps the legacy
-                // path below untouched. Deliberately no `tracing::info!` for it
-                // — that would re-enter the hub as an `Event::Log` and change
-                // what the legacy stream carries.
+                // path below untouched. (Until L3 there was a second reason not
+                // to log here: the line would have come back round as an event
+                // of its own. No tracing output becomes an event now.)
                 let requested = requested_core.borrow_and_update().clone();
                 hub.send(WsEvent::new_core_status_changed(project_core_infos(
                     &raw, requested,
@@ -711,17 +721,31 @@ fn project_core_infos(status: &CoreStatus, requested_core: Option<CoreType>) -> 
     }
 }
 
+/// Mirror the core's console output into the service's own tracing stream, for
+/// an operator watching a terminal.
+///
+/// Nothing here is above `DEBUG`, deliberately. Core output now has two homes
+/// that outlive the process — the JSONL archive and the event stream — so
+/// putting it in the service's log file at the default filter would be a third
+/// copy of the same bytes. `RUST_LOG=nyanpasu_service::core=debug` turns it back
+/// on by itself, without the noise of a full `--verbose`.
+///
+/// The severity is not lost, only un-promoted: `core_level` carries the parsed
+/// level as a field. That also retires a real defect — the level used to come
+/// from the *pipe*, so every stderr line was reported as an error however
+/// harmless it was.
 fn forward_log(frame: LogFrame) {
     let kind = frame.kind;
     let epoch = frame.epoch;
+    let stream = frame.stream;
     let core_level = frame.level;
     let raw = frame.raw;
-    match frame.stream {
-        LogStream::Stdout => {
-            tracing::info!(target: CORE_LOG_TARGET, ?core_level, %kind, epoch, "{raw}")
+    match core_level {
+        LogLevel::Trace => {
+            tracing::trace!(target: CORE_LOG_TARGET, ?core_level, ?stream, %kind, epoch, "{raw}")
         }
-        LogStream::Stderr => {
-            tracing::error!(target: CORE_LOG_TARGET, ?core_level, %kind, epoch, "{raw}")
+        _ => {
+            tracing::debug!(target: CORE_LOG_TARGET, ?core_level, ?stream, %kind, epoch, "{raw}")
         }
     }
 }

--- a/crates/nyanpasu-service-runtime/src/server/manager_bridge.rs
+++ b/crates/nyanpasu-service-runtime/src/server/manager_bridge.rs
@@ -8,8 +8,8 @@ use camino::{Utf8Path, Utf8PathBuf};
 use nyanpasu_core_manager::{
     ApplyOutcome, ConfigRevision, CoreKind, CoreManager as Manager, CoreSpec,
     CoreState as ManagerCoreState, CoreStatus, Error as ManagerError, HealthState, HealthStatus,
-    Host, InstanceOptions, InstanceSpec, LocalIpcPolicy, LogFrame, LogStream, ManagerOptions,
-    RevisionId,
+    Host, InstanceOptions, InstanceSpec, LocalIpcPolicy, LogFrame, LogLevel, LogStream,
+    ManagerOptions, RevisionId,
 };
 use nyanpasu_ipc::api::{
     R, RBuilder,
@@ -19,7 +19,9 @@ use nyanpasu_ipc::api::{
         ConfigRevisionInfo, CoreControllerInfo, CoreHealthInfo, CoreHealthState, CoreInfos,
         CoreState, CoreStateDetail, RevisionIdInfo,
     },
-    ws::events::Event as WsEvent,
+    ws::events::{
+        CoreLogField, CoreLogInfo, CoreLogKind, CoreLogLevel, CoreLogStream, Event as WsEvent,
+    },
 };
 use nyanpasu_utils::core::{ClashCoreType, CoreType};
 use serde::{Serialize, de::DeserializeOwned};
@@ -151,20 +153,29 @@ impl CoreManagerService {
         })
     }
 
-    /// State → ws events and core logs → tracing.
+    /// State → ws events, and core logs → both the ws log ring and tracing.
     pub fn spawn_bridges(&self, hub: EventHub) {
         // Only the two receivers are moved in, never the adapter: see `Inner`.
         tokio::spawn(status_bridge(
             self.inner.manager.subscribe(),
             self.inner.requested_core.subscribe(),
-            hub,
+            hub.clone(),
         ));
 
         let mut logs = self.inner.manager.subscribe_logs();
         tokio::spawn(async move {
             loop {
                 match logs.recv().await {
-                    Ok(frame) => forward_log(frame),
+                    Ok(frame) => {
+                        // The projection borrows, so `forward_log` still takes
+                        // the frame by value and moves its 16 KiB `raw` instead
+                        // of the stream paying to clone it.
+                        hub.send_log(WsEvent::new_core_log(core_log_info(
+                            &frame,
+                            chrono::Utc::now().timestamp_millis(),
+                        )));
+                        forward_log(frame);
+                    }
                     Err(RecvError::Lagged(skipped)) => {
                         tracing::warn!("core log bridge dropped {skipped} frames")
                     }
@@ -712,6 +723,59 @@ fn forward_log(frame: LogFrame) {
         LogStream::Stderr => {
             tracing::error!(target: CORE_LOG_TARGET, ?core_level, %kind, epoch, "{raw}")
         }
+    }
+}
+
+/// The wire projection of one normalized core log frame.
+///
+/// Takes `&LogFrame` so the caller can still hand the owned frame to
+/// [`forward_log`], which moves `raw` — the largest field and the one the
+/// stream deliberately does not carry.
+///
+/// `at` is a parameter rather than a `now()` call inside so the mapping is
+/// testable. It is stamped service-side, at conversion time: the manager's
+/// frame may carry no timestamp at all (a line whose header did not parse) or
+/// an inferred one, so this is the only clock every record is guaranteed to
+/// have.
+fn core_log_info(frame: &LogFrame, at: i64) -> CoreLogInfo {
+    CoreLogInfo {
+        epoch: frame.epoch,
+        kind: match frame.kind {
+            CoreKind::Mihomo => CoreLogKind::Mihomo,
+            CoreKind::ClashRust => CoreLogKind::ClashRust,
+            CoreKind::ClashPremium => CoreLogKind::ClashPremium,
+            CoreKind::Meow => CoreLogKind::Meow,
+        },
+        stream: match frame.stream {
+            LogStream::Stdout => CoreLogStream::Stdout,
+            LogStream::Stderr => CoreLogStream::Stderr,
+        },
+        level: match frame.level {
+            LogLevel::Trace => CoreLogLevel::Trace,
+            LogLevel::Debug => CoreLogLevel::Debug,
+            LogLevel::Info => CoreLogLevel::Info,
+            LogLevel::Warning => CoreLogLevel::Warning,
+            LogLevel::Error => CoreLogLevel::Error,
+            LogLevel::Fatal => CoreLogLevel::Fatal,
+        },
+        at,
+        timestamp_ms: frame
+            .timestamp
+            .as_ref()
+            .and_then(|timestamp| timestamp.unix_ms),
+        target: frame.target.clone(),
+        message: frame.message.clone(),
+        // Read field by field rather than through `clash_api::LogField`:
+        // clash-api is not a dependency of this crate and must not become one.
+        fields: frame
+            .fields
+            .iter()
+            .map(|field| CoreLogField {
+                key: field.key.clone(),
+                value: field.value.clone(),
+            })
+            .collect(),
+        truncated: frame.truncated,
     }
 }
 
@@ -1621,6 +1685,58 @@ mod tests {
         assert!(infos.health.is_none());
         assert!(infos.revision.is_none());
         assert!(infos.config_path.is_none());
+    }
+
+    fn log_frame() -> LogFrame {
+        LogFrame {
+            epoch: 7,
+            kind: CoreKind::Mihomo,
+            stream: LogStream::Stdout,
+            timestamp: Some(nyanpasu_core_manager::LogTimestamp {
+                raw: "2026-07-29T00:16:22.646059400+08:00".to_owned(),
+                unix_ms: Some(1_753_719_382_646),
+                inferred: false,
+            }),
+            level: LogLevel::Warning,
+            target: Some("dns".to_owned()),
+            message: "message body".to_owned(),
+            fields: Vec::new(),
+            raw: "the whole logical record".to_owned(),
+            truncated: true,
+        }
+    }
+
+    /// Every field the stream carries, and — just as deliberately — `raw` is
+    /// not one of them: it is the archive's job, and it can reach 16 KiB.
+    #[test]
+    fn the_core_log_projection_carries_every_streamed_field() {
+        let info = core_log_info(&log_frame(), 1_700_000_000_000);
+        assert_eq!(info.epoch, 7);
+        assert_eq!(info.kind, CoreLogKind::Mihomo);
+        assert_eq!(info.stream, CoreLogStream::Stdout);
+        assert_eq!(info.level, CoreLogLevel::Warning);
+        assert_eq!(info.at, 1_700_000_000_000);
+        assert_eq!(info.timestamp_ms, Some(1_753_719_382_646));
+        assert_eq!(info.target.as_deref(), Some("dns"));
+        assert_eq!(info.message, "message body");
+        assert!(info.truncated);
+        // The projection borrows, so the frame is still whole for `forward_log`.
+        let frame = log_frame();
+        let _ = core_log_info(&frame, 0);
+        assert_eq!(frame.raw, "the whole logical record");
+    }
+
+    /// A line whose header did not parse has no clock of its own, which is
+    /// exactly why `at` is stamped service-side and is never optional.
+    #[test]
+    fn a_frame_without_a_parsed_header_carries_no_core_timestamp() {
+        let mut degraded = log_frame();
+        degraded.timestamp = None;
+        degraded.target = None;
+        let info = core_log_info(&degraded, 1_700_000_000_002);
+        assert_eq!(info.timestamp_ms, None);
+        assert_eq!(info.target, None);
+        assert_eq!(info.at, 1_700_000_000_002);
     }
 }
 

--- a/crates/nyanpasu-service-runtime/src/server/mod.rs
+++ b/crates/nyanpasu-service-runtime/src/server/mod.rs
@@ -11,11 +11,7 @@ pub use events::EventHub;
 pub use logger::Logger;
 pub use manager_bridge::CoreManagerService as CoreManager;
 use nyanpasu_core_manager::LocalIpcPolicy;
-use nyanpasu_ipc::{
-    SERVICE_PLACEHOLDER,
-    api::ws::events::{Event as WsEvent, TraceLog},
-    server::create_server,
-};
+use nyanpasu_ipc::{SERVICE_PLACEHOLDER, server::create_server};
 use routing::{AppState, create_router};
 use tokio_util::sync::CancellationToken;
 use tracing_attributes::instrument;
@@ -39,30 +35,9 @@ pub async fn run(
 
     // The tracing writer was bound to the global logger before `run`; share that
     // instance so the `/logs` routes read the buffer that is actually being fed.
+    // Nothing forwards it anywhere else: the service's own logs are files, and
+    // `/status` reports the directory.
     let logger = Logger::global().clone();
-    let log_hub = hub.clone();
-    logger.set_subscriber(Box::new(move |logging| {
-        // Runs inside the tracing writer: stays synchronous, never logs.
-        let target = logging
-            .fields
-            .get("target")
-            .and_then(|v| v.as_str().map(|s| s.to_string()))
-            .unwrap_or("".to_string());
-        if !events::should_forward_to_hub(&target) {
-            return;
-        }
-        log_hub.send(WsEvent::new_log(TraceLog {
-            timestamp: logging.timestamp,
-            level: logging.level,
-            message: logging
-                .fields
-                .get("message")
-                .and_then(|v| v.as_str().map(|s| s.to_string()))
-                .unwrap_or("".to_string()),
-            target,
-            fields: logging.fields,
-        }));
-    }));
 
     let state = AppState {
         core_manager: core_manager.clone(),

--- a/crates/nyanpasu-service-runtime/src/server/routing/status.rs
+++ b/crates/nyanpasu-service-runtime/src/server/routing/status.rs
@@ -6,7 +6,7 @@ use nyanpasu_ipc::{
     api::{
         RBuilder,
         contract::Status as StatusOp,
-        status::{RuntimeInfos, StatusRes, StatusResBody},
+        status::{LogPathsInfo, RuntimeInfos, StatusRes, StatusResBody},
     },
     server::RegisterOperation,
 };
@@ -28,6 +28,12 @@ pub async fn status(State(state): State<AppState>) -> (StatusCode, Json<StatusRe
             nyanpasu_config_dir: Cow::Owned(state.runtime.nyanpasu_config_dir.clone()),
             nyanpasu_data_dir: Cow::Owned(state.runtime.nyanpasu_data_dir.clone()),
         },
+        // Always sent. The field is optional on the wire only so a payload
+        // without it stays byte-identical to the pre-L3 format.
+        logs: Some(LogPathsInfo {
+            service_dir: crate::utils::dirs::service_logs_dir(),
+            core_dir: state.core_manager.core_log_dir(),
+        }),
     });
 
     (StatusCode::OK, Json(res))

--- a/crates/nyanpasu-service-runtime/src/server/routing/tests.rs
+++ b/crates/nyanpasu-service-runtime/src/server/routing/tests.rs
@@ -507,3 +507,33 @@ async fn the_event_stream_ignores_any_query() {
         assert_eq!(response.status(), StatusCode::UPGRADE_REQUIRED, "{uri}");
     }
 }
+
+/// `/status` is where a caller learns where the logs are, now that the service
+/// does not stream them. The core directory comes from the manager, so this
+/// pins the forwarder as well as the field.
+#[tokio::test]
+async fn the_status_response_reports_the_log_directories() {
+    let env = TestEnv::new().await;
+    let response = create_router(env.state.clone())
+        .oneshot(
+            Request::builder()
+                .uri(STATUS_ENDPOINT)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let body: StatusRes<'static> = body_of(response).await;
+    let logs = body
+        .data
+        .expect("status returns a body")
+        .logs
+        .expect("status must report the log directories");
+    assert_eq!(logs.service_dir, crate::utils::dirs::service_logs_dir());
+    let core_dir = logs.core_dir.expect("the sink is on by default");
+    assert!(
+        core_dir.ends_with("logs"),
+        "core log dir should be the manager's archive: {core_dir:?}"
+    );
+}

--- a/crates/nyanpasu-service-runtime/src/server/routing/ws.rs
+++ b/crates/nyanpasu-service-runtime/src/server/routing/ws.rs
@@ -12,10 +12,7 @@ use nyanpasu_ipc::api::ws::events::{EVENT_URI, Event};
 use tokio::sync::broadcast::error::RecvError;
 
 use super::AppState;
-use crate::server::{
-    CoreManager,
-    events::{EventHub, WS_LAG_LOG_TARGET},
-};
+use crate::server::{CoreManager, events::EventHub};
 
 pub fn setup() -> Router<AppState> {
     let router = Router::new();
@@ -82,16 +79,13 @@ async fn handle_socket(socket: WebSocket, hub: EventHub, core_manager: CoreManag
                 }
                 // Only this connection pays for being slow. Warn once, then
                 // jump to the live tail: the receiver skips the backlog, so a
-                // full ring cannot spin us in a Lagged loop. The warn itself
-                // is tagged with WS_LAG_LOG_TARGET, which the log-forwarding
-                // subscriber filters out before it ever reaches the hub —
-                // otherwise many lagging connections could collectively
-                // refill the ring and re-lag each other.
+                // full ring cannot spin us in a Lagged loop. Until L3 this line
+                // needed a dedicated tracing target, because it would otherwise
+                // have re-entered the very ring it had just overflowed. No
+                // tracing output becomes an event now, so it is an ordinary log
+                // line.
                 Next::StatusLag(skipped) => {
-                    tracing::warn!(
-                        target: WS_LAG_LOG_TARGET,
-                        "ws subscriber dropped {skipped} events"
-                    );
+                    tracing::warn!("ws subscriber dropped {skipped} events");
                     events = events.resubscribe();
                     // The gap may have swallowed a transition, so the client is
                     // resynchronised exactly as it was on connect. This is what
@@ -104,15 +98,9 @@ async fn handle_socket(socket: WebSocket, hub: EventHub, core_manager: CoreManag
                 // Deliberately no snapshot. This is the whole reason the log
                 // ring is separate: a dropped log line is a dropped log line,
                 // and making it cost a full status resend would turn a busy
-                // core into a resynchronisation loop. The same
-                // WS_LAG_LOG_TARGET keeps this notice out of the hub — the
-                // target is what provides that, not the level, because
-                // `--verbose` admits DEBUG to the very same writer.
+                // core into a resynchronisation loop.
                 Next::LogLag(skipped) => {
-                    tracing::debug!(
-                        target: WS_LAG_LOG_TARGET,
-                        "ws subscriber dropped {skipped} core log frames"
-                    );
+                    tracing::debug!("ws subscriber dropped {skipped} core log frames");
                     logs = logs.resubscribe();
                 }
                 // Both rings belong to the same hub, so either closing means

--- a/crates/nyanpasu-service-runtime/src/server/routing/ws.rs
+++ b/crates/nyanpasu-service-runtime/src/server/routing/ws.rs
@@ -22,6 +22,17 @@ pub fn setup() -> Router<AppState> {
     router.route(EVENT_URI, any(ws_handler))
 }
 
+/// One turn of the sender loop. The two rings are read inside `select!` and
+/// every mutation happens after it, so no receiver is reassigned while the
+/// other branch's future is still alive.
+#[allow(clippy::large_enum_variant)]
+enum Next {
+    Send(Event),
+    StatusLag(u64),
+    LogLag(u64),
+    Closed,
+}
+
 /// One protocol, no negotiation: the service binary ships with the program that
 /// consumes it, so there is no client to shield from a variant it cannot decode.
 /// The query string is not extracted at all — routing ignores it, and so do we.
@@ -30,11 +41,12 @@ async fn ws_handler(State(state): State<AppState>, ws: WebSocketUpgrade) -> Resp
 }
 
 async fn handle_socket(socket: WebSocket, hub: EventHub, core_manager: CoreManager) {
-    // The subscription lives and dies with this task; there is no registry to
+    // The subscriptions live and die with this task; there is no registry to
     // insert into and no id to collide with. Subscribing *before* the snapshot
     // is read is deliberate: a transition landing in between is then delivered
     // twice rather than lost.
     let mut events = hub.subscribe();
+    let mut logs = hub.subscribe_logs();
     let (mut sink, mut stream) = socket.split();
 
     let handler = async { while let Some(Ok(_)) = stream.next().await {} };
@@ -42,13 +54,28 @@ async fn handle_socket(socket: WebSocket, hub: EventHub, core_manager: CoreManag
     let sender = async {
         // Snapshot-on-connect, for everyone: the socket's first frame is the
         // current status, so a client never has to poll `/status` to find out
-        // what it reconnected to.
+        // what it reconnected to. There is no equivalent for logs — a log
+        // stream has no "current value", and the history lives in the JSONL
+        // archive whose directory `/status` reports.
         if !send_snapshot(&mut sink, &core_manager).await {
             return;
         }
         loop {
-            match events.recv().await {
-                Ok(event) => {
+            // Unbiased on purpose: neither stream may starve the other.
+            let next = tokio::select! {
+                received = events.recv() => match received {
+                    Ok(event) => Next::Send(event),
+                    Err(RecvError::Lagged(skipped)) => Next::StatusLag(skipped),
+                    Err(RecvError::Closed) => Next::Closed,
+                },
+                received = logs.recv() => match received {
+                    Ok(event) => Next::Send(event),
+                    Err(RecvError::Lagged(skipped)) => Next::LogLag(skipped),
+                    Err(RecvError::Closed) => Next::Closed,
+                },
+            };
+            match next {
+                Next::Send(event) => {
                     if !send_event(&mut sink, &event).await {
                         break;
                     }
@@ -60,7 +87,7 @@ async fn handle_socket(socket: WebSocket, hub: EventHub, core_manager: CoreManag
                 // subscriber filters out before it ever reaches the hub —
                 // otherwise many lagging connections could collectively
                 // refill the ring and re-lag each other.
-                Err(RecvError::Lagged(skipped)) => {
+                Next::StatusLag(skipped) => {
                     tracing::warn!(
                         target: WS_LAG_LOG_TARGET,
                         "ws subscriber dropped {skipped} events"
@@ -74,7 +101,23 @@ async fn handle_socket(socket: WebSocket, hub: EventHub, core_manager: CoreManag
                         break;
                     }
                 }
-                Err(RecvError::Closed) => break,
+                // Deliberately no snapshot. This is the whole reason the log
+                // ring is separate: a dropped log line is a dropped log line,
+                // and making it cost a full status resend would turn a busy
+                // core into a resynchronisation loop. The same
+                // WS_LAG_LOG_TARGET keeps this notice out of the hub — the
+                // target is what provides that, not the level, because
+                // `--verbose` admits DEBUG to the very same writer.
+                Next::LogLag(skipped) => {
+                    tracing::debug!(
+                        target: WS_LAG_LOG_TARGET,
+                        "ws subscriber dropped {skipped} core log frames"
+                    );
+                    logs = logs.resubscribe();
+                }
+                // Both rings belong to the same hub, so either closing means
+                // the service is going away.
+                Next::Closed => break,
             }
         }
     };

--- a/crates/nyanpasu-service-runtime/src/server/routing/ws.rs
+++ b/crates/nyanpasu-service-runtime/src/server/routing/ws.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use axum::{
     Router,
     extract::{
@@ -8,6 +10,7 @@ use axum::{
     routing::any,
 };
 use futures_util::{SinkExt, StreamExt, stream::SplitSink};
+use nyanpasu_core_manager::LogFrame;
 use nyanpasu_ipc::api::ws::events::{EVENT_URI, Event};
 use tokio::sync::broadcast::error::RecvError;
 
@@ -25,6 +28,7 @@ pub fn setup() -> Router<AppState> {
 #[allow(clippy::large_enum_variant)]
 enum Next {
     Send(Event),
+    Log(Arc<LogFrame>),
     StatusLag(u64),
     LogLag(u64),
     Closed,
@@ -66,7 +70,7 @@ async fn handle_socket(socket: WebSocket, hub: EventHub, core_manager: CoreManag
                     Err(RecvError::Closed) => Next::Closed,
                 },
                 received = logs.recv() => match received {
-                    Ok(event) => Next::Send(event),
+                    Ok(frame) => Next::Log(frame),
                     Err(RecvError::Lagged(skipped)) => Next::LogLag(skipped),
                     Err(RecvError::Closed) => Next::Closed,
                 },
@@ -74,6 +78,13 @@ async fn handle_socket(socket: WebSocket, hub: EventHub, core_manager: CoreManag
             match next {
                 Next::Send(event) => {
                     if !send_event(&mut sink, &event).await {
+                        break;
+                    }
+                }
+                // The ring carries frames, so the envelope is built here, once
+                // per connection that is actually listening.
+                Next::Log(frame) => {
+                    if !send_event(&mut sink, &Event::new_core_log(frame)).await {
                         break;
                     }
                 }

--- a/docs/superpowers/specs/2026-07-30-ipc-protocol-evolution-report.md
+++ b/docs/superpowers/specs/2026-07-30-ipc-protocol-evolution-report.md
@@ -170,7 +170,7 @@ pub struct CoreApplyData {
 ### P3(可选,不阻塞):错误与日志结构化
 
 - envelope 增 `error_kind`(见 P0-B)逐步映射 manager 的 23 个错误变体;
-- 新变体 `Event::CoreLog(LogFrameInfo)` 结构直通(epoch/stream/level/target/fields/truncated),替代现在压进 `TraceLog.fields` 的降级形态。
+- 新变体 `Event::CoreLog(CoreLogInfo)` 结构直通(epoch/kind/stream/level/at/timestamp_ms/target/message/fields/truncated),替代现在压进 `TraceLog.fields` 的降级形态。**2026-07-31 修订(L2 实施)**:草稿名 `LogFrameInfo` 正式改为 `CoreLogInfo`,与 wire 侧既有的 `CoreControllerInfo`/`CoreHealthInfo`/`ConfigRevisionInfo` 命名族一致。`kind` 使用 ipc 本地的 `CoreLogKind`(四值)而非 `nyanpasu_utils::core::CoreType`——后者区分 alpha 构建,而日志帧本身不携带该信息(`LogFrame.kind` 是四值的 `ClashCoreKind`)。载荷不带 `raw`、`timestamp.raw`、`inferred`:前者与 `message` 高度重叠且可达 16 KiB,后两者是解析器内情;保真副本在 L1 的 JSONL 归档里。
 
 ## 5. 兼容与测试策略
 
@@ -203,4 +203,4 @@ pub struct CoreApplyData {
 | R6 | 存量用法:用户自声明 pipe/unix controller;第三方面板依赖 `external-controller` 直连 | 前者随 S10 放弃(小众,发布说明标注);后者文档化"显式 `Disable`",GUI 侧可评估面板流量代理作为后续增强 |
 | R7 | S10 删除 `ControllerMode` 是 core-manager 公开 API 破坏性变更 | "crates/* 不改动"约束自 S10 起解除;与 GUI 进程内复用(如有)同版本协调 |
 | R8 | `/core/start`、`/core/apply`、`/core/check` 均接受调用方任意路径,组内成员可指向任何 root 可读文件 | **接受并记录**:socket ACL 是本服务唯一的授权边界,自 `/core/start` 起一贯如此,本轮 S8 新端点未扩大该面。若日后要收窄,应做成显式的路径白名单策略,而不是在各端点里零散校验 |
-| R9 | 事件流为单一协议，快照帧比旧的两变体更密，且与日志共用 256 槽广播环（`server/events.rs:6`），启动抖动期可能略早触发 `Lagged` | **接受并记录**：稳态下事件稀疏；服务端日志记录 skipped 条数（该告警被过滤，不入 EventHub）。**2026-07-31 更新（S11）**：协商撤销后不再有连接类别之分——任何连接 `resubscribe()` 之后一律补发一帧快照，"跳到实时尾部、需自行轮询 `/status` 重新同步"的情形已消失（`events.rs` 的 `lag_recovery_with_feedback_reaches_the_tail` 已固定该路径）。若实测有压力，提高容量比拆分通道便宜 |
+| R9 | 事件流为单一协议，快照帧比旧的两变体更密，且与日志共用 256 槽广播环（`server/events.rs:6`），启动抖动期可能略早触发 `Lagged` | **接受并记录**：稳态下事件稀疏；服务端日志记录 skipped 条数（该告警被过滤，不入 EventHub）。**2026-07-31 更新（S11）**：协商撤销后不再有连接类别之分——任何连接 `resubscribe()` 之后一律补发一帧快照，"跳到实时尾部、需自行轮询 `/status` 重新同步"的情形已消失（`events.rs` 的 `lag_recovery_with_feedback_reaches_the_tail` 已固定该路径）。若实测有压力，提高容量比拆分通道便宜**2026-07-31 再更新(L2 实施)**:本行末句"提高容量比拆分通道便宜"**已被推翻并实施了拆分**。理由不是容量估算,而是两条流的丢失语义根本不同:丢一帧状态必须触发重同步(ws 处理器补发全量快照),丢一行日志必须不触发任何东西。共用一个环时二者无法区分,只能一律按最贵的方式处理。现状:`EventHub` 内两条独立 broadcast——状态环 256、日志环 1024(`server/events.rs`),ws 处理器 `select!` 同时消费;日志环 `Lagged` 只记一条 debug(仍用 `WS_LAG_LOG_TARGET`,故不入 hub)并 `resubscribe()`,**不补发快照**;状态环 `Lagged` 行为完全不变。已接受的代价:日志帧与状态帧之间不再有全局定序。 |

--- a/docs/superpowers/specs/2026-07-30-ipc-protocol-evolution-report.md
+++ b/docs/superpowers/specs/2026-07-30-ipc-protocol-evolution-report.md
@@ -171,6 +171,7 @@ pub struct CoreApplyData {
 
 - envelope 增 `error_kind`(见 P0-B)逐步映射 manager 的 23 个错误变体;
 - 新变体 `Event::CoreLog(CoreLogInfo)` 结构直通(epoch/kind/stream/level/at/timestamp_ms/target/message/fields/truncated),替代现在压进 `TraceLog.fields` 的降级形态。**2026-07-31 修订(L2 实施)**:草稿名 `LogFrameInfo` 正式改为 `CoreLogInfo`,与 wire 侧既有的 `CoreControllerInfo`/`CoreHealthInfo`/`ConfigRevisionInfo` 命名族一致。`kind` 使用 ipc 本地的 `CoreLogKind`(四值)而非 `nyanpasu_utils::core::CoreType`——后者区分 alpha 构建,而日志帧本身不携带该信息(`LogFrame.kind` 是四值的 `ClashCoreKind`)。载荷不带 `raw`、`timestamp.raw`、`inferred`:前者与 `message` 高度重叠且可达 16 KiB,后两者是解析器内情;保真副本在 L1 的 JSONL 归档里。
+。**2026-07-31 再更新(L3 实施)**:`Event::Log` 与 `TraceLog` **已从 wire 删除**,service 自身日志不再上事件流;`/status` 尾部新增 `logs` 对象(`service_dir` + 可选 `core_dir`)。随之清算:`WS_LAG_LOG_TARGET`、`should_forward_to_hub`、`Logger` 的订阅者扇出机制与 `server::run` 的 hub 转发回调全部删除——"日志→hub→滞后告警→再入 hub"的反馈回路在结构上不再可能,而不只是被过滤。核心日志 tracing 打点去重:删除 `instance.rs` 监督循环内的内联打点,保留桥上的 `forward_log`,改为按 `frame.level` 分派且不高于 `DEBUG`(Q3)。**注意**:两个目录均已按 owner/SYSTEM/Administrators 加固,普通用户态消费方读不到——`logs` 是"位置公告"而非读取授权。
 
 ## 5. 兼容与测试策略
 
@@ -195,7 +196,7 @@ pub struct CoreApplyData {
 
 | # | 问题 | 处置建议 |
 |---|---|---|
-| R1 | GUI 消费侧对单条事件解码错误的容错未验证 | S9 前在 GUI 仓实测；ws 版本协商本身已兜底。**2026-07-31（S11）**：协商已撤销，该兜底不复存在——服务与 GUI 同版本分发，兼容性改由发布协调保证 |
+| R1 | GUI 消费侧对单条事件解码错误的容错未验证 | S9 前在 GUI 仓实测；ws 版本协商本身已兜底。**2026-07-31（S11）**：协商已撤销，该兜底不复存在——服务与 GUI 同版本分发，兼容性改由发布协调保证**2026-07-31(L3)**:`Event::Log` 变体已删除。旧 GUI 若穷尽 `match` 该枚举将编译失败,若仅解码则少一个变体、且再也收不到 service 自身日志——必须与 GUI 同版本协调,发布说明须标注。 |
 | R2 | `apply` 在核心停止态的语义(报错 vs 隐式 start) | 倾向报错,保持 start 显式;实施时与 GUI 确认交互预期 |
 | R3 | envelope 加 `error_kind` 字段对第三方脚本消费者的影响 | serde 默认忽略未知字段;wire golden 会暴露任何意外 |
 | R4 | Managed 模式下若未来自动生成 secret | 独立决策,需分发与权限设计;本轮明确不做 |
@@ -203,4 +204,4 @@ pub struct CoreApplyData {
 | R6 | 存量用法:用户自声明 pipe/unix controller;第三方面板依赖 `external-controller` 直连 | 前者随 S10 放弃(小众,发布说明标注);后者文档化"显式 `Disable`",GUI 侧可评估面板流量代理作为后续增强 |
 | R7 | S10 删除 `ControllerMode` 是 core-manager 公开 API 破坏性变更 | "crates/* 不改动"约束自 S10 起解除;与 GUI 进程内复用(如有)同版本协调 |
 | R8 | `/core/start`、`/core/apply`、`/core/check` 均接受调用方任意路径,组内成员可指向任何 root 可读文件 | **接受并记录**:socket ACL 是本服务唯一的授权边界,自 `/core/start` 起一贯如此,本轮 S8 新端点未扩大该面。若日后要收窄,应做成显式的路径白名单策略,而不是在各端点里零散校验 |
-| R9 | 事件流为单一协议，快照帧比旧的两变体更密，且与日志共用 256 槽广播环（`server/events.rs:6`），启动抖动期可能略早触发 `Lagged` | **接受并记录**：稳态下事件稀疏；服务端日志记录 skipped 条数（该告警被过滤，不入 EventHub）。**2026-07-31 更新（S11）**：协商撤销后不再有连接类别之分——任何连接 `resubscribe()` 之后一律补发一帧快照，"跳到实时尾部、需自行轮询 `/status` 重新同步"的情形已消失（`events.rs` 的 `lag_recovery_with_feedback_reaches_the_tail` 已固定该路径）。若实测有压力，提高容量比拆分通道便宜**2026-07-31 再更新(L2 实施)**:本行末句"提高容量比拆分通道便宜"**已被推翻并实施了拆分**。理由不是容量估算,而是两条流的丢失语义根本不同:丢一帧状态必须触发重同步(ws 处理器补发全量快照),丢一行日志必须不触发任何东西。共用一个环时二者无法区分,只能一律按最贵的方式处理。现状:`EventHub` 内两条独立 broadcast——状态环 256、日志环 1024(`server/events.rs`),ws 处理器 `select!` 同时消费;日志环 `Lagged` 只记一条 debug(仍用 `WS_LAG_LOG_TARGET`,故不入 hub)并 `resubscribe()`,**不补发快照**;状态环 `Lagged` 行为完全不变。已接受的代价:日志帧与状态帧之间不再有全局定序。 |
+| R9 | 事件流为单一协议，快照帧比旧的两变体更密，且与日志共用 256 槽广播环（`server/events.rs:6`），启动抖动期可能略早触发 `Lagged` | **接受并记录**：稳态下事件稀疏；服务端日志记录 skipped 条数（该告警被过滤，不入 EventHub）。**2026-07-31 更新（S11）**：协商撤销后不再有连接类别之分——任何连接 `resubscribe()` 之后一律补发一帧快照，"跳到实时尾部、需自行轮询 `/status` 重新同步"的情形已消失（`events.rs` 的 `lag_recovery_with_feedback_reaches_the_tail` 已固定该路径）。若实测有压力，提高容量比拆分通道便宜。**2026-07-31 再更新(L2 实施)**:本行末句"提高容量比拆分通道便宜"**已被推翻并实施了拆分**。理由不是容量估算,而是两条流的丢失语义根本不同:丢一帧状态必须触发重同步(ws 处理器补发全量快照),丢一行日志必须不触发任何东西。共用一个环时二者无法区分,只能一律按最贵的方式处理。现状:`EventHub` 内两条独立 broadcast——状态环 256、日志环 1024(`server/events.rs`),ws 处理器 `select!` 同时消费;日志环 `Lagged` 只记一条 debug(L3 后已无需专用 target——没有任何 tracing 输出会成为事件)并 `resubscribe()`,**不补发快照**;状态环 `Lagged` 行为完全不变。已接受的代价:日志帧与状态帧之间不再有全局定序。 |

--- a/nyanpasu_ipc/Cargo.toml
+++ b/nyanpasu_ipc/Cargo.toml
@@ -11,6 +11,7 @@ required-features = ["client", "server"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+nyanpasu-core-metadata = { path = "../crates/nyanpasu-core-metadata" }
 nyanpasu-utils = {
   path = "../crates/nyanpasu-utils",
   default-features = false,
@@ -29,7 +30,10 @@ http = "1"
 interprocess = { version = "2.4.2", features = ["tokio"] }
 reqwest = { version = "0.13", features = ["json"], optional = true }
 reqwest-websocket = { version = "0.6.0", optional = true }
-serde = { workspace = true }
+# `rc`: `Event::CoreLog` carries the manager's frame behind an `Arc` so the
+# service fans one allocation out to every subscriber. The feature only exposes
+# serde's `Rc`/`Arc` impls, which serialize transparently by value.
+serde = { workspace = true, features = ["rc"] }
 specta = { version = "^2.0.0-rc.25", features = ["derive", "indexmap", "serde_json"], optional = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }

--- a/nyanpasu_ipc/src/api/status.rs
+++ b/nyanpasu_ipc/src/api/status.rs
@@ -150,6 +150,16 @@ pub struct CoreInfos {
 /// running as an ordinary user generally cannot read them — surface the path
 /// for a support request rather than building a tail on it. Live core output is
 /// on the event stream; the service's own logs are not streamed at all.
+///
+/// TODO: that restriction is the open question here, not a settled posture. A
+/// user-level GUI reading the archive would need one of: a widened DACL (which
+/// means teaching `nyanpasu_utils::io::atomic_fs`'s hardener *and* its verifier
+/// a second acceptable shape — the verifier rejects user-readable DACLs today,
+/// so both move together or directory creation starts failing), some other
+/// grant mechanism, or an RPC that serves the archive so the directory stays
+/// closed. All three are acceptable; none is chosen yet. The two sites that
+/// would change are `log_sink::prepare_dir` and the service's own log directory
+/// setup.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "specta", derive(specta::Type))]
 pub struct LogPathsInfo {

--- a/nyanpasu_ipc/src/api/status.rs
+++ b/nyanpasu_ipc/src/api/status.rs
@@ -140,6 +140,29 @@ pub struct CoreInfos {
     pub detail: Option<CoreStateDetail>,
 }
 
+/// Where this service writes logs.
+///
+/// These are the service's own facts, not an echo of what the caller passed at
+/// start-up, which is why they are here and not in [`RuntimeInfos`].
+///
+/// **These are locations, not a grant.** Both directories are restricted to the
+/// account the service runs under plus local administrators, so a caller
+/// running as an ordinary user generally cannot read them — surface the path
+/// for a support request rather than building a tail on it. Live core output is
+/// on the event stream; the service's own logs are not streamed at all.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+pub struct LogPathsInfo {
+    /// The service's own logs: JSON lines from `tracing-appender`, rotated
+    /// daily, seven files kept.
+    pub service_dir: PathBuf,
+    /// The core log archive: one rolling JSONL stream, rotated by size and
+    /// retained by count. Absent when the manager's sink is switched off, in
+    /// which case no such directory exists at all.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub core_dir: Option<PathBuf>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "specta", derive(specta::Type))]
 pub struct RuntimeInfos<'a> {
@@ -155,6 +178,12 @@ pub struct StatusResBody<'a> {
     pub version: Cow<'a, str>,
     pub core_infos: CoreInfos,
     pub runtime_infos: RuntimeInfos<'a>,
+    /// Declared last and omitted rather than null when absent, so a payload
+    /// without it is byte-identical to the pre-L3 format — the rule S7 used for
+    /// `CoreInfos`. The service always sends it; the `Option` exists so every
+    /// existing golden literal stays unchanged.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub logs: Option<LogPathsInfo>,
 }
 
 pub type StatusRes<'a> = R<'a, StatusResBody<'a>>;

--- a/nyanpasu_ipc/src/api/ws/events.rs
+++ b/nyanpasu_ipc/src/api/ws/events.rs
@@ -18,6 +18,98 @@ pub struct TraceLog {
     pub fields: IndexMap<String, serde_json::Value>,
 }
 
+/// Which console stream a record arrived on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+#[serde(rename_all = "lowercase")]
+pub enum CoreLogStream {
+    Stdout,
+    Stderr,
+}
+
+/// Normalized severity. Go's `fatal` and `panic` both terminate the process, so
+/// the manager's parser collapses them into `Fatal`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+#[serde(rename_all = "lowercase")]
+pub enum CoreLogLevel {
+    Trace,
+    Debug,
+    Info,
+    Warning,
+    Error,
+    Fatal,
+}
+
+/// Which core printed the record.
+///
+/// A deliberately separate type from [`nyanpasu_utils::core::CoreType`], for
+/// the same reason [`crate::api::status::CoreControllerInfo`] is separate from
+/// `clash_api::Host` — but here there is a second, sharper reason: `CoreType`
+/// distinguishes alpha builds (`mihomo-alpha`, `clash-rs-alpha`) and a log
+/// frame does not. The manager parses console output per *kind*, and its four
+/// kinds are exactly these. Rendering a frame as `CoreType` would mean
+/// inventing a distinction the frame never carried.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+pub enum CoreLogKind {
+    #[serde(rename = "mihomo")]
+    Mihomo,
+    #[serde(rename = "clash-rs")]
+    ClashRust,
+    #[serde(rename = "clash")]
+    ClashPremium,
+    #[serde(rename = "meow")]
+    Meow,
+}
+
+/// One structured field the core printed beside its message.
+///
+/// Not `clash_api::LogField`: clash-api is an internal dependency of the core
+/// manager and must not enter the wire dependency tree — the same rule that
+/// produced [`crate::api::status::CoreControllerInfo`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+pub struct CoreLogField {
+    pub key: String,
+    pub value: String,
+}
+
+/// One normalized core console record.
+///
+/// What is deliberately absent is the point of the type. The manager's frame
+/// also carries `raw` (the whole logical record, up to 16 KiB), the timestamp's
+/// original spelling, and whether that timestamp was inferred. `raw` overlaps
+/// `message` almost entirely — for a record whose header did not parse they are
+/// the same string — and the other two are parser internals. The JSONL archive
+/// keeps all three for fidelity; this stream carries what a log panel renders.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+pub struct CoreLogInfo {
+    pub epoch: u64,
+    pub kind: CoreLogKind,
+    pub stream: CoreLogStream,
+    pub level: CoreLogLevel,
+    /// Unix milliseconds, stamped by the service when it observed the frame.
+    /// Always present, which is what makes the stream sortable: a record whose
+    /// header did not parse has no clock of its own.
+    pub at: i64,
+    /// Unix milliseconds as the core reported them, when it reported any. Clash
+    /// premium and clash-rs do not print a full instant, so the manager infers
+    /// theirs from the observation time — treat this as advisory and sort by
+    /// [`Self::at`].
+    pub timestamp_ms: Option<i64>,
+    /// Clash premium's `[Tag]` prefix, meow's tracing target, or clash-rs's
+    /// `file:line`.
+    pub target: Option<String>,
+    pub message: String,
+    /// Populated only where field boundaries are decidable, which today means
+    /// mihomo's quoted logfmt.
+    pub fields: Vec<CoreLogField>,
+    /// Continuation lines were dropped after hitting a size limit.
+    pub truncated: bool,
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[cfg_attr(feature = "specta", derive(specta::Type))]
 pub enum Event {
@@ -36,6 +128,16 @@ pub enum Event {
     /// already keeps for `/status`. Treat it as idempotent — a reconnect or a
     /// lag recovery can repeat one.
     CoreStatusChanged(CoreInfos),
+    /// One core console record, pushed live. Carried on its own broadcast ring
+    /// inside the service, because the two streams fail differently: losing a
+    /// status frame costs a full snapshot resend, losing a log line costs
+    /// nothing. Consequence, stated rather than hidden: there is **no ordering
+    /// guarantee between this variant and the status variants**. They render in
+    /// different panels and have no causal relationship.
+    ///
+    /// Nothing is replayed on connect. The authoritative history is the JSONL
+    /// archive the manager writes, whose directory `/status` reports.
+    CoreLog(CoreLogInfo),
 }
 
 impl Event {
@@ -49,5 +151,9 @@ impl Event {
 
     pub fn new_core_status_changed(infos: CoreInfos) -> Self {
         Self::CoreStatusChanged(infos)
+    }
+
+    pub fn new_core_log(log: CoreLogInfo) -> Self {
+        Self::CoreLog(log)
     }
 }

--- a/nyanpasu_ipc/src/api/ws/events.rs
+++ b/nyanpasu_ipc/src/api/ws/events.rs
@@ -1,4 +1,3 @@
-use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 
 use crate::api::status::{CoreInfos, CoreState};
@@ -7,16 +6,6 @@ use crate::api::status::{CoreInfos, CoreState};
 /// parameter: the service binary ships with the program that consumes it, so
 /// every connection speaks the same stream and any query string is ignored.
 pub const EVENT_URI: &str = "/ws/events";
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(feature = "specta", derive(specta::Type))]
-pub struct TraceLog {
-    pub timestamp: String,
-    pub level: String,
-    pub message: String,
-    pub target: String,
-    pub fields: IndexMap<String, serde_json::Value>,
-}
 
 /// Which console stream a record arrived on.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -113,7 +102,6 @@ pub struct CoreLogInfo {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[cfg_attr(feature = "specta", derive(specta::Type))]
 pub enum Event {
-    Log(TraceLog),
     /// The lossy state, kept exactly as it has always been: `Starting` and
     /// `Restarting` are reported as `Stopped(None)`, so a crash loop is
     /// indistinguishable from a stop. Kept because the GUI still consumes it,
@@ -141,10 +129,6 @@ pub enum Event {
 }
 
 impl Event {
-    pub fn new_log(log: TraceLog) -> Self {
-        Self::Log(log)
-    }
-
     pub fn new_core_state_changed(state: CoreState) -> Self {
         Self::CoreStateChanged(state)
     }

--- a/nyanpasu_ipc/src/api/ws/events.rs
+++ b/nyanpasu_ipc/src/api/ws/events.rs
@@ -1,104 +1,27 @@
+use std::sync::Arc;
+
 use serde::{Deserialize, Serialize};
 
 use crate::api::status::{CoreInfos, CoreState};
+
+/// The core log vocabulary, re-exported so a consumer of this stream never has
+/// to name the metadata crate to spell the payload it just decoded.
+pub use nyanpasu_core_metadata::{
+    ClashCoreKind, LogField, LogFrame, LogLevel, LogStream, LogTimestamp,
+};
 
 /// The event endpoint. There is no protocol negotiation and no version
 /// parameter: the service binary ships with the program that consumes it, so
 /// every connection speaks the same stream and any query string is ignored.
 pub const EVENT_URI: &str = "/ws/events";
 
-/// Which console stream a record arrived on.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(feature = "specta", derive(specta::Type))]
-#[serde(rename_all = "lowercase")]
-pub enum CoreLogStream {
-    Stdout,
-    Stderr,
-}
-
-/// Normalized severity. Go's `fatal` and `panic` both terminate the process, so
-/// the manager's parser collapses them into `Fatal`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(feature = "specta", derive(specta::Type))]
-#[serde(rename_all = "lowercase")]
-pub enum CoreLogLevel {
-    Trace,
-    Debug,
-    Info,
-    Warning,
-    Error,
-    Fatal,
-}
-
-/// Which core printed the record.
-///
-/// A deliberately separate type from [`nyanpasu_utils::core::CoreType`], for
-/// the same reason [`crate::api::status::CoreControllerInfo`] is separate from
-/// `clash_api::Host` — but here there is a second, sharper reason: `CoreType`
-/// distinguishes alpha builds (`mihomo-alpha`, `clash-rs-alpha`) and a log
-/// frame does not. The manager parses console output per *kind*, and its four
-/// kinds are exactly these. Rendering a frame as `CoreType` would mean
-/// inventing a distinction the frame never carried.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(feature = "specta", derive(specta::Type))]
-pub enum CoreLogKind {
-    #[serde(rename = "mihomo")]
-    Mihomo,
-    #[serde(rename = "clash-rs")]
-    ClashRust,
-    #[serde(rename = "clash")]
-    ClashPremium,
-    #[serde(rename = "meow")]
-    Meow,
-}
-
-/// One structured field the core printed beside its message.
-///
-/// Not `clash_api::LogField`: clash-api is an internal dependency of the core
-/// manager and must not enter the wire dependency tree — the same rule that
-/// produced [`crate::api::status::CoreControllerInfo`].
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(feature = "specta", derive(specta::Type))]
-pub struct CoreLogField {
-    pub key: String,
-    pub value: String,
-}
-
-/// One normalized core console record.
-///
-/// What is deliberately absent is the point of the type. The manager's frame
-/// also carries `raw` (the whole logical record, up to 16 KiB), the timestamp's
-/// original spelling, and whether that timestamp was inferred. `raw` overlaps
-/// `message` almost entirely — for a record whose header did not parse they are
-/// the same string — and the other two are parser internals. The JSONL archive
-/// keeps all three for fidelity; this stream carries what a log panel renders.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[cfg_attr(feature = "specta", derive(specta::Type))]
-pub struct CoreLogInfo {
-    pub epoch: u64,
-    pub kind: CoreLogKind,
-    pub stream: CoreLogStream,
-    pub level: CoreLogLevel,
-    /// Unix milliseconds, stamped by the service when it observed the frame.
-    /// Always present, which is what makes the stream sortable: a record whose
-    /// header did not parse has no clock of its own.
-    pub at: i64,
-    /// Unix milliseconds as the core reported them, when it reported any. Clash
-    /// premium and clash-rs do not print a full instant, so the manager infers
-    /// theirs from the observation time — treat this as advisory and sort by
-    /// [`Self::at`].
-    pub timestamp_ms: Option<i64>,
-    /// Clash premium's `[Tag]` prefix, meow's tracing target, or clash-rs's
-    /// `file:line`.
-    pub target: Option<String>,
-    pub message: String,
-    /// Populated only where field boundaries are decidable, which today means
-    /// mihomo's quoted logfmt.
-    pub fields: Vec<CoreLogField>,
-    /// Continuation lines were dropped after hitting a size limit.
-    pub truncated: bool,
-}
-
+/// The status snapshot is the only large variant, and it is deliberately not
+/// boxed: since the log ring started carrying frames rather than events, every
+/// `Event` that exists travels on the status ring, where a `CoreStatusChanged`
+/// is the common case. Boxing would buy back a few dozen KiB of ring and pay for
+/// it with a heap allocation per snapshot, on the path that fans out to every
+/// connection.
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[cfg_attr(feature = "specta", derive(specta::Type))]
 pub enum Event {
@@ -116,16 +39,31 @@ pub enum Event {
     /// already keeps for `/status`. Treat it as idempotent — a reconnect or a
     /// lag recovery can repeat one.
     CoreStatusChanged(CoreInfos),
-    /// One core console record, pushed live. Carried on its own broadcast ring
-    /// inside the service, because the two streams fail differently: losing a
-    /// status frame costs a full snapshot resend, losing a log line costs
-    /// nothing. Consequence, stated rather than hidden: there is **no ordering
-    /// guarantee between this variant and the status variants**. They render in
-    /// different panels and have no causal relationship.
+    /// One core console record, pushed live — the manager's own frame, not a
+    /// projection of it. The archive and this stream therefore carry the same
+    /// bytes: `raw` is present because under the service's ACL a client cannot
+    /// read the JSONL archive, which makes this the only live fidelity source
+    /// there is.
+    ///
+    /// Two clocks, and they mean different things. [`LogFrame::at`] is when the
+    /// manager's parser observed the record's root line and is always present,
+    /// so it is what a client sorts on; `timestamp` is what the core itself
+    /// printed, absent when the header did not parse and `inferred` when the
+    /// core printed only a time of day.
+    ///
+    /// Carried on its own broadcast ring inside the service, because the two
+    /// streams fail differently: losing a status frame costs a full snapshot
+    /// resend, losing a log line costs nothing. Consequence, stated rather than
+    /// hidden: there is **no ordering guarantee between this variant and the
+    /// status variants**. They render in different panels and have no causal
+    /// relationship.
     ///
     /// Nothing is replayed on connect. The authoritative history is the JSONL
     /// archive the manager writes, whose directory `/status` reports.
-    CoreLog(CoreLogInfo),
+    ///
+    /// The `Arc` is a service-side fan-out detail and is invisible on the wire:
+    /// serde encodes it as the frame itself.
+    CoreLog(Arc<LogFrame>),
 }
 
 impl Event {
@@ -137,7 +75,7 @@ impl Event {
         Self::CoreStatusChanged(infos)
     }
 
-    pub fn new_core_log(log: CoreLogInfo) -> Self {
-        Self::CoreLog(log)
+    pub fn new_core_log(frame: Arc<LogFrame>) -> Self {
+        Self::CoreLog(frame)
     }
 }

--- a/nyanpasu_ipc/tests/roundtrip.rs
+++ b/nyanpasu_ipc/tests/roundtrip.rs
@@ -56,7 +56,10 @@ use nyanpasu_ipc::{
             ConfigRevisionInfo, CoreInfos, CoreState, CoreStateDetail, RevisionIdInfo,
             RuntimeInfos, STATUS_ENDPOINT, StatusRes, StatusResBody,
         },
-        ws::events::{EVENT_URI, Event, TraceLog},
+        ws::events::{
+            CoreLogField, CoreLogInfo, CoreLogKind, CoreLogLevel, CoreLogStream, EVENT_URI, Event,
+            TraceLog,
+        },
     },
     client::{Client, ClientError},
 };
@@ -315,6 +318,18 @@ async fn ws_handler(ws: WebSocketUpgrade) -> Response {
                 fields: IndexMap::new(),
             }),
             Event::new_core_state_changed(CoreState::Stopped(Some("bye".to_owned()))),
+            Event::new_core_log(CoreLogInfo {
+                epoch: 4,
+                kind: CoreLogKind::Mihomo,
+                stream: CoreLogStream::Stdout,
+                level: CoreLogLevel::Info,
+                at: 1_700_000_000_000,
+                timestamp_ms: Some(1_753_719_382_646),
+                target: Some("dns".to_owned()),
+                message: "hello core".to_owned(),
+                fields: Vec::<CoreLogField>::new(),
+                truncated: false,
+            }),
         ];
         for event in events {
             let bytes = serde_json::to_vec(&event).unwrap();
@@ -567,6 +582,48 @@ async fn events_roundtrip() {
         }
         other => panic!("expected a core state changed event, got: {other:?}"),
     }
+
+    let _ = shutdown.send(());
+    cleanup(&placeholder);
+}
+
+/// The new variant over the real transport: it decodes through the same
+/// unchanged `EventStream` path, behind the frames a pre-L2 client already
+/// understood. A client that predates the variant fails on this one frame only
+/// — `filter_map` yields `Some(Err(Decode))` and the stream keeps running —
+/// which is what lets L2 ship without the GUI.
+#[tokio::test]
+async fn core_log_roundtrip() {
+    let placeholder = format!("nyanpasu-ipc-test-{}-core-log", std::process::id());
+    let Some((shutdown, client)) = run_server(&placeholder, test_router(Shared::default())).await
+    else {
+        return;
+    };
+
+    let mut events = client.events().await.expect("events should connect");
+    let mut seen = None;
+    for _ in 0..4 {
+        let event = events
+            .next()
+            .await
+            .expect("stream should yield four frames")
+            .expect("every frame should decode");
+        if let Event::CoreLog(log) = event {
+            seen = Some(log);
+        }
+    }
+
+    let log = seen.expect("the stream should carry a core log frame");
+    assert_eq!(log.epoch, 4);
+    assert_eq!(log.kind, CoreLogKind::Mihomo);
+    assert_eq!(log.stream, CoreLogStream::Stdout);
+    assert_eq!(log.level, CoreLogLevel::Info);
+    assert_eq!(log.at, 1_700_000_000_000);
+    assert_eq!(log.timestamp_ms, Some(1_753_719_382_646));
+    assert_eq!(log.target.as_deref(), Some("dns"));
+    assert_eq!(log.message, "hello core");
+    assert!(log.fields.is_empty());
+    assert!(!log.truncated);
 
     let _ = shutdown.send(());
     cleanup(&placeholder);

--- a/nyanpasu_ipc/tests/roundtrip.rs
+++ b/nyanpasu_ipc/tests/roundtrip.rs
@@ -56,7 +56,7 @@ use nyanpasu_ipc::{
             RuntimeInfos, STATUS_ENDPOINT, StatusRes, StatusResBody,
         },
         ws::events::{
-            CoreLogField, CoreLogInfo, CoreLogKind, CoreLogLevel, CoreLogStream, EVENT_URI, Event,
+            ClashCoreKind, EVENT_URI, Event, LogFrame, LogLevel, LogStream, LogTimestamp,
         },
     },
     client::{Client, ClientError},
@@ -310,18 +310,23 @@ async fn ws_handler(ws: WebSocketUpgrade) -> Response {
         let events = [
             Event::new_core_status_changed(test_snapshot()),
             Event::new_core_state_changed(CoreState::Stopped(Some("bye".to_owned()))),
-            Event::new_core_log(CoreLogInfo {
-                epoch: 4,
-                kind: CoreLogKind::Mihomo,
-                stream: CoreLogStream::Stdout,
-                level: CoreLogLevel::Info,
+            Event::new_core_log(std::sync::Arc::new(LogFrame {
                 at: 1_700_000_000_000,
-                timestamp_ms: Some(1_753_719_382_646),
+                epoch: 4,
+                kind: ClashCoreKind::Mihomo,
+                stream: LogStream::Stdout,
+                level: LogLevel::Info,
+                timestamp: Some(LogTimestamp {
+                    raw: "2026-07-29T00:16:22.646059400+08:00".to_owned(),
+                    unix_ms: Some(1_753_719_382_646),
+                    inferred: false,
+                }),
                 target: Some("dns".to_owned()),
                 message: "hello core".to_owned(),
-                fields: Vec::<CoreLogField>::new(),
+                fields: Vec::new(),
+                raw: "the whole logical record".to_owned(),
                 truncated: false,
-            }),
+            })),
         ];
         for event in events {
             let bytes = serde_json::to_vec(&event).unwrap();
@@ -592,15 +597,19 @@ async fn core_log_roundtrip() {
     }
 
     let log = seen.expect("the stream should carry a core log frame");
-    assert_eq!(log.epoch, 4);
-    assert_eq!(log.kind, CoreLogKind::Mihomo);
-    assert_eq!(log.stream, CoreLogStream::Stdout);
-    assert_eq!(log.level, CoreLogLevel::Info);
     assert_eq!(log.at, 1_700_000_000_000);
-    assert_eq!(log.timestamp_ms, Some(1_753_719_382_646));
+    assert_eq!(log.epoch, 4);
+    assert_eq!(log.kind, ClashCoreKind::Mihomo);
+    assert_eq!(log.stream, LogStream::Stdout);
+    assert_eq!(log.level, LogLevel::Info);
+    let timestamp = log.timestamp.as_ref().expect("the fixture parsed a header");
+    assert_eq!(timestamp.raw, "2026-07-29T00:16:22.646059400+08:00");
+    assert_eq!(timestamp.unix_ms, Some(1_753_719_382_646));
+    assert!(!timestamp.inferred);
     assert_eq!(log.target.as_deref(), Some("dns"));
     assert_eq!(log.message, "hello core");
     assert!(log.fields.is_empty());
+    assert_eq!(log.raw, "the whole logical record");
     assert!(!log.truncated);
 
     let _ = shutdown.send(());

--- a/nyanpasu_ipc/tests/roundtrip.rs
+++ b/nyanpasu_ipc/tests/roundtrip.rs
@@ -33,7 +33,6 @@ use axum::{
     routing::{get, post},
 };
 use futures_util::StreamExt;
-use indexmap::IndexMap;
 use interprocess::local_socket::{
     GenericFilePath, ListenerNonblockingMode, ListenerOptions, ToFsName,
     tokio::{Listener, Stream as IpcStream, prelude::*},
@@ -58,7 +57,6 @@ use nyanpasu_ipc::{
         },
         ws::events::{
             CoreLogField, CoreLogInfo, CoreLogKind, CoreLogLevel, CoreLogStream, EVENT_URI, Event,
-            TraceLog,
         },
     },
     client::{Client, ClientError},
@@ -224,6 +222,7 @@ fn test_status_body() -> StatusResBody<'static> {
             nyanpasu_config_dir: Cow::Owned(PathBuf::from("/home/config")),
             nyanpasu_data_dir: Cow::Owned(PathBuf::from("/home/data")),
         },
+        logs: None,
     }
 }
 
@@ -310,13 +309,6 @@ async fn ws_handler(ws: WebSocketUpgrade) -> Response {
     ws.on_upgrade(|mut socket: WebSocket| async move {
         let events = [
             Event::new_core_status_changed(test_snapshot()),
-            Event::new_log(TraceLog {
-                timestamp: "2026-01-01T00:00:00Z".to_owned(),
-                level: "INFO".to_owned(),
-                message: "hello events".to_owned(),
-                target: "roundtrip".to_owned(),
-                fields: IndexMap::new(),
-            }),
             Event::new_core_state_changed(CoreState::Stopped(Some("bye".to_owned()))),
             Event::new_core_log(CoreLogInfo {
                 epoch: 4,
@@ -560,20 +552,6 @@ async fn events_roundtrip() {
     let event = events
         .next()
         .await
-        .expect("stream should yield the log event")
-        .expect("log event should decode");
-    match event {
-        Event::Log(log) => {
-            assert_eq!(log.message, "hello events");
-            assert_eq!(log.target, "roundtrip");
-            assert_eq!(log.level, "INFO");
-        }
-        other => panic!("expected a log event, got: {other:?}"),
-    }
-
-    let event = events
-        .next()
-        .await
         .expect("stream should yield the legacy state event")
         .expect("legacy state event should decode");
     match event {
@@ -602,11 +580,11 @@ async fn core_log_roundtrip() {
 
     let mut events = client.events().await.expect("events should connect");
     let mut seen = None;
-    for _ in 0..4 {
+    for _ in 0..3 {
         let event = events
             .next()
             .await
-            .expect("stream should yield four frames")
+            .expect("stream should yield three frames")
             .expect("every frame should decode");
         if let Event::CoreLog(log) = event {
             seen = Some(log);

--- a/nyanpasu_ipc/tests/wire_golden.rs
+++ b/nyanpasu_ipc/tests/wire_golden.rs
@@ -9,6 +9,7 @@ use std::{
     borrow::Cow,
     net::{IpAddr, Ipv4Addr},
     path::PathBuf,
+    sync::Arc,
 };
 
 use nyanpasu_ipc::api::{
@@ -26,7 +27,7 @@ use nyanpasu_ipc::api::{
         CoreState, CoreStateDetail, LogPathsInfo, RevisionIdInfo, RuntimeInfos, StatusResBody,
     },
     ws::events::{
-        CoreLogField, CoreLogInfo, CoreLogKind, CoreLogLevel, CoreLogStream, EVENT_URI, Event,
+        ClashCoreKind, EVENT_URI, Event, LogField, LogFrame, LogLevel, LogStream, LogTimestamp,
     },
 };
 use nyanpasu_utils::core::{ClashCoreType, CoreType};
@@ -377,21 +378,27 @@ fn the_ws_events_are_pinned() {
 /// with `serde_json`, so a divergence must show up as a diff between two
 /// otherwise identical strings.
 fn pinned_core_log() -> Event {
-    Event::new_core_log(CoreLogInfo {
-        epoch: 1,
-        kind: CoreLogKind::Mihomo,
-        stream: CoreLogStream::Stdout,
-        level: CoreLogLevel::Info,
+    Event::new_core_log(Arc::new(LogFrame {
         at: 1_700_000_000_000,
-        timestamp_ms: Some(1_753_719_382_646),
+        epoch: 1,
+        kind: ClashCoreKind::Mihomo,
+        stream: LogStream::Stdout,
+        level: LogLevel::Info,
+        timestamp: Some(LogTimestamp {
+            raw: "2026-07-29T00:16:22.646059400+08:00".to_owned(),
+            unix_ms: Some(1_753_719_382_646),
+            inferred: false,
+        }),
         target: None,
         message: "hello core".to_owned(),
-        fields: vec![CoreLogField {
+        fields: vec![LogField {
             key: "request".to_owned(),
             value: "7".to_owned(),
         }],
+        raw: "time=\"2026-07-29T00:16:22.646059400+08:00\" level=info msg=\"hello core\" request=7"
+            .to_owned(),
         truncated: false,
-    })
+    }))
 }
 
 #[test]
@@ -399,10 +406,12 @@ fn the_core_log_event_is_pinned() {
     assert_eq!(
         serde_json::to_string(&pinned_core_log()).unwrap(),
         concat!(
-            r#"{"CoreLog":{"epoch":1,"kind":"mihomo","stream":"stdout","level":"info","#,
-            r#""at":1700000000000,"timestamp_ms":1753719382646,"target":null,"#,
+            r#"{"CoreLog":{"at":1700000000000,"epoch":1,"kind":"mihomo","stream":"stdout","#,
+            r#""level":"info","timestamp":{"raw":"2026-07-29T00:16:22.646059400+08:00","#,
+            r#""unix_ms":1753719382646,"inferred":false},"target":null,"#,
             r#""message":"hello core","fields":[{"key":"request","value":"7"}],"#,
-            r#""truncated":false}}"#
+            r#""raw":"time=\"2026-07-29T00:16:22.646059400+08:00\" level=info "#,
+            r#"msg=\"hello core\" request=7","truncated":false}}"#
         )
     );
 }
@@ -412,24 +421,26 @@ fn the_core_log_event_is_pinned() {
 /// still sortable.
 #[test]
 fn a_degraded_core_log_event_is_pinned() {
-    let event = Event::new_core_log(CoreLogInfo {
-        epoch: 2,
-        kind: CoreLogKind::ClashRust,
-        stream: CoreLogStream::Stderr,
-        level: CoreLogLevel::Warning,
+    let event = Event::new_core_log(Arc::new(LogFrame {
         at: 1_700_000_000_001,
-        timestamp_ms: None,
+        epoch: 2,
+        kind: ClashCoreKind::ClashRust,
+        stream: LogStream::Stderr,
+        level: LogLevel::Warning,
+        timestamp: None,
         target: None,
         message: "unparsed line".to_owned(),
         fields: Vec::new(),
+        raw: "unparsed line".to_owned(),
         truncated: true,
-    });
+    }));
     assert_eq!(
         serde_json::to_string(&event).unwrap(),
         concat!(
-            r#"{"CoreLog":{"epoch":2,"kind":"clash-rs","stream":"stderr","#,
-            r#""level":"warning","at":1700000000001,"timestamp_ms":null,"target":null,"#,
-            r#""message":"unparsed line","fields":[],"truncated":true}}"#
+            r#"{"CoreLog":{"at":1700000000001,"epoch":2,"kind":"clash-rs","stream":"stderr","#,
+            r#""level":"warning","timestamp":null,"target":null,"#,
+            r#""message":"unparsed line","fields":[],"raw":"unparsed line","#,
+            r#""truncated":true}}"#
         )
     );
 }

--- a/nyanpasu_ipc/tests/wire_golden.rs
+++ b/nyanpasu_ipc/tests/wire_golden.rs
@@ -11,7 +11,6 @@ use std::{
     path::PathBuf,
 };
 
-use indexmap::IndexMap;
 use nyanpasu_ipc::api::{
     R, RBuilder, ResponseCode,
     core::{
@@ -24,11 +23,10 @@ use nyanpasu_ipc::api::{
     network::set_dns::NetworkSetDnsReq,
     status::{
         ConfigRevisionInfo, CoreControllerInfo, CoreHealthInfo, CoreHealthState, CoreInfos,
-        CoreState, CoreStateDetail, RevisionIdInfo, RuntimeInfos, StatusResBody,
+        CoreState, CoreStateDetail, LogPathsInfo, RevisionIdInfo, RuntimeInfos, StatusResBody,
     },
     ws::events::{
         CoreLogField, CoreLogInfo, CoreLogKind, CoreLogLevel, CoreLogStream, EVENT_URI, Event,
-        TraceLog,
     },
 };
 use nyanpasu_utils::core::{ClashCoreType, CoreType};
@@ -329,6 +327,7 @@ fn the_status_response_is_pinned() {
             nyanpasu_config_dir: Cow::Owned(PathBuf::from("/home/config")),
             nyanpasu_data_dir: Cow::Owned(PathBuf::from("/home/data")),
         },
+        logs: None,
     };
     assert_eq!(
         serde_json::to_string(&ok_envelope(body)).unwrap(),
@@ -360,25 +359,12 @@ fn the_core_states_are_pinned() {
     );
 }
 
+/// The legacy state frame, unchanged since before S7. A service-log frame was
+/// pinned here too until L3, when the service stopped pushing its own logs.
+/// (Deliberately not naming the removed variant: §7 step 2's `rg` gate covers
+/// this file.)
 #[test]
 fn the_ws_events_are_pinned() {
-    let mut fields = IndexMap::new();
-    fields.insert("epoch".to_owned(), serde_json::json!(1));
-    let log = Event::new_log(TraceLog {
-        timestamp: "2026-01-01T00:00:00Z".to_owned(),
-        level: "INFO".to_owned(),
-        message: "hello".to_owned(),
-        target: "nyanpasu_service::core".to_owned(),
-        fields,
-    });
-    assert_eq!(
-        serde_json::to_string(&log).unwrap(),
-        concat!(
-            r#"{"Log":{"timestamp":"2026-01-01T00:00:00Z","level":"INFO","#,
-            r#""message":"hello","target":"nyanpasu_service::core","#,
-            r#""fields":{"epoch":1}}}"#
-        )
-    );
     assert_eq!(
         serde_json::to_string(&Event::new_core_state_changed(CoreState::Running)).unwrap(),
         r#"{"CoreStateChanged":"Running"}"#
@@ -615,6 +601,7 @@ fn the_enriched_status_response_is_pinned() {
             nyanpasu_config_dir: Cow::Owned(PathBuf::from("/home/config")),
             nyanpasu_data_dir: Cow::Owned(PathBuf::from("/home/data")),
         },
+        logs: None,
     };
     assert_eq!(
         serde_json::to_string(&ok_envelope(body)).unwrap(),
@@ -635,6 +622,33 @@ fn the_enriched_status_response_is_pinned() {
             r#""nyanpasu_config_dir":"/home/config","#,
             r#""nyanpasu_data_dir":"/home/data"}},"ts":1700000000}"#
         )
+    );
+}
+
+/// The L3 addition. The field is `Option` only so a payload without it matches
+/// the pre-L3 bytes exactly — which the two literals above still assert — but
+/// the service always sends it.
+#[test]
+fn the_status_log_paths_are_pinned() {
+    assert_eq!(
+        serde_json::to_string(&LogPathsInfo {
+            service_dir: PathBuf::from("/var/lib/nyanpasu-service/logs"),
+            core_dir: Some(PathBuf::from("/var/lib/nyanpasu-service/core-runtime/logs")),
+        })
+        .unwrap(),
+        concat!(
+            r#"{"service_dir":"/var/lib/nyanpasu-service/logs","#,
+            r#""core_dir":"/var/lib/nyanpasu-service/core-runtime/logs"}"#
+        )
+    );
+    // Sink disabled: the key is omitted, not null.
+    assert_eq!(
+        serde_json::to_string(&LogPathsInfo {
+            service_dir: PathBuf::from("/var/lib/nyanpasu-service/logs"),
+            core_dir: None,
+        })
+        .unwrap(),
+        r#"{"service_dir":"/var/lib/nyanpasu-service/logs"}"#
     );
 }
 

--- a/nyanpasu_ipc/tests/wire_golden.rs
+++ b/nyanpasu_ipc/tests/wire_golden.rs
@@ -26,7 +26,10 @@ use nyanpasu_ipc::api::{
         ConfigRevisionInfo, CoreControllerInfo, CoreHealthInfo, CoreHealthState, CoreInfos,
         CoreState, CoreStateDetail, RevisionIdInfo, RuntimeInfos, StatusResBody,
     },
-    ws::events::{EVENT_URI, Event, TraceLog},
+    ws::events::{
+        CoreLogField, CoreLogInfo, CoreLogKind, CoreLogLevel, CoreLogStream, EVENT_URI, Event,
+        TraceLog,
+    },
 };
 use nyanpasu_utils::core::{ClashCoreType, CoreType};
 
@@ -379,6 +382,69 @@ fn the_ws_events_are_pinned() {
     assert_eq!(
         serde_json::to_string(&Event::new_core_state_changed(CoreState::Running)).unwrap(),
         r#"{"CoreStateChanged":"Running"}"#
+    );
+}
+
+/// The fixture both serializer pins use. `crates/nyanpasu-service-runtime`'s
+/// `ws_core_log_frames_are_pinned` builds the identical value and asserts the
+/// identical literal: the service writes with `simd_json` and the client reads
+/// with `serde_json`, so a divergence must show up as a diff between two
+/// otherwise identical strings.
+fn pinned_core_log() -> Event {
+    Event::new_core_log(CoreLogInfo {
+        epoch: 1,
+        kind: CoreLogKind::Mihomo,
+        stream: CoreLogStream::Stdout,
+        level: CoreLogLevel::Info,
+        at: 1_700_000_000_000,
+        timestamp_ms: Some(1_753_719_382_646),
+        target: None,
+        message: "hello core".to_owned(),
+        fields: vec![CoreLogField {
+            key: "request".to_owned(),
+            value: "7".to_owned(),
+        }],
+        truncated: false,
+    })
+}
+
+#[test]
+fn the_core_log_event_is_pinned() {
+    assert_eq!(
+        serde_json::to_string(&pinned_core_log()).unwrap(),
+        concat!(
+            r#"{"CoreLog":{"epoch":1,"kind":"mihomo","stream":"stdout","level":"info","#,
+            r#""at":1700000000000,"timestamp_ms":1753719382646,"target":null,"#,
+            r#""message":"hello core","fields":[{"key":"request","value":"7"}],"#,
+            r#""truncated":false}}"#
+        )
+    );
+}
+
+/// The degraded shape, which is the common one: a line whose header did not
+/// parse has no clock, no target and no fields — and `at` is why the record is
+/// still sortable.
+#[test]
+fn a_degraded_core_log_event_is_pinned() {
+    let event = Event::new_core_log(CoreLogInfo {
+        epoch: 2,
+        kind: CoreLogKind::ClashRust,
+        stream: CoreLogStream::Stderr,
+        level: CoreLogLevel::Warning,
+        at: 1_700_000_000_001,
+        timestamp_ms: None,
+        target: None,
+        message: "unparsed line".to_owned(),
+        fields: Vec::new(),
+        truncated: true,
+    });
+    assert_eq!(
+        serde_json::to_string(&event).unwrap(),
+        concat!(
+            r#"{"CoreLog":{"epoch":2,"kind":"clash-rs","stream":"stderr","#,
+            r#""level":"warning","at":1700000000001,"timestamp_ms":null,"target":null,"#,
+            r#""message":"unparsed line","fields":[],"truncated":true}}"#
+        )
     );
 }
 


### PR DESCRIPTION
Core log pipeline in three stages plus a three-round review-fix loop. Core console output gets a durable, size-bounded on-disk home and a dedicated live push channel; the service stops streaming its own logs and instead tells callers where the files are.

## Stages

**L1 — `feat(core-manager)`: rotating JSONL archive (cbdff2c)**
- New `log_sink` module: an ordinary subscriber of the manager's existing `log_tx` broadcast — never on the supervision hot path.
- One rolling stream `{runtime_dir}/logs/core-NNNNNN.jsonl`, `epoch`/`kind` as record fields (epochs renumber after a clean stop, so per-epoch files would collide; `jq 'select(.epoch==7)'` separates at zero cost).
- Hand-rolled rotation: size limit checked **per record** (a burst batch cannot overshoot by more than one record), retention by count, prune on rollover and startup, `{"t":"gap","dropped":n}` records make broadcast loss explicit.
- Knobs: `log_sink_enabled` (true), `log_max_bytes` (4 MiB), `log_max_files` (5) — a 20 MiB ceiling. Directory is ACL-hardened (`SE_DACL_PROTECTED` verified; inherited DACLs don't carry it).

**L2 — `feat(ipc,service)`: `Event::CoreLog` on its own ring (f56b739)**
- New wire types `CoreLogInfo`/`CoreLogKind`/`CoreLogStream`/`CoreLogLevel`/`CoreLogField` (ipc-local; `CoreType` would invent an alpha distinction the frame never carried). No `raw` on the wire — files are fidelity, the stream is live view.
- Second broadcast ring in `EventHub` (1024 beside status's 256). The two streams fail differently: a dropped status frame must trigger a snapshot resync, a dropped log line must trigger nothing. The ws handler `select!`s both; log-ring lag = debug + resubscribe, **no snapshot resend**.
- Purely additive: every pre-existing golden literal byte-identical, old GUIs see one decode error per CoreLog frame and keep streaming.

**L3 — `refactor(ipc,service)!`: retire `Event::Log`, publish the directories (89df381)**
- `Event::Log`/`TraceLog` leave the wire; the tracing→hub callback, `Logger`'s subscriber machinery and the `WS_LAG_LOG_TARGET` filter are deleted — the log→hub→lag-warn→log feedback-loop class becomes structurally impossible rather than filtered.
- `/status` gains `logs { service_dir, core_dir? }` (Option-tail rule; pre-L3 payloads byte-identical). `service_logs_dir` is ACL-hardened now that it's advertised; hardening failure fails startup by design.
- Core-log tracing de-duplicated: the supervision-loop inline call is gone; the bridge's `forward_log` dispatches on the parsed level, capped at DEBUG (`RUST_LOG=nyanpasu_service::core=debug` re-enables without `--verbose`).

## Review-fix rounds (dual-model review: codex 62→78→81→**mergeable YES**; antigravity 98 APPROVE)

- **R1 (abdb473)**: sink lifecycle handle awaited in `shutdown()` before directory-lock release; drain batches capped at 256 records; size caps extended to `target`/`timestamp.raw`/`fields` on disk **and** `message`/`target`/`fields` on the wire (both reviewers independently found the cap bypass); symlink/reparse guard before log-dir hardening; prune-before-create; projection skipped when nobody subscribes.
- **R2 (9839495)**: timeout no longer detaches the writer (`&mut` poll → abort → await, termination proven); shutdown finalizes the sink on error paths too (finally-shaped, original error preserved); `log_max_files == 1` can no longer unlink the active file (prune gains a `protect` parameter).
- **R3 (0196a57)**: `ctrl` guard held through sink finalization, restoring control-plane serialization the R2 restructure had narrowed.

## Breaking changes / release notes

1. `Event::Log`, `TraceLog`, `Event::new_log` are **removed**. The GUI must consume `Event::CoreLog` (L2) before shipping against this; exhaustive `match`es on `Event` stop compiling.
2. A pre-L3 GUI against this service **silently** loses service logs — no error, the variant simply never arrives. Most likely failure to be misread as "logging broke".
3. `/status` gains `logs`; `core_dir` absent means the archive is switched off, not an error.
4. **Both advertised directories are elevated-read-only** (owner/SYSTEM/Administrators; the verifier rejects user-readable DACLs). They are locations for support requests, **not a read grant** — a user-level GUI cannot tail them. Live core output is the `CoreLog` stream. Granting reads would need a second SDDL + relaxed verifier in `nyanpasu-utils` (separate repo/PR) and is an open posture question.
5. Core output leaves the service's own log file at the default filter (authoritative copies: JSONL archive + event stream).
6. A machine where the service log directory cannot be created or ACL-hardened now fails startup instead of running unprotected.

## Tests

core-manager 144 → **164**, ipc+runtime 140 → **152** (ipc 48 / runtime 104); wire goldens for every new shape, both serializers pinned to identical literals (server writes simd_json, client reads serde_json); pre-S7/pre-L3 payload decode pins intact; known pre-existing red unchanged (`logging.rs:25` under `--all-features`).

Known follow-ups (deliberately out of scope): `nyanpasu-utils` owner verification on pre-existing directories; the user-readability posture decision above; sink-timeout/concurrent-shutdown test coverage (noted as review suggestions, not blockers).

cc @4o3f
