### PR TITLE
refactor(ipc)!: converge the service error protocol on a typed CoreErrorKind

### DIFF
--- a/crates/nyanpasu-core-manager/src/error.rs
+++ b/crates/nyanpasu-core-manager/src/error.rs
@@ -1,4 +1,5 @@
 use camino::Utf8PathBuf;
+pub use nyanpasu_core_metadata::CoreErrorKind;
 
 use crate::{kind::CoreKind, state::RevisionId};
 
@@ -71,6 +72,52 @@ pub enum Error {
     Io(#[from] std::io::Error),
 }
 
+impl Error {
+    /// The machine-readable classification a caller can branch on, or `None`
+    /// when this failure has none.
+    ///
+    /// `None` means "not classified", never "no error": naming a kind is a
+    /// statement of fact about the failure, and a guessed one is worse than an
+    /// absent one. The wire omits the field entirely for `None`.
+    ///
+    /// The match is exhaustive on purpose. `Error` is `#[non_exhaustive]` only
+    /// to *downstream* crates, so this — the defining crate — is the one place
+    /// a new variant can be made to fail the build instead of silently
+    /// answering `None`. Do not collapse the unclassified arms into a wildcard.
+    pub fn kind(&self) -> Option<CoreErrorKind> {
+        match self {
+            Self::AlreadyRunning => Some(CoreErrorKind::AlreadyRunning),
+            Self::NotStarted => Some(CoreErrorKind::NotStarted),
+            Self::ConfigNotFound(_) => Some(CoreErrorKind::ConfigNotFound),
+            Self::BinaryNotFound(_) => Some(CoreErrorKind::BinaryNotFound),
+            Self::ControllerMissing => Some(CoreErrorKind::ControllerMissing),
+            Self::ConfigCheckFailed(_) => Some(CoreErrorKind::ConfigCheckFailed),
+            Self::InvalidConfig(_) | Self::Yaml(_) => Some(CoreErrorKind::InvalidConfig),
+            Self::StopUnconfirmed(_) => Some(CoreErrorKind::StopUnconfirmed),
+            Self::ManagerQuarantined { .. } => Some(CoreErrorKind::Quarantined),
+            Self::RevisionConflict { .. } => Some(CoreErrorKind::RevisionConflict),
+            Self::ApplyFailed(_) => Some(CoreErrorKind::ApplyFailed),
+            Self::ApplyRollbackFailed { .. } => Some(CoreErrorKind::ApplyRollbackFailed),
+            // The durability wrapper is a warning around a real failure; report
+            // the failure's kind so a caller can still branch on it.
+            Self::DurabilityUncertain { source, .. } => source.kind(),
+            // Unclassified, listed one by one so a new variant is a compile
+            // error here. Mapping these is the protocol report's P3.
+            Self::CoreVersionProbeFailed { .. }
+            | Self::RequiredLocalIpcUnsupported { .. }
+            | Self::InvalidManagerOptions(_)
+            | Self::InvalidHealthPolicy(_)
+            | Self::UnsafeRuntimeArtifact(_)
+            | Self::RuntimeDirectoryOwned(_)
+            | Self::StartupTimeout { .. }
+            | Self::StartupFailed { .. }
+            | Self::Process(_)
+            | Self::Api(_)
+            | Self::Io(_) => None,
+        }
+    }
+}
+
 impl From<nyanpasu_utils::io::atomic_fs::AtomicFsError> for Error {
     fn from(error: nyanpasu_utils::io::atomic_fs::AtomicFsError) -> Self {
         use nyanpasu_utils::io::atomic_fs::AtomicFsError;
@@ -85,4 +132,99 @@ impl From<nyanpasu_utils::io::atomic_fs::AtomicFsError> for Error {
 fn utf8_lossy(path: std::path::PathBuf) -> Utf8PathBuf {
     Utf8PathBuf::from_path_buf(path)
         .unwrap_or_else(|path| Utf8PathBuf::from(path.to_string_lossy().into_owned()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn manager_errors_carry_their_wire_kind() {
+        let cases: [(Error, Option<CoreErrorKind>); 8] = [
+            (Error::NotStarted, Some(CoreErrorKind::NotStarted)),
+            (Error::AlreadyRunning, Some(CoreErrorKind::AlreadyRunning)),
+            (
+                Error::RevisionConflict {
+                    expected: RevisionId {
+                        epoch: 3,
+                        generation: 7,
+                        effective_hash: "fedcba9876543210".to_owned(),
+                    },
+                    actual: None,
+                },
+                Some(CoreErrorKind::RevisionConflict),
+            ),
+            (
+                Error::ManagerQuarantined {
+                    epoch: 3,
+                    reason: "death unconfirmed".to_owned(),
+                },
+                Some(CoreErrorKind::Quarantined),
+            ),
+            (
+                Error::ConfigCheckFailed("unknown field".to_owned()),
+                Some(CoreErrorKind::ConfigCheckFailed),
+            ),
+            (
+                Error::ControllerMissing,
+                Some(CoreErrorKind::ControllerMissing),
+            ),
+            (
+                Error::DurabilityUncertain {
+                    source: Box::new(Error::ApplyFailed("boom".to_owned())),
+                    warning: "sync failed".to_owned(),
+                },
+                Some(CoreErrorKind::ApplyFailed),
+            ),
+            (
+                Error::StartupFailed {
+                    stderr_tail: String::new(),
+                },
+                None,
+            ),
+        ];
+        for (error, expected) in cases {
+            assert_eq!(error.kind(), expected, "{error}");
+        }
+    }
+
+    #[test]
+    fn the_durability_wrapper_reports_its_source_kind() {
+        let error = Error::DurabilityUncertain {
+            source: Box::new(Error::ApplyFailed("boom".to_owned())),
+            warning: "sync failed".to_owned(),
+        };
+        assert_eq!(error.kind(), Some(CoreErrorKind::ApplyFailed));
+    }
+
+    #[test]
+    fn a_nested_durability_wrapper_still_reaches_the_source() {
+        let error = Error::DurabilityUncertain {
+            source: Box::new(Error::DurabilityUncertain {
+                source: Box::new(Error::RevisionConflict {
+                    expected: RevisionId {
+                        epoch: 3,
+                        generation: 7,
+                        effective_hash: "fedcba9876543210".to_owned(),
+                    },
+                    actual: None,
+                }),
+                warning: "inner sync failed".to_owned(),
+            }),
+            warning: "outer sync failed".to_owned(),
+        };
+        assert_eq!(error.kind(), Some(CoreErrorKind::RevisionConflict));
+    }
+
+    #[test]
+    fn an_unclassified_failure_has_no_kind() {
+        assert!(Error::Io(std::io::Error::other("boom")).kind().is_none());
+        assert!(
+            Error::StartupTimeout {
+                stderr_tail: String::new(),
+            }
+            .kind()
+            .is_none()
+        );
+    }
 }

--- a/crates/nyanpasu-core-manager/src/lib.rs
+++ b/crates/nyanpasu-core-manager/src/lib.rs
@@ -18,7 +18,7 @@ pub mod state;
 pub use capability::{Feature, RuntimeFeature};
 pub use clash_api::Host;
 pub use config::runtime_store;
-pub use error::Error;
+pub use error::{CoreErrorKind, Error};
 pub use health::{HealthPolicy, probe};
 pub use instance::{Instance, InstanceBuilder};
 pub use kind::CoreKind;

--- a/crates/nyanpasu-core-metadata/src/error_kind.rs
+++ b/crates/nyanpasu-core-metadata/src/error_kind.rs
@@ -1,0 +1,152 @@
+//! Stable machine-readable classifications for core-manager failures.
+//!
+//! Lives here rather than in the core manager because three layers need the
+//! same type: the manager that classifies a failure, the IPC envelope that
+//! carries it, and the client that interprets it. Every wire spelling is
+//! defined here.
+
+use serde::{Deserialize, Serialize};
+use specta::Type;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Type, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CoreErrorKind {
+    /// The operation needs a running core and there is none.
+    NotStarted,
+    /// The operation needs a stopped core and one is running.
+    AlreadyRunning,
+    /// `expected_revision` did not match the running revision. Nothing was
+    /// applied; re-read `/status` for the current one and retry.
+    RevisionConflict,
+    /// An epoch whose death could not be confirmed has latched the manager.
+    /// Every lifecycle operation is refused until `POST /core/recover` clears it.
+    Quarantined,
+    /// The core itself rejected the config in a dry run.
+    ConfigCheckFailed,
+    ConfigNotFound,
+    BinaryNotFound,
+    /// The config could not be parsed or canonicalized.
+    InvalidConfig,
+    /// The config declares no external controller, so the core cannot be
+    /// health-probed.
+    ControllerMissing,
+    /// The apply failed and the previous revision was restored.
+    ApplyFailed,
+    /// The apply failed and so did the rollback: no epoch is running.
+    ApplyRollbackFailed,
+    /// A core process could not be proven dead; the manager is now quarantined.
+    StopUnconfirmed,
+}
+
+impl CoreErrorKind {
+    /// Every kind, in wire-declaration order. The single place a new kind has to
+    /// be listed besides the enum itself; `from_wire` and the golden test both
+    /// walk it.
+    pub const ALL: &'static [Self] = &[
+        Self::NotStarted,
+        Self::AlreadyRunning,
+        Self::RevisionConflict,
+        Self::Quarantined,
+        Self::ConfigCheckFailed,
+        Self::ConfigNotFound,
+        Self::BinaryNotFound,
+        Self::InvalidConfig,
+        Self::ControllerMissing,
+        Self::ApplyFailed,
+        Self::ApplyRollbackFailed,
+        Self::StopUnconfirmed,
+    ];
+
+    /// The wire string. `serde` derives the same spelling from
+    /// `rename_all = "snake_case"`; the two are pinned equal by this module's
+    /// tests, and this one exists because an envelope needs a `&'static str`.
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::NotStarted => "not_started",
+            Self::AlreadyRunning => "already_running",
+            Self::RevisionConflict => "revision_conflict",
+            Self::Quarantined => "quarantined",
+            Self::ConfigCheckFailed => "config_check_failed",
+            Self::ConfigNotFound => "config_not_found",
+            Self::BinaryNotFound => "binary_not_found",
+            Self::InvalidConfig => "invalid_config",
+            Self::ControllerMissing => "controller_missing",
+            Self::ApplyFailed => "apply_failed",
+            Self::ApplyRollbackFailed => "apply_rollback_failed",
+            Self::StopUnconfirmed => "stop_unconfirmed",
+        }
+    }
+
+    /// The kind a wire string names, or `None` when this build does not know it.
+    ///
+    /// `None` is not an error: a newer service may classify a failure this build
+    /// has no variant for, and the raw string stays available to the caller.
+    pub fn from_wire(value: &str) -> Option<Self> {
+        Self::ALL
+            .iter()
+            .copied()
+            .find(|kind| kind.as_str() == value)
+    }
+}
+
+impl std::fmt::Display for CoreErrorKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_kind_serializes_to_its_wire_string() {
+        for kind in CoreErrorKind::ALL {
+            assert_eq!(
+                serde_json::to_string(kind).unwrap(),
+                format!("\"{}\"", kind.as_str())
+            );
+        }
+
+        assert_eq!(CoreErrorKind::NotStarted.as_str(), "not_started");
+        assert_eq!(CoreErrorKind::AlreadyRunning.as_str(), "already_running");
+        assert_eq!(
+            CoreErrorKind::RevisionConflict.as_str(),
+            "revision_conflict"
+        );
+        assert_eq!(CoreErrorKind::Quarantined.as_str(), "quarantined");
+        assert_eq!(
+            CoreErrorKind::ConfigCheckFailed.as_str(),
+            "config_check_failed"
+        );
+        assert_eq!(CoreErrorKind::ConfigNotFound.as_str(), "config_not_found");
+        assert_eq!(CoreErrorKind::BinaryNotFound.as_str(), "binary_not_found");
+        assert_eq!(CoreErrorKind::InvalidConfig.as_str(), "invalid_config");
+        assert_eq!(
+            CoreErrorKind::ControllerMissing.as_str(),
+            "controller_missing"
+        );
+        assert_eq!(CoreErrorKind::ApplyFailed.as_str(), "apply_failed");
+        assert_eq!(
+            CoreErrorKind::ApplyRollbackFailed.as_str(),
+            "apply_rollback_failed"
+        );
+        assert_eq!(CoreErrorKind::StopUnconfirmed.as_str(), "stop_unconfirmed");
+    }
+
+    #[test]
+    fn every_wire_string_parses_back() {
+        for kind in CoreErrorKind::ALL {
+            assert_eq!(CoreErrorKind::from_wire(kind.as_str()), Some(*kind));
+            assert_eq!(
+                serde_json::from_str::<CoreErrorKind>(&format!("\"{}\"", kind.as_str())).unwrap(),
+                *kind
+            );
+        }
+    }
+
+    #[test]
+    fn an_unknown_wire_string_has_no_kind() {
+        assert!(CoreErrorKind::from_wire("a_future_kind").is_none());
+    }
+}

--- a/crates/nyanpasu-core-metadata/src/lib.rs
+++ b/crates/nyanpasu-core-metadata/src/lib.rs
@@ -1,9 +1,11 @@
 mod dist;
+mod error_kind;
 mod feature;
 mod kind;
 mod log;
 
 pub use dist::{CoreDistribution, VariantTag};
+pub use error_kind::*;
 pub use feature::{
     clash::{Feature, FeatureSupport},
     *,

--- a/crates/nyanpasu-service-runtime/src/server/manager_bridge.rs
+++ b/crates/nyanpasu-service-runtime/src/server/manager_bridge.rs
@@ -6,7 +6,7 @@ use std::{
 
 use camino::{Utf8Path, Utf8PathBuf};
 use nyanpasu_core_manager::{
-    ApplyOutcome, ConfigRevision, CoreKind, CoreManager as Manager, CoreSpec,
+    ApplyOutcome, ConfigRevision, CoreErrorKind, CoreKind, CoreManager as Manager, CoreSpec,
     CoreState as ManagerCoreState, CoreStatus, Error as ManagerError, HealthState, HealthStatus,
     Host, InstanceOptions, InstanceSpec, LocalIpcPolicy, LogFrame, LogLevel, ManagerOptions,
     RevisionId,
@@ -51,7 +51,7 @@ pub(crate) const MSG_CORE_NOT_STARTED: &str = "core have not been started yet";
 /// place it can be derived without downcasting is where the `ManagerError` is
 /// still typed.
 pub(crate) struct OpError {
-    kind: Option<&'static str>,
+    kind: Option<CoreErrorKind>,
     message: String,
 }
 
@@ -67,7 +67,7 @@ impl OpError {
 
     /// A failure the service *can* classify, where the classification is a fact
     /// about the failure and not a guess about its cause.
-    fn with_kind(kind: &'static str, message: impl Into<String>) -> Self {
+    fn with_kind(kind: CoreErrorKind, message: impl Into<String>) -> Self {
         Self {
             kind: Some(kind),
             message: message.into(),
@@ -79,14 +79,17 @@ impl OpError {
     where
         T: Serialize + DeserializeOwned + std::fmt::Debug,
     {
-        RBuilder::other_error_with_kind(Cow::Owned(self.message), self.kind.map(Cow::Borrowed))
+        RBuilder::other_error_with_kind(
+            Cow::Owned(self.message),
+            self.kind.map(|kind| Cow::Borrowed(kind.as_str())),
+        )
     }
 }
 
 impl From<ManagerError> for OpError {
     fn from(error: ManagerError) -> Self {
         Self {
-            kind: map_error_kind(&error),
+            kind: error.kind(),
             message: match &error {
                 // The legacy wire string the GUI already branches on, so
                 // `apply` on a stopped core reads exactly like `restart` on
@@ -401,7 +404,7 @@ impl CoreManagerService {
                 ))
             })?;
         let binary_path = find_binary_path(infos, core_type)
-            .map_err(|error| OpError::with_kind(error_kind::BINARY_NOT_FOUND, error.to_string()))
+            .map_err(|error| OpError::with_kind(CoreErrorKind::BinaryNotFound, error.to_string()))
             .and_then(|path| {
                 Utf8PathBuf::from_path_buf(path).map_err(|path| {
                     OpError::plain(format!("core binary path is not UTF-8: {}", path.display()))
@@ -638,32 +641,6 @@ fn map_apply_outcome(outcome: &ApplyOutcome) -> CoreApplyData {
     }
 }
 
-/// The wire classification for a manager error, or `None` when this change does
-/// not classify it yet (report P3 maps the rest).
-///
-/// `Error` is `#[non_exhaustive]`, so the wildcard arm is mandatory; it must
-/// stay "no kind", never a guess.
-fn map_error_kind(error: &ManagerError) -> Option<&'static str> {
-    match error {
-        ManagerError::NotStarted => Some(error_kind::NOT_STARTED),
-        ManagerError::AlreadyRunning => Some(error_kind::ALREADY_RUNNING),
-        ManagerError::RevisionConflict { .. } => Some(error_kind::REVISION_CONFLICT),
-        ManagerError::ManagerQuarantined { .. } => Some(error_kind::QUARANTINED),
-        ManagerError::ConfigCheckFailed(_) => Some(error_kind::CONFIG_CHECK_FAILED),
-        ManagerError::ConfigNotFound(_) => Some(error_kind::CONFIG_NOT_FOUND),
-        ManagerError::BinaryNotFound(_) => Some(error_kind::BINARY_NOT_FOUND),
-        ManagerError::InvalidConfig(_) | ManagerError::Yaml(_) => Some(error_kind::INVALID_CONFIG),
-        ManagerError::ControllerMissing => Some(error_kind::CONTROLLER_MISSING),
-        ManagerError::ApplyFailed(_) => Some(error_kind::APPLY_FAILED),
-        ManagerError::ApplyRollbackFailed { .. } => Some(error_kind::APPLY_ROLLBACK_FAILED),
-        ManagerError::StopUnconfirmed(_) => Some(error_kind::STOP_UNCONFIRMED),
-        // The durability wrapper is a warning around a real failure; report the
-        // failure's kind so a caller can still branch on it.
-        ManagerError::DurabilityUncertain { source, .. } => map_error_kind(source),
-        _ => None,
-    }
-}
-
 /// The lossless counterpart to `map_core_state`.
 fn map_state_detail(state: &ManagerCoreState) -> Option<CoreStateDetail> {
     match state {
@@ -788,7 +765,7 @@ async fn canonical_config_path(config_file: &Path) -> Result<Utf8PathBuf, OpErro
             );
             match error.kind() {
                 std::io::ErrorKind::NotFound => {
-                    OpError::with_kind(error_kind::CONFIG_NOT_FOUND, message)
+                    OpError::with_kind(CoreErrorKind::ConfigNotFound, message)
                 }
                 _ => OpError::plain(message),
             }
@@ -1234,62 +1211,13 @@ mod tests {
         assert_eq!(data.failed_apply.as_deref(), Some("boom"));
     }
 
-    #[test]
-    fn manager_errors_map_onto_the_wire_error_kinds() {
-        let cases: [(ManagerError, Option<&str>); 8] = [
-            (ManagerError::NotStarted, Some("not_started")),
-            (ManagerError::AlreadyRunning, Some("already_running")),
-            (
-                ManagerError::RevisionConflict {
-                    expected: RevisionId {
-                        epoch: 3,
-                        generation: 7,
-                        effective_hash: "fedcba9876543210".to_owned(),
-                    },
-                    actual: None,
-                },
-                Some("revision_conflict"),
-            ),
-            (
-                ManagerError::ManagerQuarantined {
-                    epoch: 3,
-                    reason: "death unconfirmed".to_owned(),
-                },
-                Some("quarantined"),
-            ),
-            (
-                ManagerError::ConfigCheckFailed("unknown field".to_owned()),
-                Some("config_check_failed"),
-            ),
-            (ManagerError::ControllerMissing, Some("controller_missing")),
-            // The durability wrapper reports the wrapped failure's kind.
-            (
-                ManagerError::DurabilityUncertain {
-                    source: Box::new(ManagerError::ApplyFailed("boom".to_owned())),
-                    warning: "sync failed".to_owned(),
-                },
-                Some("apply_failed"),
-            ),
-            // Unmapped until report P3: no kind rather than a guessed one.
-            (
-                ManagerError::StartupFailed {
-                    stderr_tail: String::new(),
-                },
-                None,
-            ),
-        ];
-        for (error, expected) in cases {
-            assert_eq!(map_error_kind(&error), expected, "{error}");
-        }
-    }
-
     /// `apply` on a stopped core answers with the same string `restart` does,
     /// so a GUI branching on it keeps working, and gains the kind beside it.
     #[test]
     fn the_not_started_failure_keeps_the_legacy_wire_string() {
         let error = OpError::from(ManagerError::NotStarted);
         assert_eq!(error.message, MSG_CORE_NOT_STARTED);
-        assert_eq!(error.kind, Some("not_started"));
+        assert_eq!(error.kind, Some(CoreErrorKind::NotStarted));
     }
 
     #[test]
@@ -1516,7 +1444,7 @@ mod tests {
             .check(&infos, &mihomo(), &missing)
             .await
             .expect_err("the path does not exist");
-        assert_eq!(resolved.kind, Some(error_kind::CONFIG_NOT_FOUND));
+        assert_eq!(resolved.kind, Some(CoreErrorKind::ConfigNotFound));
         assert!(
             resolved.message.contains("nope.yaml"),
             "the failure must name the path: {}",
@@ -1539,7 +1467,7 @@ mod tests {
             .check(&infos, &mihomo(), &config)
             .await
             .expect_err("no binary exists under either dir");
-        assert_eq!(error.kind, Some(error_kind::BINARY_NOT_FOUND));
+        assert_eq!(error.kind, Some(CoreErrorKind::BinaryNotFound));
         assert!(
             error.message.contains(mihomo().get_executable_name()),
             "the failure must name the binary: {}",

--- a/crates/nyanpasu-service-runtime/src/server/manager_bridge.rs
+++ b/crates/nyanpasu-service-runtime/src/server/manager_bridge.rs
@@ -14,7 +14,6 @@ use nyanpasu_core_manager::{
 use nyanpasu_ipc::api::{
     R, RBuilder,
     core::apply::{ApplyOutcomeKind, CoreApplyData},
-    error_kind,
     status::{
         ConfigRevisionInfo, CoreControllerInfo, CoreHealthInfo, CoreHealthState, CoreInfos,
         CoreState, CoreStateDetail, RevisionIdInfo,
@@ -79,10 +78,7 @@ impl OpError {
     where
         T: Serialize + DeserializeOwned + std::fmt::Debug,
     {
-        RBuilder::other_error_with_kind(
-            Cow::Owned(self.message),
-            self.kind.map(|kind| Cow::Borrowed(kind.as_str())),
-        )
+        RBuilder::other_error_with_kind(Cow::Owned(self.message), self.kind)
     }
 }
 

--- a/nyanpasu_ipc/src/api/mod.rs
+++ b/nyanpasu_ipc/src/api/mod.rs
@@ -6,6 +6,18 @@ pub mod status;
 pub mod ws;
 
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
+
+/// Stable machine-readable failure kinds carried by [`R::error_kind`].
+///
+/// These strings are protocol: a caller branches on them instead of parsing
+/// `msg`. [`ResponseCode`] deliberately stays a two-variant enum — a new
+/// variant would make every older client fail to decode the whole envelope —
+/// so the detail lives in an additive string field instead (report §4 P0-B).
+///
+/// Absent means "not classified", never "no error": only the operations added
+/// in S8 populate it, and only for the failures listed here. Mapping the
+/// manager's remaining error variants is report P3.
+pub use nyanpasu_core_metadata::CoreErrorKind;
 use std::{borrow::Cow, fmt::Debug, io::Error as IoError};
 
 #[derive(Debug, Serialize, Deserialize, Clone, Copy, Default, PartialEq)]
@@ -25,46 +37,6 @@ impl ResponseCode {
     }
 }
 
-/// Stable machine-readable failure kinds carried by [`R::error_kind`].
-///
-/// These strings are protocol: a caller branches on them instead of parsing
-/// `msg`. [`ResponseCode`] deliberately stays a two-variant enum — a new
-/// variant would make every older client fail to decode the whole envelope —
-/// so the detail lives in an additive string field instead (report §4 P0-B).
-///
-/// Absent means "not classified", never "no error": only the operations added
-/// in S8 populate it, and only for the failures listed here. Mapping the
-/// manager's remaining error variants is report P3.
-pub mod error_kind {
-    /// The operation needs a running core and there is none.
-    pub const NOT_STARTED: &str = "not_started";
-    /// The operation needs a stopped core and one is running.
-    pub const ALREADY_RUNNING: &str = "already_running";
-    /// `expected_revision` did not match the running revision. Nothing was
-    /// applied; re-read `/status` for the current one and retry.
-    pub const REVISION_CONFLICT: &str = "revision_conflict";
-    /// An epoch whose death could not be confirmed has latched the manager.
-    /// Every lifecycle operation is refused until `POST /core/recover` clears
-    /// it.
-    pub const QUARANTINED: &str = "quarantined";
-    /// The core itself rejected the config in a dry run.
-    pub const CONFIG_CHECK_FAILED: &str = "config_check_failed";
-    pub const CONFIG_NOT_FOUND: &str = "config_not_found";
-    pub const BINARY_NOT_FOUND: &str = "binary_not_found";
-    /// The config could not be parsed or canonicalized.
-    pub const INVALID_CONFIG: &str = "invalid_config";
-    /// The config declares no external controller, so the core cannot be
-    /// health-probed.
-    pub const CONTROLLER_MISSING: &str = "controller_missing";
-    /// The apply failed and the previous revision was restored.
-    pub const APPLY_FAILED: &str = "apply_failed";
-    /// The apply failed and so did the rollback: no epoch is running.
-    pub const APPLY_ROLLBACK_FAILED: &str = "apply_rollback_failed";
-    /// A core process could not be proven dead; the manager is now
-    /// quarantined.
-    pub const STOP_UNCONFIRMED: &str = "stop_unconfirmed";
-}
-
 /// The IPC Response body definition
 #[derive(Debug, Serialize, Deserialize, Clone, Builder)]
 #[builder(build_fn(validate = "Self::validate"))]
@@ -77,7 +49,7 @@ pub struct R<'a, T: Serialize + DeserializeOwned + Debug> {
     pub data: Option<T>,
     #[builder(setter(skip), default = "self.default_ts()")]
     pub ts: i64,
-    /// Machine-readable failure classification, see [`error_kind`]. Declared
+    /// Machine-readable failure classification, see [`CoreErrorKind`]. Declared
     /// last and omitted when absent, so every pre-S8 envelope stays
     /// byte-identical and every pre-S8 payload still decodes.
     #[builder(default)]
@@ -131,18 +103,20 @@ impl<'a, T: Serialize + DeserializeOwned + Debug> RBuilder<'a, T> {
         }
     }
 
-    /// An error envelope carrying a [`error_kind`] classification.
+    /// An error envelope carrying a [`CoreErrorKind`] classification.
     ///
     /// `kind` is `Option` because a failure the service cannot classify must
-    /// still be reportable — guessing a kind is worse than omitting it.
-    pub fn other_error_with_kind(msg: Cow<'a, str>, kind: Option<Cow<'a, str>>) -> R<'a, T> {
+    /// still be reportable — guessing a kind is worse than omitting it. Taking
+    /// the enum rather than a string is what keeps a hand-typed kind off the
+    /// wire.
+    pub fn other_error_with_kind(msg: Cow<'a, str>, kind: Option<CoreErrorKind>) -> R<'a, T> {
         let code = ResponseCode::OtherError;
         R {
             code,
             msg,
             data: None,
             ts: crate::utils::get_current_ts(),
-            error_kind: kind,
+            error_kind: kind.map(|kind| Cow::Borrowed(kind.as_str())),
         }
     }
 

--- a/nyanpasu_ipc/src/client/mod.rs
+++ b/nyanpasu_ipc/src/client/mod.rs
@@ -5,7 +5,7 @@ use reqwest::{Method, RequestBuilder, StatusCode, Url};
 use crate::{
     SERVICE_PLACEHOLDER,
     api::{
-        R, ResponseCode,
+        CoreErrorKind, R, ResponseCode,
         contract::{IpcOperation, OpResponse},
     },
 };
@@ -60,6 +60,25 @@ pub enum ClientError {
         #[source]
         source: reqwest_websocket::Error,
     },
+}
+
+impl ClientError {
+    /// The typed classification of a server-side failure, when there is one
+    /// this build knows.
+    ///
+    /// `None` covers three different things and deliberately does not
+    /// distinguish them: a transport failure with no envelope, an envelope the
+    /// service did not classify, and a kind a newer service named that this
+    /// build has no variant for. The raw string is still on
+    /// [`Self::Server::error_kind`] for the last case.
+    pub fn core_error_kind(&self) -> Option<CoreErrorKind> {
+        match self {
+            Self::Server { error_kind, .. } => {
+                error_kind.as_deref().and_then(CoreErrorKind::from_wire)
+            }
+            _ => None,
+        }
+    }
 }
 
 /// An IPC client sharing one underlying HTTP client across all operations.
@@ -188,5 +207,41 @@ impl Client {
             });
         }
         Ok(envelope)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_known_kind_is_typed() {
+        let error = ClientError::Server {
+            operation: "/core/apply",
+            code: ResponseCode::OtherError,
+            msg: "boom".into(),
+            error_kind: Some("revision_conflict".into()),
+        };
+        assert_eq!(
+            error.core_error_kind(),
+            Some(CoreErrorKind::RevisionConflict)
+        );
+    }
+
+    #[test]
+    fn an_unknown_kind_keeps_its_raw_string() {
+        let error = ClientError::Server {
+            operation: "/core/apply",
+            code: ResponseCode::OtherError,
+            msg: "boom".into(),
+            error_kind: Some("a_future_kind".into()),
+        };
+        assert!(error.core_error_kind().is_none());
+        match error {
+            ClientError::Server { error_kind, .. } => {
+                assert_eq!(error_kind.as_deref(), Some("a_future_kind"));
+            }
+            other => panic!("expected a server error, got: {other:?}"),
+        }
     }
 }

--- a/nyanpasu_ipc/src/client/mod.rs
+++ b/nyanpasu_ipc/src/client/mod.rs
@@ -49,7 +49,7 @@ pub enum ClientError {
         code: ResponseCode,
         msg: String,
         /// The envelope's `error_kind`, when the service classified the
-        /// failure. See [`crate::api::error_kind`].
+        /// failure. See [`crate::api::CoreErrorKind`].
         error_kind: Option<String>,
     },
     #[error("IPC request `{operation}` succeeded but carried no data")]

--- a/nyanpasu_ipc/tests/roundtrip.rs
+++ b/nyanpasu_ipc/tests/roundtrip.rs
@@ -761,13 +761,18 @@ async fn a_server_error_kind_reaches_the_client() {
         return;
     };
 
-    match client.apply_config(&apply_payload()).await {
-        Err(ClientError::Server {
+    let error = client.apply_config(&apply_payload()).await.unwrap_err();
+    assert_eq!(
+        error.core_error_kind(),
+        Some(CoreErrorKind::RevisionConflict)
+    );
+    match error {
+        ClientError::Server {
             code,
             msg,
             error_kind,
             ..
-        }) => {
+        } => {
             assert_eq!(code, ResponseCode::OtherError);
             assert_eq!(msg, "config revision conflict");
             assert_eq!(error_kind.as_deref(), Some("revision_conflict"));

--- a/nyanpasu_ipc/tests/roundtrip.rs
+++ b/nyanpasu_ipc/tests/roundtrip.rs
@@ -39,7 +39,7 @@ use interprocess::local_socket::{
 };
 use nyanpasu_ipc::{
     api::{
-        RBuilder, ResponseCode,
+        CoreErrorKind, RBuilder, ResponseCode,
         core::{
             apply::{
                 ApplyOutcomeKind, CORE_APPLY_ENDPOINT, CoreApplyData, CoreApplyReq, CoreApplyRes,
@@ -48,7 +48,6 @@ use nyanpasu_ipc::{
             start::{CORE_START_ENDPOINT, CoreStartReq, CoreStartRes},
             stop::{CORE_STOP_ENDPOINT, CoreStopRes},
         },
-        error_kind,
         log::{LOGS_INSPECT_ENDPOINT, LOGS_RETRIEVE_ENDPOINT, LogsRes, LogsResBody},
         network::set_dns::{NETWORK_SET_DNS_ENDPOINT, NetworkSetDnsReq, NetworkSetDnsRes},
         status::{
@@ -401,7 +400,7 @@ async fn apply_config_conflict_handler() -> (StatusCode, Json<CoreApplyRes<'stat
         StatusCode::INTERNAL_SERVER_ERROR,
         Json(RBuilder::other_error_with_kind(
             Cow::Borrowed("config revision conflict"),
-            Some(Cow::Borrowed(error_kind::REVISION_CONFLICT)),
+            Some(CoreErrorKind::RevisionConflict),
         )),
     )
 }

--- a/nyanpasu_ipc/tests/wire_golden.rs
+++ b/nyanpasu_ipc/tests/wire_golden.rs
@@ -13,13 +13,12 @@ use std::{
 };
 
 use nyanpasu_ipc::api::{
-    R, RBuilder, ResponseCode,
+    CoreErrorKind, R, RBuilder, ResponseCode,
     core::{
         apply::{ApplyOutcomeKind, CoreApplyData, CoreApplyReq},
         check::CoreCheckReq,
         start::CoreStartReq,
     },
-    error_kind,
     log::LogsResBody,
     network::set_dns::NetworkSetDnsReq,
     status::{
@@ -53,12 +52,12 @@ where
     envelope
 }
 
-fn error_envelope_with_kind<T>(msg: &'static str, kind: &'static str) -> R<'static, T>
+fn error_envelope_with_kind<T>(msg: &'static str, kind: CoreErrorKind) -> R<'static, T>
 where
     T: serde::Serialize + serde::de::DeserializeOwned + std::fmt::Debug,
 {
     let mut envelope: R<'static, T> =
-        RBuilder::other_error_with_kind(Cow::Borrowed(msg), Some(Cow::Borrowed(kind)));
+        RBuilder::other_error_with_kind(Cow::Borrowed(msg), Some(kind));
     envelope.ts = TS;
     envelope
 }
@@ -702,19 +701,29 @@ fn the_apply_outcome_kinds_are_pinned() {
 
 #[test]
 fn the_error_kind_strings_are_pinned() {
-    // These are protocol: a caller branches on them.
-    assert_eq!(error_kind::NOT_STARTED, "not_started");
-    assert_eq!(error_kind::ALREADY_RUNNING, "already_running");
-    assert_eq!(error_kind::REVISION_CONFLICT, "revision_conflict");
-    assert_eq!(error_kind::QUARANTINED, "quarantined");
-    assert_eq!(error_kind::CONFIG_CHECK_FAILED, "config_check_failed");
-    assert_eq!(error_kind::CONFIG_NOT_FOUND, "config_not_found");
-    assert_eq!(error_kind::BINARY_NOT_FOUND, "binary_not_found");
-    assert_eq!(error_kind::INVALID_CONFIG, "invalid_config");
-    assert_eq!(error_kind::CONTROLLER_MISSING, "controller_missing");
-    assert_eq!(error_kind::APPLY_FAILED, "apply_failed");
-    assert_eq!(error_kind::APPLY_ROLLBACK_FAILED, "apply_rollback_failed");
-    assert_eq!(error_kind::STOP_UNCONFIRMED, "stop_unconfirmed");
+    // These are protocol: a caller branches on them. The enum lives in
+    // nyanpasu-core-metadata now, so this pins what actually reaches the wire.
+    for (kind, expected) in [
+        (CoreErrorKind::NotStarted, r#""not_started""#),
+        (CoreErrorKind::AlreadyRunning, r#""already_running""#),
+        (CoreErrorKind::RevisionConflict, r#""revision_conflict""#),
+        (CoreErrorKind::Quarantined, r#""quarantined""#),
+        (CoreErrorKind::ConfigCheckFailed, r#""config_check_failed""#),
+        (CoreErrorKind::ConfigNotFound, r#""config_not_found""#),
+        (CoreErrorKind::BinaryNotFound, r#""binary_not_found""#),
+        (CoreErrorKind::InvalidConfig, r#""invalid_config""#),
+        (CoreErrorKind::ControllerMissing, r#""controller_missing""#),
+        (CoreErrorKind::ApplyFailed, r#""apply_failed""#),
+        (
+            CoreErrorKind::ApplyRollbackFailed,
+            r#""apply_rollback_failed""#,
+        ),
+        (CoreErrorKind::StopUnconfirmed, r#""stop_unconfirmed""#),
+    ] {
+        assert_eq!(serde_json::to_string(&kind).unwrap(), expected);
+    }
+    // Every kind is covered above; a new one must be added here too.
+    assert_eq!(CoreErrorKind::ALL.len(), 12);
 }
 
 /// The new field is appended, so no existing key moves; the absent case is
@@ -722,7 +731,7 @@ fn the_error_kind_strings_are_pinned() {
 #[test]
 fn an_error_envelope_carries_its_kind() {
     let envelope: R<'static, ()> =
-        error_envelope_with_kind("config revision conflict", error_kind::REVISION_CONFLICT);
+        error_envelope_with_kind("config revision conflict", CoreErrorKind::RevisionConflict);
     assert_eq!(
         serde_json::to_string(&envelope).unwrap(),
         concat!(


### PR DESCRIPTION
## What this changes

The service reported failures as an `error_kind` string that each side had to agree on by convention. Three places independently decided what a failure "was": the manager produced an error, `manager_bridge` re-mapped it to a string constant, and every client branched on that string. Adding a case meant touching all three and hoping they stayed in sync, and a client had no type-level way to know which strings existed.

This replaces the string convention with a single typed wire table, `CoreErrorKind`, owned by `nyanpasu-core-metadata`:

- **`feat(core-metadata)`** — adds `CoreErrorKind`, the one place that enumerates the kinds.
- **`feat(core-manager)`** — the manager classifies its own errors through `Error::kind()`, so classification lives next to the error definitions rather than in a downstream mapper.
- **`refactor(service)`** — `manager_bridge` reads the kind from the manager instead of re-deriving it, which deletes the second mapping table (~90 lines).
- **`refactor(ipc)!`** — the wire field becomes `CoreErrorKind` instead of the loose string constants.
- **`feat(ipc)`** — `ClientError` exposes the typed kind, so callers branch on a variant instead of comparing strings.

## Why it matters beyond tidiness

A downstream consumer (clash-nyanpasu's core actor) needs to route a service failure to a specific recovery behaviour: a revision conflict retries with a fresh revision, a not-running core takes a different branch, and a transport loss is a third case entirely. With `error_kind` as a bare string, that routing degenerates into matching on error text — the exact fragility this replaces. The typed table makes the distinction checkable at the type level on the consumer side.

## Compatibility

`refactor(ipc)!` is marked breaking: the wire field's representation changes from an open string to the typed enum. `ResponseCode` deliberately stays a two-variant enum, so the classification detail remains in the additive `error_kind` field rather than expanding a field that older clients decode strictly.

Absent still means "not classified", never "no error" — the lifecycle operations that predate `error_kind` (`start` / `stop` / `restart`) continue to return an unclassified envelope, and consumers must treat absence as unclassified rather than as success.

## Verification

- Wire golden tests updated to cover the typed representation (`nyanpasu_ipc/tests/wire_golden.rs`).
- Roundtrip tests exercise encode/decode of the new field (`nyanpasu_ipc/tests/roundtrip.rs`).
- No public version bumps in this branch; the mapping tables that previously duplicated the classification are removed rather than left as dead code.

Branch is based on current `main` (`0c67f56`), 5 commits, no merge conflicts.
